### PR TITLE
fix: account for pre-request Codex cancellations

### DIFF
--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -71,12 +71,6 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
     Open question: Has this been observed in practice, justifying a caller-supplied idempotency key or narrow handle-recovery read?
     Notes: Evidence remains under `.agent-layer/tmp/runs/`; documented in docs/AGENT-DISPATCH.md and the dispatch-mcp-interface decision.
 
-- Issue 2026-07-27 benchmark-cancelled-session-cost: Pre-request cancellation invalidates an otherwise-scored treatment run
-    Priority: High. Area: benchmarks / treatment cost accounting
-    Description: A Koota treatment completed and scored 37/51, but normalization rejected it because one Codex child dispatch was explicitly cancelled before a request and its session had identity but no token-count event.
-    Next step: Exclude only sessions proven by dispatch evidence to be caller-cancelled before any token-usage event, while retaining strict failure for ambiguous or incomplete billable sessions.
-    Notes: The consolidated executor now preserves every successful cell and continues the remaining queue after failures; only the no-token cancelled-session accounting case remains.
-
 - Issue 2026-07-23 benchmark-provider-auth-preflight: Candidate authentication is not validated before a costly benchmark launch
     Priority: High. Area: benchmarks / provider setup
     Description: The twelve-task `opus-high-bare-calibration-20260722` run prepared every task, then all Claude candidates failed before inference because the copied OAuth session had expired; the current no-model helper preflight did not exercise Claude authentication.

--- a/internal/benchmark/normalize.go
+++ b/internal/benchmark/normalize.go
@@ -457,9 +457,10 @@ func submittedPatchBytes(stage string) (int64, error) {
 }
 
 type codexSessionUsage struct {
-	id      string
-	isChild bool
-	cost    costRange
+	id               string
+	isChild          bool
+	hasCompleteUsage bool
+	cost             costRange
 }
 
 type codexTokenUsage struct {
@@ -510,7 +511,7 @@ func codexAttemptCost(stage string) (treatmentCost, error) {
 	if len(sessions) == 0 {
 		return treatmentCost{}, fmt.Errorf("benchmark attempt has no Codex provider session evidence")
 	}
-	dispatchSessions, err := dispatchProviderSessionIDs(stage)
+	dispatchSessions, err := dispatchProviderSessions(stage)
 	if err != nil {
 		return treatmentCost{}, err
 	}
@@ -525,7 +526,16 @@ func codexAttemptCost(stage string) (treatmentCost, error) {
 			return treatmentCost{}, fmt.Errorf("codex provider session %q is duplicated", usage.id)
 		}
 		sessionIDs[usage.id] = true
-		if dispatchSessions[usage.id] {
+		if !usage.hasCompleteUsage {
+			if !dispatchRecordsProveCallerCancellation(dispatchSessions[usage.id]) {
+				return treatmentCost{}, fmt.Errorf(
+					"codex session %q has no complete request-level usage and is not proven caller-cancelled before usage",
+					usage.id,
+				)
+			}
+			continue
+		}
+		if len(dispatchSessions[usage.id]) > 0 {
 			usage.isChild = true
 		}
 		result.total.add(usage.cost)
@@ -534,8 +544,8 @@ func codexAttemptCost(stage string) (treatmentCost, error) {
 		} else {
 			result.coordinator.add(usage.cost)
 		}
+		result.invocations++
 	}
-	result.invocations = len(sessions)
 	for id := range dispatchSessions {
 		if !sessionIDs[id] {
 			return treatmentCost{}, fmt.Errorf(
@@ -551,7 +561,7 @@ func treatmentClaudeCost(stage string, coordinator *float64) (treatmentCost, err
 	if coordinator == nil || *coordinator < 0 {
 		return treatmentCost{}, fmt.Errorf("claude treatment coordinator cost is unavailable")
 	}
-	dispatchSessions, err := dispatchProviderSessionIDs(stage)
+	dispatchSessions, err := dispatchProviderSessions(stage)
 	if err != nil {
 		return treatmentCost{}, err
 	}
@@ -579,7 +589,7 @@ func treatmentClaudeCost(stage string, coordinator *float64) (treatmentCost, err
 		if parseErr != nil {
 			return treatmentCost{}, parseErr
 		}
-		if !dispatchSessions[sessionID] {
+		if len(dispatchSessions[sessionID]) == 0 {
 			return treatmentCost{}, fmt.Errorf("claude dispatch billing session %q has no matching dispatch record", sessionID)
 		}
 		if seen[sessionID] {
@@ -660,8 +670,13 @@ func loadBenchmarkPricing() (benchmarkPricing, error) {
 	return pricing, nil
 }
 
-func dispatchProviderSessionIDs(stage string) (map[string]bool, error) {
-	ids := make(map[string]bool)
+type dispatchProviderSession struct {
+	state          string
+	terminalReason string
+}
+
+func dispatchProviderSessions(stage string) (map[string][]dispatchProviderSession, error) {
+	sessions := make(map[string][]dispatchProviderSession)
 	err := filepath.WalkDir(filepath.Join(stage, "jobs"), func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -676,16 +691,34 @@ func dispatchProviderSessionIDs(stage string) (map[string]bool, error) {
 		}
 		var record struct {
 			ProviderSessionID string `json:"provider_session_id"`
+			State             string `json:"state"`
+			TerminalReason    string `json:"terminal_reason"`
 		}
 		if err := json.Unmarshal(data, &record); err != nil {
 			return err
 		}
-		if record.ProviderSessionID != "" {
-			ids[record.ProviderSessionID] = true
+		if record.ProviderSessionID == "" {
+			return nil
 		}
+		sessions[record.ProviderSessionID] = append(sessions[record.ProviderSessionID], dispatchProviderSession{
+			state:          record.State,
+			terminalReason: record.TerminalReason,
+		})
 		return nil
 	})
-	return ids, err
+	return sessions, err
+}
+
+func dispatchRecordsProveCallerCancellation(records []dispatchProviderSession) bool {
+	if len(records) == 0 {
+		return false
+	}
+	for _, record := range records {
+		if record.state != "cancelled" || record.terminalReason != "cancelled by caller" {
+			return false
+		}
+	}
+	return true
 }
 
 func parseCodexSessionCost(path string, pricing benchmarkPricing) (codexSessionUsage, error) {
@@ -771,9 +804,10 @@ func parseCodexSessionCost(path string, pricing benchmarkPricing) (codexSessionU
 	if err := scanner.Err(); err != nil {
 		return codexSessionUsage{}, err
 	}
-	if result.id == "" || len(seen) == 0 {
+	if result.id == "" {
 		return codexSessionUsage{}, fmt.Errorf("codex session %s has incomplete identity or billing evidence", filepath.Base(path))
 	}
+	result.hasCompleteUsage = len(seen) > 0
 	if cacheWriteTelemetryComplete && cacheWriteTelemetryPopulated {
 		result.cost.minimum = exactCost
 		result.cost.maximum = exactCost

--- a/internal/benchmark/runtime_test.go
+++ b/internal/benchmark/runtime_test.go
@@ -493,6 +493,171 @@ func TestCodexCostRejectsDispatchWithoutRequestLevelSessionEvidence(t *testing.T
 	}
 }
 
+func TestCodexCostOmitsCallerCancelledSessionWithoutUsage(t *testing.T) {
+	pricing, err := loadBenchmarkPricing()
+	if err != nil {
+		t.Fatal(err)
+	}
+	coordinator, err := os.ReadFile(filepath.Join("testdata", "codex-session-cost.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	noUsage := []byte(`{"type":"session_meta","payload":{"id":"cancelled-session","source":"exec"}}` + "\n" +
+		`{"type":"turn_context","payload":{"model":"gpt-5.6-luna"}}` + "\n" +
+		`{"type":"event_msg","payload":{"type":"token_count","info":null,"rate_limits":{"primary":{"used_percent":12.5}}}}` + "\n")
+	parsed, err := parseCodexSessionCost(writeTempSession(t, noUsage), pricing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.id != "cancelled-session" || parsed.hasCompleteUsage || parsed.cost != (costRange{}) {
+		t.Fatalf("identified no-usage parse = %#v", parsed)
+	}
+
+	callerCancel := []byte(`{"provider_session_id":"cancelled-session","state":"cancelled","terminal_reason":"cancelled by caller"}`)
+	stage := writeCodexCostStage(t, map[string][]byte{
+		"coordinator.jsonl": coordinator,
+		"cancelled.jsonl":   noUsage,
+	}, map[string][]byte{
+		"cancelled.json": callerCancel,
+		"continued.json": callerCancel,
+		"preflight.json": []byte(`{"id":"codex-mcp-preflight"}`),
+	})
+	cost, err := codexAttemptCost(stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cost.invocations != 1 ||
+		math.Abs(cost.total.minimum-.240304) > 1e-12 ||
+		math.Abs(cost.total.maximum-.290319) > 1e-12 ||
+		cost.child != (costRange{}) ||
+		cost.coordinator != cost.total {
+		t.Fatalf("omitted caller-cancelled session cost = %#v", cost)
+	}
+}
+
+func TestCodexCostBillsCallerCancelledSessionWithCompleteUsage(t *testing.T) {
+	coordinator, err := os.ReadFile(filepath.Join("testdata", "codex-session-cost.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	child := bytes.Replace(coordinator, []byte("shared-cost-session"), []byte("cancelled-session"), 1)
+	stage := writeCodexCostStage(t, map[string][]byte{
+		"coordinator.jsonl": coordinator,
+		"cancelled.jsonl":   child,
+	}, map[string][]byte{
+		"cancelled.json": []byte(`{"provider_session_id":"cancelled-session","state":"cancelled","terminal_reason":"cancelled by caller"}`),
+		"continued.json": []byte(`{"provider_session_id":"cancelled-session","state":"completed"}`),
+	})
+	cost, err := codexAttemptCost(stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cost.invocations != 2 ||
+		math.Abs(cost.total.minimum-.480608) > 1e-12 ||
+		math.Abs(cost.total.maximum-.580638) > 1e-12 ||
+		math.Abs(cost.child.minimum-.240304) > 1e-12 ||
+		math.Abs(cost.child.maximum-.290319) > 1e-12 {
+		t.Fatalf("billed cancelled session cost = %#v", cost)
+	}
+}
+
+func TestCodexCostRejectsNoUsageWithoutProvenCallerCancellation(t *testing.T) {
+	coordinator, err := os.ReadFile(filepath.Join("testdata", "codex-session-cost.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	noUsage := []byte(`{"type":"session_meta","payload":{"id":"cancelled-session","source":"exec"}}` + "\n" +
+		`{"type":"event_msg","payload":{"type":"token_count","info":null}}` + "\n")
+	incomplete := []byte(`{"type":"session_meta","payload":{"id":"cancelled-session"}}` + "\n" +
+		`{"type":"turn_context","payload":{"model":"gpt-5.6-luna"}}` + "\n" +
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1}}}}` + "\n")
+	missingIdentity := []byte(`{"type":"turn_context","payload":{"model":"gpt-5.6-luna"}}` + "\n")
+	malformed := []byte(`{"type":"session_meta","payload":{"id":"cancelled-session"}}` + "\n" +
+		`{"timestamp":"2026-08-03T20:00:03Z","type":"event_msg","payload":{"type":"token_count"` + "\n")
+	callerCancel := []byte(`{"provider_session_id":"cancelled-session","state":"cancelled","terminal_reason":"cancelled by caller"}`)
+	for _, test := range []struct {
+		name       string
+		sessions   map[string][]byte
+		dispatches map[string][]byte
+		want       string
+	}{
+		{
+			name: "missing dispatch",
+			sessions: map[string][]byte{
+				"coordinator.jsonl": coordinator,
+				"cancelled.jsonl":   noUsage,
+			},
+			want: `session "cancelled-session" has no complete request-level usage and is not proven caller-cancelled before usage`,
+		},
+		{
+			name: "mixed lifecycle records",
+			sessions: map[string][]byte{
+				"coordinator.jsonl": coordinator,
+				"cancelled.jsonl":   noUsage,
+			},
+			dispatches: map[string][]byte{
+				"cancelled.json": callerCancel,
+				"continued.json": []byte(`{"provider_session_id":"cancelled-session","state":"completed"}`),
+			},
+			want: `session "cancelled-session" has no complete request-level usage and is not proven caller-cancelled before usage`,
+		},
+		{
+			name: "failed dispatch",
+			sessions: map[string][]byte{
+				"coordinator.jsonl": coordinator,
+				"cancelled.jsonl":   noUsage,
+			},
+			dispatches: map[string][]byte{
+				"cancelled.json": []byte(`{"provider_session_id":"cancelled-session","state":"failed","terminal_reason":"cancelled by caller"}`),
+			},
+			want: `session "cancelled-session" has no complete request-level usage and is not proven caller-cancelled before usage`,
+		},
+		{
+			name: "non-caller cancellation",
+			sessions: map[string][]byte{
+				"coordinator.jsonl": coordinator,
+				"cancelled.jsonl":   noUsage,
+			},
+			dispatches: map[string][]byte{
+				"cancelled.json": []byte(`{"provider_session_id":"cancelled-session","state":"cancelled","terminal_reason":"dispatch was interrupted before launching its worker"}`),
+			},
+			want: `session "cancelled-session" has no complete request-level usage and is not proven caller-cancelled before usage`,
+		},
+		{
+			name: "incomplete non-null usage",
+			sessions: map[string][]byte{
+				"coordinator.jsonl": coordinator,
+				"cancelled.jsonl":   incomplete,
+			},
+			dispatches: map[string][]byte{"cancelled.json": callerCancel},
+			want:       "incomplete request-level token usage",
+		},
+		{
+			name: "missing identity",
+			sessions: map[string][]byte{
+				"coordinator.jsonl": coordinator,
+				"cancelled.jsonl":   missingIdentity,
+			},
+			dispatches: map[string][]byte{"cancelled.json": callerCancel},
+			want:       "incomplete identity or billing evidence",
+		},
+		{
+			name: "malformed billing event",
+			sessions: map[string][]byte{
+				"coordinator.jsonl": coordinator,
+				"cancelled.jsonl":   malformed,
+			},
+			dispatches: map[string][]byte{"cancelled.json": callerCancel},
+			want:       "decode codex session",
+		},
+	} {
+		if _, err := codexAttemptCost(writeCodexCostStage(t, test.sessions, test.dispatches)); err == nil ||
+			!strings.Contains(err.Error(), test.want) {
+			t.Fatalf("%s error = %v", test.name, err)
+		}
+	}
+}
+
 func TestClaudeCostUsesProviderReportedCoordinatorAndDispatchTotals(t *testing.T) {
 	stage := t.TempDir()
 	dispatch := filepath.Join(stage, "jobs", "job", "agent", "agent-layer-dispatch")
@@ -803,6 +968,39 @@ func TestPinnedCheckoutValidationRejectsMissingAndWrongRepositoryState(t *testin
 		!strings.Contains(err.Error(), "invalid Pier execution request") {
 		t.Fatalf("invalid Pier request error = %v", err)
 	}
+}
+
+func writeTempSession(t *testing.T, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(path, data, 0o600); err != nil { // #nosec G703 -- path is rooted in a test-owned temporary directory.
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeCodexCostStage(t *testing.T, sessions, dispatches map[string][]byte) string {
+	t.Helper()
+	stage := t.TempDir()
+	sessionDir := filepath.Join(stage, "jobs", "job", "agent", "sessions")
+	dispatchDir := filepath.Join(stage, "jobs", "job", "agent", dispatchEvidenceDir)
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dispatchDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range sessions {
+		if err := os.WriteFile(filepath.Join(sessionDir, name), data, 0o600); err != nil { // #nosec G703 -- sessionDir is beneath a test-owned temporary directory.
+			t.Fatal(err)
+		}
+	}
+	for name, data := range dispatches {
+		if err := os.WriteFile(filepath.Join(dispatchDir, name), data, 0o600); err != nil { // #nosec G703 -- dispatchDir is beneath a test-owned temporary directory.
+			t.Fatal(err)
+		}
+	}
+	return stage
 }
 
 func writePierStage(t *testing.T, checksum string, score, cost float64) string {


### PR DESCRIPTION
## Summary

- Normalize Codex benchmark costs so identified sessions without complete request-level usage are omitted only when every matching dispatch record proves explicit caller cancellation.
- Preserve billing and invocation counts for sessions with complete usage, including sessions cancelled later in their lifecycle.
- Resolve issue `2026-07-27 benchmark-cancelled-session-cost`.

## Changes

- Treat `token_count` events with `info: null` as non-usage telemetry.
- Preserve repeated lifecycle records for shared provider session IDs and reconcile their dispatch evidence.
- Reject malformed, unidentified, incomplete, missing, mixed, or ambiguous evidence.
- Add acceptance and strict-rejection regression coverage and remove the resolved issue from project memory.

## Verification

- `go test ./internal/benchmark -count=1` — passed.
- `make dev` — passed: 4,292 Go tests, 90.05% total coverage against the 90% threshold, browser checks, static/release checks, and 99 release tests.
- `git diff --check` — passed.
- Commit hooks — passed formatting, module-tidy, lint, and `go test ./...`.

## Notes

- Plan artifacts are retained under `.agent-layer/tmp/write-plan.20260820-175628-c7a4.*`.
- Independent Codex Sol medium review found no material issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark cost reporting for sessions cancelled before usage data was recorded.
  * Excludes sessions from cost totals only when caller cancellation is clearly confirmed.
  * Continues billing cancelled sessions when complete usage data is available.
  * Reports errors instead of silently accepting incomplete or ambiguous session records.
* **Tests**
  * Added coverage for cancelled sessions, complete and missing usage data, and invalid cancellation evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->