### PR TITLE
test: synchronize Antigravity prefetch readiness

### DIFF
--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -29,12 +29,6 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
 
 <!-- ENTRIES START -->
 
-- Issue 2026-08-18 antigravity-async-prefetch-test-flake: `TestPromptModelsAntigravityUsesReadyAsyncPrefetch` is load-sensitive
-    Priority: Low. Area: test suite / wizard
-    Description: `waitForAntigravityModelDiscoveryReady` (`internal/wizard/option_discovery_test.go:438`) waits a hardcoded 1 second for async discovery that forks a shell `agy` stub. Under full-suite parallel load the fork can exceed that deadline, failing `make test`; the test passes repeatedly in isolation.
-    Next step: Replace the fixed deadline with a generous bound or a synchronization signal from the prefetch goroutine rather than wall-clock polling.
-    Notes: Observed once during PR #188 (`make test` via pre-commit); re-ran 5x isolated with no failure. Unrelated to the Grok change.
-
 - Issue 2026-08-18 grok-duplicate-root-instructions: Grok loads both generated instruction shims
     Priority: Low. Area: providers / grok / instructions / warnings
     Description: Grok 1.0.5 loads both byte-identical generated `AGENTS.md` and `CLAUDE.md`, duplicating project instructions while the shared instruction-token warning counts the source once.

--- a/internal/wizard/option_discovery_test.go
+++ b/internal/wizard/option_discovery_test.go
@@ -435,20 +435,19 @@ func TestPromptWizardFlowSkipsAntigravityPrefetchWhenAgentDisabled(t *testing.T)
 
 func waitForAntigravityModelDiscoveryReady(t *testing.T, cache *wizardOptionDiscoveryCache) {
 	t.Helper()
-	deadline := time.After(time.Second)
-	tick := time.NewTicker(time.Millisecond)
-	defer tick.Stop()
-	for {
-		cache.mu.Lock()
-		ready := cache.antigravityModelsReady
-		cache.mu.Unlock()
-		if ready {
-			return
-		}
-		select {
-		case <-deadline:
-			t.Fatal("timed out waiting for async Antigravity model discovery")
-		case <-tick.C:
-		}
+	cache.mu.Lock()
+	ready := cache.antigravityModelsReady
+	done := cache.antigravityModelsDone
+	cache.mu.Unlock()
+	if ready {
+		return
+	}
+	if done == nil {
+		t.Fatal("async Antigravity model discovery was not started")
+	}
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for async Antigravity model discovery")
 	}
 }


### PR DESCRIPTION
## Summary

- Make Antigravity model prefetch test setup synchronize with the cache completion signal.
- Remove the resolved load-sensitive test-flake issue from project memory.

## Changes

- `waitForAntigravityModelDiscoveryReady` now waits on `antigravityModelsDone`, retains a 30-second timeout, and fails explicitly if prefetch was never started.
- Removed `antigravity-async-prefetch-test-flake` from `docs/agent-layer/ISSUES.md`.

## Verification

- `go test ./internal/wizard` — passed.
- `go test ./internal/wizard -run 'TestPromptModelsAntigravityUsesReadyAsyncPrefetch|TestPromptModelsScriptedAntigravityWaitsForPendingAsyncPrefetch|TestPromptWizardFlow' -count=10` — passed.
- Repository pre-commit hooks, including `golangci-lint` and `go test ./...` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model discovery completion handling to provide more reliable results and clearer errors when discovery is unavailable or takes too long.
  * Reduced timing-related instability during discovery workflows.

* **Documentation**
  * Removed an obsolete issue from the project’s tracked issues list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->