### PR TITLE
fix: recover completed benchmark reports without auth

### DIFF
--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -29,11 +29,6 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
 
 <!-- ENTRIES START -->
 
-- Issue 2026-08-20 benchmark-auth-free-report-recovery: Completed cells without a report still require authentication
-    Priority: Low. Area: benchmark / study recovery
-    Description: No-auth report regeneration discovers candidates only from existing `report/report.json`. If every selected cell is written but report generation is interrupted, the retry authenticates and can fail closed for Claude or expired Codex even though `executeMatrix` would have no missing jobs.
-    Next step: If this interruption window is observed, discover unique completed matches from immutable manifests and cell evidence without inventing authentication provenance.
-
 - Issue 2026-08-18 grok-duplicate-root-instructions: Grok loads both generated instruction shims
     Priority: Low. Area: providers / grok / instructions / warnings
     Description: Grok 1.0.5 loads both byte-identical generated `AGENTS.md` and `CLAUDE.md`, duplicating project instructions while the shared instruction-token warning counts the source once.

--- a/internal/benchmark/auth_preflight_test.go
+++ b/internal/benchmark/auth_preflight_test.go
@@ -1140,6 +1140,8 @@ func TestRunStudyAuthenticatesWhenManifestOnlyCellsAreMissing(t *testing.T) {
 	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
 		return nil, fmt.Errorf("missing-cell run reached authentication")
 	}
+	originalStage := stageBenchmarkExperimentBundles
+	t.Cleanup(func() { stageBenchmarkExperimentBundles = originalStage })
 	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
 		return nil, fmt.Errorf("missing-cell run reached bundle staging")
 	}
@@ -1152,6 +1154,48 @@ func TestRunStudyAuthenticatesWhenManifestOnlyCellsAreMissing(t *testing.T) {
 	}
 	if *preparedCalls != 1 {
 		t.Fatalf("task preparation ran %d times", *preparedCalls)
+	}
+}
+
+func TestManifestOnlyCachedStudyCompleteDoesNotMutateCallerStudyID(t *testing.T) {
+	root := t.TempDir()
+	writeParsedBareStudy(t, root, "luna:low")
+	stubStudyInfrastructure(t, root)
+	originalAuth := validateBenchmarkAuthentication
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{}, nil
+	}
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	removeStudyReport(t, root, first.StudyID)
+	studies := filepath.Join(root, ".agent-layer", "state", "benchmarks", "deepswe", "studies")
+	rejected := filepath.Join(studies, "rejected-identity")
+	if err := os.Rename(filepath.Join(studies, first.StudyID), rejected); err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := prepareStudy(StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.cleanupInputs()
+	prepared.studyID = "sentinel-study-id"
+	tasks := make([]benchmarkPlanTask, len(prepared.selection.Tasks))
+	for i, task := range prepared.selection.Tasks {
+		tasks[i] = benchmarkPlanTask{ID: task.ID, RepetitionsPerArm: task.Repetitions}
+	}
+	complete, err := manifestOnlyCachedStudyComplete(root, &prepared, rejected, tasks, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if complete {
+		t.Fatal("identity-mismatched candidate was treated as complete")
+	}
+	if prepared.studyID != "sentinel-study-id" {
+		t.Fatalf("rejected probe mutated studyID to %q", prepared.studyID)
 	}
 }
 
@@ -1428,6 +1472,14 @@ func removeStudyReport(t *testing.T, root, studyID string) {
 
 func blockCachedStudySidecars(t *testing.T) {
 	t.Helper()
+	originalPreflight, originalVerify := preflightBenchmark, verifyBenchmarkPier
+	originalAuth, originalPrepare := validateBenchmarkAuthentication, prepareBenchmarkTaskSet
+	originalTreatment := preflightTreatmentRuntime
+	t.Cleanup(func() {
+		preflightBenchmark, verifyBenchmarkPier = originalPreflight, originalVerify
+		validateBenchmarkAuthentication, prepareBenchmarkTaskSet = originalAuth, originalPrepare
+		preflightTreatmentRuntime = originalTreatment
+	})
 	preflightBenchmark = func([]parsedSelection) error {
 		return fmt.Errorf("cached regeneration reached prerequisite discovery")
 	}
@@ -1440,11 +1492,9 @@ func blockCachedStudySidecars(t *testing.T) {
 	prepareBenchmarkTaskSet = func(context.Context, string, []benchmarkPlanTask) (map[string]string, map[string]string, error) {
 		return nil, nil, fmt.Errorf("cached regeneration reached task preparation")
 	}
-	originalTreatment := preflightTreatmentRuntime
 	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error {
 		return fmt.Errorf("cached regeneration reached treatment runtime preflight")
 	}
-	t.Cleanup(func() { preflightTreatmentRuntime = originalTreatment })
 }
 
 func writeMatchingStudyReport(t *testing.T, root, studyID string, prepared preparedStudy, completed, required int) {

--- a/internal/benchmark/auth_preflight_test.go
+++ b/internal/benchmark/auth_preflight_test.go
@@ -738,6 +738,562 @@ func TestRunStudyFailsClosedWhenCompletedReportLacksStudyManifest(t *testing.T) 
 	}
 }
 
+func TestRunStudyRegeneratesCompletedStudyWithoutReportOrAuthentication(t *testing.T) {
+	for _, test := range []struct {
+		name, selection string
+	}{
+		{name: adapterCodex, selection: "luna:low"},
+		{name: providerClaude, selection: "opus:high"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			model, effort, err := ParseModelSelection(test.selection)
+			if err != nil {
+				t.Fatal(err)
+			}
+			root := t.TempDir()
+			writeBareStudy(t, root, model.Name, effort)
+			preparedCalls := stubStudyInfrastructure(t, root)
+			originalAuth := validateBenchmarkAuthentication
+			t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+			validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+				return map[string]AuthenticationPreflight{}, nil
+			}
+			if model.Adapter == adapterCodex {
+				writeJSONCredential(t, filepath.Join(root, ".codex", "auth.json"), []byte(`{"token":"`+authPreflightSecret+`"}`))
+				installAuthCommandStubs(t, successfulCodexStatusScript(), "")
+				validateBenchmarkAuthentication = originalAuth
+			}
+			first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if first.Completed != 2 || first.Missing != 0 || first.JSONPath == "" {
+				t.Fatalf("seeded study=%#v", first)
+			}
+			removeStudyReport(t, root, first.StudyID)
+
+			blockCachedStudySidecars(t)
+			switch model.Adapter {
+			case adapterCodex:
+				if err := os.Remove(filepath.Join(root, ".codex", "auth.json")); err != nil {
+					t.Fatal(err)
+				}
+			case adapterClaudeCode:
+				writeJSONCredential(t, filepath.Join(root, ".claude-config", ".credentials.json"), []byte(`{"token":"`+authPreflightSecret+`"}`))
+			}
+			executor := &studyWorkflowExecutor{}
+			second, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, executor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if *preparedCalls != 1 {
+				t.Fatalf("cached regeneration prepared tasks %d times", *preparedCalls)
+			}
+			if calls := executor.requests(); len(calls) != 0 {
+				t.Fatalf("cached regeneration reached provider execution: %#v", calls)
+			}
+			if second.StudyID != first.StudyID || second.Completed != 2 || second.Missing != 0 || second.JSONPath == "" {
+				t.Fatalf("cached regeneration=%#v", second)
+			}
+			raw, err := os.ReadFile(second.JSONPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(raw), authPreflightSecret) {
+				t.Fatalf("regenerated report leaked credential: %s", raw)
+			}
+			var report StudyReport
+			if err := json.Unmarshal(raw, &report); err != nil {
+				t.Fatal(err)
+			}
+			if report.StudyID != first.StudyID || len(report.Experiments) != 1 || report.Experiments[0].CompletedCells != 2 {
+				t.Fatalf("regenerated report=%#v", report)
+			}
+			if report.Experiments[0].AuthenticationPreflight != nil {
+				t.Fatalf("regenerated report invented authentication provenance: %#v", report.Experiments[0].AuthenticationPreflight)
+			}
+		})
+	}
+}
+
+func TestRunStudyRetainsAuthenticationProvenanceFromIncompletePriorReport(t *testing.T) {
+	root := t.TempDir()
+	writeParsedBareStudy(t, root, "luna:low")
+	preparedCalls := stubStudyInfrastructure(t, root)
+	originalAuth := validateBenchmarkAuthentication
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	writeJSONCredential(t, filepath.Join(root, ".codex", "auth.json"), []byte(`{"token":"`+authPreflightSecret+`"}`))
+	installAuthCommandStubs(t, successfulCodexStatusScript(), "")
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var prior StudyReport
+	if err := readStudyJSON(first.JSONPath, &prior); err != nil {
+		t.Fatal(err)
+	}
+	if len(prior.Experiments) != 1 || prior.Experiments[0].AuthenticationPreflight == nil {
+		t.Fatalf("seeded report lacks authentication provenance: %#v", prior.Experiments)
+	}
+	prior.Experiments[0].CompletedCells--
+	if err := writeJSON(first.JSONPath, prior); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, ".codex", "auth.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	blockCachedStudySidecars(t)
+	second, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *preparedCalls != 1 || second.StudyID != first.StudyID || second.Completed != 2 {
+		t.Fatalf("cached regeneration=%#v task preparation calls=%d", second, *preparedCalls)
+	}
+	var regenerated StudyReport
+	if err := readStudyJSON(second.JSONPath, &regenerated); err != nil {
+		t.Fatal(err)
+	}
+	if len(regenerated.Experiments) != 1 || regenerated.Experiments[0].AuthenticationPreflight == nil ||
+		regenerated.Experiments[0].AuthenticationPreflight.AuthenticationMethod != codexAuthMethodChatGPT {
+		t.Fatalf("regenerated report lost authentication provenance: %#v", regenerated.Experiments)
+	}
+}
+
+func TestRunStudyRejectsAuthenticationProvenanceFromUnrelatedPriorReport(t *testing.T) {
+	root := t.TempDir()
+	writeParsedBareStudy(t, root, "luna:low")
+	stubStudyInfrastructure(t, root)
+	originalAuth := validateBenchmarkAuthentication
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	writeJSONCredential(t, filepath.Join(root, ".codex", "auth.json"), []byte(`{"token":"`+authPreflightSecret+`"}`))
+	installAuthCommandStubs(t, successfulCodexStatusScript(), "")
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var prior StudyReport
+	if err := readStudyJSON(first.JSONPath, &prior); err != nil {
+		t.Fatal(err)
+	}
+	prior.Experiments[0].Identity = "unrelated-experiment"
+	prior.Experiments[0].CompletedCells--
+	if err := writeJSON(first.JSONPath, prior); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, ".codex", "auth.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	blockCachedStudySidecars(t)
+	_, err = RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err == nil || !strings.Contains(err.Error(), "report declaration does not match its immutable study") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestRunStudyRegeneratesCompletedTreatmentStudyWithoutReport(t *testing.T) {
+	root := t.TempDir()
+	writeParsedTreatmentStudy(t, root, "luna:low")
+	preparedCalls := stubStudyInfrastructure(t, root)
+	bundle := fakeStudyTreatmentBundle()
+	bundle.TemplatesCommit = "current-templates"
+	originalStage := stageBenchmarkExperimentBundles
+	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
+		return []*TreatmentBundle{bundle}, nil
+	}
+	t.Cleanup(func() { stageBenchmarkExperimentBundles = originalStage })
+	originalTreatment := preflightTreatmentRuntime
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error { return nil }
+	t.Cleanup(func() { preflightTreatmentRuntime = originalTreatment })
+	originalAuth := validateBenchmarkAuthentication
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{}, nil
+	}
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Completed != 2 || first.Missing != 0 {
+		t.Fatalf("seeded study=%#v", first)
+	}
+	removeStudyReport(t, root, first.StudyID)
+
+	stageCalls := 0
+	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
+		stageCalls++
+		return []*TreatmentBundle{bundle}, nil
+	}
+	blockCachedStudySidecars(t)
+	executor := &studyWorkflowExecutor{}
+	second, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, executor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stageCalls != 1 {
+		t.Fatalf("treatment cache verification staged %d times", stageCalls)
+	}
+	if *preparedCalls != 1 {
+		t.Fatalf("cached regeneration prepared tasks %d times", *preparedCalls)
+	}
+	if calls := executor.requests(); len(calls) != 0 {
+		t.Fatalf("cached regeneration reached provider execution: %#v", calls)
+	}
+	if second.StudyID != first.StudyID || second.Completed != 2 || second.JSONPath == "" {
+		t.Fatalf("cached regeneration=%#v", second)
+	}
+	var report StudyReport
+	if err := readStudyJSON(second.JSONPath, &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Experiments) != 1 || report.Experiments[0].AuthenticationPreflight != nil {
+		t.Fatalf("regenerated report invented authentication provenance: %#v", report.Experiments)
+	}
+	item := report.Experiments[0]
+	if item.LinuxBinarySHA256 != bundle.LinuxBinarySHA256 || item.AdapterSHA256 != bundle.AdapterSHA256 ||
+		item.SourceCommit != bundle.TemplatesCommit || item.BundleManifest == nil || item.BundleManifest.Mode != bundle.Manifest.Mode {
+		t.Fatalf("regenerated report lost current staged bundle provenance: %#v", item)
+	}
+}
+
+func TestRunStudySkipsDeclarationCompatibleSiblingWithDifferentIdentity(t *testing.T) {
+	root := t.TempDir()
+	writeParsedTreatmentStudy(t, root, "luna:low")
+	preparedCalls := stubStudyInfrastructure(t, root)
+	stubFakeStudyTreatmentBundles(t)
+	originalTreatment := preflightTreatmentRuntime
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error { return nil }
+	t.Cleanup(func() { preflightTreatmentRuntime = originalTreatment })
+	originalAuth := validateBenchmarkAuthentication
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{}, nil
+	}
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	removeStudyReport(t, root, first.StudyID)
+	if err := os.WriteFile(filepath.Join(root, "config.toml"), []byte("changed-config\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return nil, fmt.Errorf("declaration-compatible sibling reached authentication")
+	}
+	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
+		return nil, fmt.Errorf("declaration-compatible sibling reached bundle staging")
+	}
+	_, err = RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err == nil || !strings.Contains(err.Error(), "declaration-compatible sibling reached authentication") {
+		t.Fatalf("error=%v", err)
+	}
+	if strings.Contains(err.Error(), "more than one historical state directory") || strings.Contains(err.Error(), "conflicts with its immutable manifest") {
+		t.Fatalf("sibling was not skipped: %v", err)
+	}
+	if *preparedCalls != 1 {
+		t.Fatalf("task preparation ran %d times", *preparedCalls)
+	}
+}
+
+func TestRunStudyFallsThroughWhenCurrentTreatmentPinsDoNotMatch(t *testing.T) {
+	root := t.TempDir()
+	writeParsedTreatmentStudy(t, root, "luna:low")
+	preparedCalls := stubStudyInfrastructure(t, root)
+	bundle := fakeStudyTreatmentBundle()
+	originalStage := stageBenchmarkExperimentBundles
+	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
+		return []*TreatmentBundle{bundle}, nil
+	}
+	t.Cleanup(func() { stageBenchmarkExperimentBundles = originalStage })
+	originalTreatment := preflightTreatmentRuntime
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error { return nil }
+	t.Cleanup(func() { preflightTreatmentRuntime = originalTreatment })
+	originalAuth := validateBenchmarkAuthentication
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{}, nil
+	}
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	removeStudyReport(t, root, first.StudyID)
+
+	mismatched := *bundle
+	mismatched.ManifestHash = "other-manifest-hash"
+	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
+		return []*TreatmentBundle{&mismatched}, nil
+	}
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return nil, fmt.Errorf("current pin mismatch reached authentication")
+	}
+	_, err = RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err == nil || !strings.Contains(err.Error(), "current pin mismatch reached authentication") {
+		t.Fatalf("error=%v", err)
+	}
+	if strings.Contains(err.Error(), "execution receipt does not match") || strings.Contains(err.Error(), "inspect immutable study cell") {
+		t.Fatalf("pin mismatch was treated as corruption: %v", err)
+	}
+	if *preparedCalls != 1 {
+		t.Fatalf("task preparation ran %d times", *preparedCalls)
+	}
+}
+
+func TestRunStudyAuthenticatesBeforeStagingIncompleteTreatmentWithoutReport(t *testing.T) {
+	root := t.TempDir()
+	writeParsedTreatmentStudy(t, root, "luna:low")
+	preparedCalls := stubStudyInfrastructure(t, root)
+	stubFakeStudyTreatmentBundles(t)
+	originalTreatment := preflightTreatmentRuntime
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error { return nil }
+	t.Cleanup(func() { preflightTreatmentRuntime = originalTreatment })
+	originalAuth := validateBenchmarkAuthentication
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{}, nil
+	}
+	if _, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml"), DryRun: true}, &studyWorkflowExecutor{}); err != nil {
+		t.Fatal(err)
+	}
+
+	order := []string{}
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		order = append(order, "auth")
+		return map[string]AuthenticationPreflight{
+			adapterCodex: {Provider: adapterCodex, Check: codexLoginStatusCheck, AuthenticationMethod: codexAuthMethodChatGPT, VerifiedAt: time.Now().UTC()},
+		}, nil
+	}
+	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
+		order = append(order, "stage")
+		return nil, fmt.Errorf("stop after staging observation")
+	}
+	_, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err == nil || !strings.Contains(err.Error(), "stop after staging observation") {
+		t.Fatalf("error=%v", err)
+	}
+	if strings.Join(order, ",") != "auth,stage" {
+		t.Fatalf("order=%q", order)
+	}
+	if *preparedCalls != 1 {
+		t.Fatalf("task preparation ran %d times", *preparedCalls)
+	}
+}
+
+func TestRunStudyRejectsCorruptManifestOnlyEvidenceWithoutTaskSetup(t *testing.T) {
+	root := t.TempDir()
+	writeParsedBareStudy(t, root, "luna:low")
+	preparedCalls := stubStudyInfrastructure(t, root)
+	originalAuth := validateBenchmarkAuthentication
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{}, nil
+	}
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest immutableStudyManifest
+	if err := readStudyJSON(filepath.Join(root, ".agent-layer", "state", "benchmarks", "deepswe", "studies", first.StudyID, "study-manifest.json"), &manifest); err != nil {
+		t.Fatal(err)
+	}
+	corrupt := armResultPath(filepath.Join(root, ".agent-layer", "state", "benchmarks", "deepswe", "studies", first.StudyID, "arms", manifest.Arms[0].ID), "first-task", 1)
+	if err := os.WriteFile(corrupt, []byte("not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	removeStudyReport(t, root, first.StudyID)
+
+	blockCachedStudySidecars(t)
+	if _, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{}); err == nil || !strings.Contains(err.Error(), "inspect immutable study cell") {
+		t.Fatalf("corrupt cached error=%v", err)
+	}
+	if *preparedCalls != 1 {
+		t.Fatalf("corrupt cached evidence prepared tasks %d times", *preparedCalls)
+	}
+}
+
+func TestRunStudyAuthenticatesWhenManifestOnlyCellsAreMissing(t *testing.T) {
+	root := t.TempDir()
+	writeParsedBareStudy(t, root, "luna:low")
+	preparedCalls := stubStudyInfrastructure(t, root)
+	originalAuth := validateBenchmarkAuthentication
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{}, nil
+	}
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest immutableStudyManifest
+	if err := readStudyJSON(filepath.Join(root, ".agent-layer", "state", "benchmarks", "deepswe", "studies", first.StudyID, "study-manifest.json"), &manifest); err != nil {
+		t.Fatal(err)
+	}
+	missing := armResultPath(filepath.Join(root, ".agent-layer", "state", "benchmarks", "deepswe", "studies", first.StudyID, "arms", manifest.Arms[0].ID), "first-task", 1)
+	if err := os.Remove(missing); err != nil {
+		t.Fatal(err)
+	}
+	removeStudyReport(t, root, first.StudyID)
+
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return nil, fmt.Errorf("missing-cell run reached authentication")
+	}
+	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
+		return nil, fmt.Errorf("missing-cell run reached bundle staging")
+	}
+	_, err = RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err == nil || !strings.Contains(err.Error(), "missing-cell run reached authentication") {
+		t.Fatalf("error=%v", err)
+	}
+	if strings.Contains(err.Error(), "missing required cell evidence") {
+		t.Fatalf("missing cells were treated as completed-report corruption: %v", err)
+	}
+	if *preparedCalls != 1 {
+		t.Fatalf("task preparation ran %d times", *preparedCalls)
+	}
+}
+
+func TestRunStudyRejectsMultipleCompleteManifestOnlyMatches(t *testing.T) {
+	root := t.TempDir()
+	writeParsedBareStudy(t, root, "luna:low")
+	preparedCalls := stubStudyInfrastructure(t, root)
+	tag := "one"
+	prepareBenchmarkTaskSet = func(_ context.Context, gotRoot string, tasks []benchmarkPlanTask) (map[string]string, map[string]string, error) {
+		*preparedCalls++
+		if gotRoot != root {
+			return nil, nil, fmt.Errorf("unexpected task preparation root %q", gotRoot)
+		}
+		checksums := make(map[string]string, len(tasks))
+		environments := make(map[string]string, len(tasks))
+		for _, task := range tasks {
+			checksums[task.ID] = task.ID + "-checksum-" + tag
+			environments[task.ID] = task.ID + "-env-" + tag
+		}
+		return checksums, environments, nil
+	}
+	originalAuth := validateBenchmarkAuthentication
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{}, nil
+	}
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	studies := filepath.Join(root, ".agent-layer", "state", "benchmarks", "deepswe", "studies")
+	hidden := filepath.Join(t.TempDir(), first.StudyID)
+	if err := os.Rename(filepath.Join(studies, first.StudyID), hidden); err != nil {
+		t.Fatal(err)
+	}
+	tag = "two"
+	second, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.StudyID == first.StudyID {
+		t.Fatalf("second study reused first identity: %#v", second)
+	}
+	if err := os.Rename(hidden, filepath.Join(studies, first.StudyID)); err != nil {
+		t.Fatal(err)
+	}
+	removeStudyReport(t, root, first.StudyID)
+	removeStudyReport(t, root, second.StudyID)
+
+	blockCachedStudySidecars(t)
+	if _, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{}); err == nil || !strings.Contains(err.Error(), "matches more than one historical state directory") {
+		t.Fatalf("error=%v", err)
+	}
+	if *preparedCalls != 2 {
+		t.Fatalf("task preparation ran %d times", *preparedCalls)
+	}
+}
+
+func TestListPlausibleCompletedCachedStudiesDeduplicatesReportAndManifest(t *testing.T) {
+	root := t.TempDir()
+	writeParsedBareStudy(t, root, "luna:low")
+	stubStudyInfrastructure(t, root)
+	originalAuth := validateBenchmarkAuthentication
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{}, nil
+	}
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := prepareStudy(StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.cleanupInputs()
+	candidates, err := listPlausibleCompletedCachedStudies(root, &prepared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 1 || !candidates[0].reportClaimedComplete || filepath.Base(candidates[0].stateDir) != first.StudyID {
+		t.Fatalf("report+manifest candidates=%#v", candidates)
+	}
+
+	blockCachedStudySidecars(t)
+	executor := &studyWorkflowExecutor{}
+	second, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, executor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.StudyID != first.StudyID || second.Completed != 2 || len(executor.requests()) != 0 {
+		t.Fatalf("deduplicated regeneration=%#v calls=%#v", second, executor.requests())
+	}
+
+	removeStudyReport(t, root, first.StudyID)
+	candidates, err = listPlausibleCompletedCachedStudies(root, &prepared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 1 || candidates[0].reportClaimedComplete || filepath.Base(candidates[0].stateDir) != first.StudyID {
+		t.Fatalf("manifest-only candidates=%#v", candidates)
+	}
+}
+
+func TestRunStudyIgnoresUnrelatedMalformedStateDuringManifestOnlyRecovery(t *testing.T) {
+	root := t.TempDir()
+	writeParsedBareStudy(t, root, "luna:low")
+	preparedCalls := stubStudyInfrastructure(t, root)
+	originalAuth := validateBenchmarkAuthentication
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{}, nil
+	}
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	removeStudyReport(t, root, first.StudyID)
+	unrelated := filepath.Join(root, ".agent-layer", "state", "benchmarks", "deepswe", "studies", "unrelated")
+	if err := os.MkdirAll(filepath.Join(unrelated, "report"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(unrelated, "report", "report.json"), []byte("not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(unrelated, "study-manifest.json"), []byte("also-not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	blockCachedStudySidecars(t)
+	second, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *preparedCalls != 1 {
+		t.Fatalf("task preparation ran %d times", *preparedCalls)
+	}
+	if second.StudyID != first.StudyID || second.Completed != 2 || second.JSONPath == "" {
+		t.Fatalf("cached regeneration=%#v", second)
+	}
+}
+
 func TestStudyReportOmitsAuthenticationPreflightWhenAbsent(t *testing.T) {
 	item := StudyExperimentReport{Name: "Bare"}
 	data, err := json.Marshal(item)
@@ -802,7 +1358,7 @@ func TestCachedAuthenticationPreflightRejectsExperimentCountMismatch(t *testing.
 		t.Fatal(err)
 	}
 	_, err := cachedAuthenticationPreflight(stateDir, &preparedStudy{})
-	if err == nil || !strings.Contains(err.Error(), "report experiments changed during preparation") {
+	if err == nil || !strings.Contains(err.Error(), "report declaration does not match its immutable study") {
 		t.Fatalf("error=%v", err)
 	}
 }
@@ -860,6 +1416,35 @@ func fakeStudyTreatmentBundle() *TreatmentBundle {
 		RuntimeVersion:    "test",
 		Manifest:          TreatmentManifest{Mode: TreatmentInstructionsOnly, AgentTimeoutMultiplier: skillsAgentTimeoutFactor},
 	}
+}
+
+func removeStudyReport(t *testing.T, root, studyID string) {
+	t.Helper()
+	path := filepath.Join(root, ".agent-layer", "state", "benchmarks", "deepswe", "studies", studyID, "report", "report.json")
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func blockCachedStudySidecars(t *testing.T) {
+	t.Helper()
+	preflightBenchmark = func([]parsedSelection) error {
+		return fmt.Errorf("cached regeneration reached prerequisite discovery")
+	}
+	verifyBenchmarkPier = func(context.Context) error {
+		return fmt.Errorf("cached regeneration reached Pier verification")
+	}
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return nil, fmt.Errorf("cached regeneration reached authentication")
+	}
+	prepareBenchmarkTaskSet = func(context.Context, string, []benchmarkPlanTask) (map[string]string, map[string]string, error) {
+		return nil, nil, fmt.Errorf("cached regeneration reached task preparation")
+	}
+	originalTreatment := preflightTreatmentRuntime
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error {
+		return fmt.Errorf("cached regeneration reached treatment runtime preflight")
+	}
+	t.Cleanup(func() { preflightTreatmentRuntime = originalTreatment })
 }
 
 func writeMatchingStudyReport(t *testing.T, root, studyID string, prepared preparedStudy, completed, required int) {

--- a/internal/benchmark/study.go
+++ b/internal/benchmark/study.go
@@ -546,7 +546,8 @@ func manifestOnlyCachedStudyComplete(repoRoot string, prepared *preparedStudy, s
 	if !studyManifestDeclarationCompatible(manifest, prepared) {
 		return false, nil
 	}
-	preparation, err := bindStudyPreparation(repoRoot, prepared, tasks, copyStringMap(manifest.Checksums), copyStringMap(manifest.Environments), historicalBundlesFromManifest(manifest), nil, concurrency)
+	probe := *prepared
+	preparation, err := bindStudyPreparation(repoRoot, &probe, tasks, copyStringMap(manifest.Checksums), copyStringMap(manifest.Environments), historicalBundlesFromManifest(manifest), nil, concurrency)
 	if err != nil {
 		return false, err
 	}

--- a/internal/benchmark/study.go
+++ b/internal/benchmark/study.go
@@ -249,19 +249,12 @@ func prepareStudyExecution(ctx context.Context, options StudyOptions, prepared *
 	if err != nil {
 		return matrixPreparation{}, err
 	}
-	var bundles []*TreatmentBundle
-	if len(candidates) > 0 {
-		bundles, err = stageStudyBundlesIfNeeded(options.RepoRoot, prepared)
-		if err != nil {
-			return matrixPreparation{}, err
-		}
-		cached, found, err := loadCompleteCachedStudy(options.RepoRoot, prepared, candidates, bundles, tasks, options.TaskConcurrency)
-		if err != nil {
-			return matrixPreparation{}, err
-		}
-		if found {
-			return cached, nil
-		}
+	cached, bundles, found, err := loadCompleteCachedStudy(options.RepoRoot, prepared, candidates, tasks, options.TaskConcurrency)
+	if err != nil {
+		return matrixPreparation{}, err
+	}
+	if found {
+		return cached, nil
 	}
 	if err := preflightBenchmark(selections); err != nil {
 		return matrixPreparation{}, err
@@ -356,6 +349,11 @@ func stageStudyBundlesIfNeeded(repoRoot string, prepared *preparedStudy) ([]*Tre
 
 const maxHistoricalStudyDirectories = 1024
 
+type cachedStudyCandidate struct {
+	stateDir              string
+	reportClaimedComplete bool
+}
+
 type cachedStudyReportDeclaration struct {
 	SchemaVersion string                             `json:"schema_version"`
 	StudyID       string                             `json:"study_id"`
@@ -373,7 +371,7 @@ type cachedStudyExperimentDeclaration struct {
 	RequiredCells           int                      `json:"required_cells"`
 }
 
-func listPlausibleCompletedCachedStudies(repoRoot string, prepared *preparedStudy) ([]string, error) {
+func listPlausibleCompletedCachedStudies(repoRoot string, prepared *preparedStudy) ([]cachedStudyCandidate, error) {
 	root := filepath.Join(repoRoot, ".agent-layer", "state", "benchmarks", "deepswe", "studies")
 	entries, err := os.ReadDir(root)
 	if errors.Is(err, os.ErrNotExist) {
@@ -383,7 +381,7 @@ func listPlausibleCompletedCachedStudies(repoRoot string, prepared *preparedStud
 		return nil, fmt.Errorf("inspect completed study state: %w", err)
 	}
 	var directories int
-	var candidates []string
+	var candidates []cachedStudyCandidate
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -394,22 +392,37 @@ func listPlausibleCompletedCachedStudies(repoRoot string, prepared *preparedStud
 		}
 		stateDir := filepath.Join(root, entry.Name())
 		var report cachedStudyReportDeclaration
-		if err := readStudyJSON(filepath.Join(stateDir, "report", "report.json"), &report); err != nil {
+		if err := readStudyJSON(filepath.Join(stateDir, "report", "report.json"), &report); err == nil && cachedStudyReportMatchesDeclaration(report, prepared, entry.Name()) {
+			candidates = append(candidates, cachedStudyCandidate{stateDir: stateDir, reportClaimedComplete: true})
 			continue
 		}
-		if !cachedStudyReportMatchesDeclaration(report, prepared) {
+		var manifest immutableStudyManifest
+		if err := readStudyJSON(filepath.Join(stateDir, "study-manifest.json"), &manifest); err != nil {
 			continue
 		}
-		candidates = append(candidates, stateDir)
+		if !studyManifestDeclarationCompatible(manifest, prepared) {
+			continue
+		}
+		candidates = append(candidates, cachedStudyCandidate{stateDir: stateDir})
 	}
 	return candidates, nil
 }
 
-func cachedStudyReportMatchesDeclaration(report cachedStudyReportDeclaration, prepared *preparedStudy) bool {
-	if report.SchemaVersion != studyReportSchema || report.SelectionID != prepared.selectionID {
+func cachedStudyReportMatchesDeclaration(report cachedStudyReportDeclaration, prepared *preparedStudy, studyID string) bool {
+	if !cachedStudyReportMatchesIdentity(report, prepared, studyID) {
 		return false
 	}
-	if len(report.Experiments) != len(prepared.experiments) {
+	for _, item := range report.Experiments {
+		if item.CompletedCells != item.RequiredCells {
+			return false
+		}
+	}
+	return true
+}
+
+func cachedStudyReportMatchesIdentity(report cachedStudyReportDeclaration, prepared *preparedStudy, studyID string) bool {
+	if report.SchemaVersion != studyReportSchema || report.StudyID != studyID || report.SelectionID != prepared.selectionID ||
+		len(report.Experiments) != len(prepared.experiments) {
 		return false
 	}
 	required := 0
@@ -425,43 +438,160 @@ func cachedStudyReportMatchesDeclaration(report cachedStudyReportDeclaration, pr
 			item.Model != experiment.model.PublishedIdentifier || item.Reasoning != experiment.effort {
 			return false
 		}
-		if item.RequiredCells != required || item.CompletedCells != item.RequiredCells {
+		if item.RequiredCells != required {
 			return false
 		}
 	}
 	return true
 }
 
-func loadCompleteCachedStudy(repoRoot string, prepared *preparedStudy, candidates []string, bundles []*TreatmentBundle, tasks []benchmarkPlanTask, concurrency int) (matrixPreparation, bool, error) {
-	var matches []matrixPreparation
-	for _, stateDir := range candidates {
-		var manifest immutableStudyManifest
-		if err := readStudyJSON(filepath.Join(stateDir, "study-manifest.json"), &manifest); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return matrixPreparation{}, false, fmt.Errorf("completed cached study %s is missing its immutable manifest", filepath.Base(stateDir))
-			}
-			return matrixPreparation{}, false, fmt.Errorf("read immutable study manifest %s: %w", filepath.Base(stateDir), err)
-		}
-		if !studyManifestDeclarationCompatible(manifest, prepared) {
-			return matrixPreparation{}, false, fmt.Errorf("completed cached study %s conflicts with its immutable manifest declaration", filepath.Base(stateDir))
-		}
-		if !studyManifestBundleMatches(manifest, bundles) {
+func loadCompleteCachedStudy(repoRoot string, prepared *preparedStudy, candidates []cachedStudyCandidate, tasks []benchmarkPlanTask, concurrency int) (matrixPreparation, []*TreatmentBundle, bool, error) {
+	var reportClaimed, manifestOnly []cachedStudyCandidate
+	for _, candidate := range candidates {
+		if candidate.reportClaimedComplete {
+			reportClaimed = append(reportClaimed, candidate)
 			continue
 		}
-		preparation, err := preparationFromCachedStudy(repoRoot, prepared, manifest, stateDir, bundles, tasks, concurrency)
+		manifestOnly = append(manifestOnly, candidate)
+	}
+	var bundles []*TreatmentBundle
+	var matches []matrixPreparation
+	if len(reportClaimed) > 0 {
+		var err error
+		bundles, err = stageStudyBundlesIfNeeded(repoRoot, prepared)
 		if err != nil {
-			return matrixPreparation{}, false, err
+			return matrixPreparation{}, nil, false, err
 		}
-		matches = append(matches, preparation)
+		for _, candidate := range reportClaimed {
+			preparation, skip, err := loadReportClaimedCachedStudy(repoRoot, prepared, candidate.stateDir, bundles, tasks, concurrency)
+			if err != nil {
+				return matrixPreparation{}, nil, false, err
+			}
+			if skip {
+				continue
+			}
+			matches = append(matches, preparation)
+		}
+	}
+	var completeManifestOnly []cachedStudyCandidate
+	for _, candidate := range manifestOnly {
+		complete, err := manifestOnlyCachedStudyComplete(repoRoot, prepared, candidate.stateDir, tasks, concurrency)
+		if err != nil {
+			return matrixPreparation{}, nil, false, err
+		}
+		if complete {
+			completeManifestOnly = append(completeManifestOnly, candidate)
+		}
+	}
+	if len(completeManifestOnly) > 0 {
+		if bundles == nil {
+			var err error
+			bundles, err = stageStudyBundlesIfNeeded(repoRoot, prepared)
+			if err != nil {
+				return matrixPreparation{}, nil, false, err
+			}
+		}
+		for _, candidate := range completeManifestOnly {
+			var manifest immutableStudyManifest
+			if err := readStudyJSON(filepath.Join(candidate.stateDir, "study-manifest.json"), &manifest); err != nil {
+				return matrixPreparation{}, nil, false, fmt.Errorf("read immutable study manifest %s: %w", filepath.Base(candidate.stateDir), err)
+			}
+			if !studyManifestBundleMatches(manifest, bundles) {
+				continue
+			}
+			preparation, err := preparationFromCachedStudy(repoRoot, prepared, manifest, candidate.stateDir, bundles, tasks, concurrency)
+			if err != nil {
+				return matrixPreparation{}, nil, false, err
+			}
+			matches = append(matches, preparation)
+		}
 	}
 	switch len(matches) {
 	case 0:
-		return matrixPreparation{}, false, nil
+		return matrixPreparation{}, bundles, false, nil
 	case 1:
 		prepared.studyID = filepath.Base(matches[0].stateDir)
-		return matches[0], true, nil
+		return matches[0], bundles, true, nil
 	default:
-		return matrixPreparation{}, false, fmt.Errorf("completed benchmark study matches more than one historical state directory")
+		return matrixPreparation{}, nil, false, fmt.Errorf("completed benchmark study matches more than one historical state directory")
+	}
+}
+
+func loadReportClaimedCachedStudy(repoRoot string, prepared *preparedStudy, stateDir string, bundles []*TreatmentBundle, tasks []benchmarkPlanTask, concurrency int) (matrixPreparation, bool, error) {
+	var manifest immutableStudyManifest
+	if err := readStudyJSON(filepath.Join(stateDir, "study-manifest.json"), &manifest); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return matrixPreparation{}, false, fmt.Errorf("completed cached study %s is missing its immutable manifest", filepath.Base(stateDir))
+		}
+		return matrixPreparation{}, false, fmt.Errorf("read immutable study manifest %s: %w", filepath.Base(stateDir), err)
+	}
+	if !studyManifestDeclarationCompatible(manifest, prepared) {
+		return matrixPreparation{}, false, fmt.Errorf("completed cached study %s conflicts with its immutable manifest declaration", filepath.Base(stateDir))
+	}
+	if !studyManifestBundleMatches(manifest, bundles) {
+		return matrixPreparation{}, true, nil
+	}
+	preparation, err := preparationFromCachedStudy(repoRoot, prepared, manifest, stateDir, bundles, tasks, concurrency)
+	if err != nil {
+		return matrixPreparation{}, false, err
+	}
+	return preparation, false, nil
+}
+
+func manifestOnlyCachedStudyComplete(repoRoot string, prepared *preparedStudy, stateDir string, tasks []benchmarkPlanTask, concurrency int) (bool, error) {
+	var manifest immutableStudyManifest
+	if err := readStudyJSON(filepath.Join(stateDir, "study-manifest.json"), &manifest); err != nil {
+		return false, fmt.Errorf("reread immutable study manifest %s: %w", filepath.Base(stateDir), err)
+	}
+	if !studyManifestDeclarationCompatible(manifest, prepared) {
+		return false, nil
+	}
+	preparation, err := bindStudyPreparation(repoRoot, prepared, tasks, copyStringMap(manifest.Checksums), copyStringMap(manifest.Environments), historicalBundlesFromManifest(manifest), nil, concurrency)
+	if err != nil {
+		return false, err
+	}
+	if filepath.Base(stateDir) != manifest.StudyID || preparation.stateDir != stateDir {
+		return false, nil
+	}
+	for index := range preparation.arms {
+		arm := &preparation.arms[index]
+		if arm.ID != manifest.Arms[index].ID || arm.Label != manifest.Arms[index].Name {
+			return false, nil
+		}
+	}
+	for index := range preparation.arms {
+		if err := requireStudyArmManifest(prepared.selectionID, tasks, preparation.checksums, &preparation.arms[index]); err != nil {
+			return false, err
+		}
+	}
+	progress, err := studyProgressChecked(preparation)
+	if err != nil {
+		return false, err
+	}
+	return progress.Missing == 0, nil
+}
+
+func historicalBundlesFromManifest(manifest immutableStudyManifest) []*TreatmentBundle {
+	bundles := make([]*TreatmentBundle, len(manifest.Arms))
+	for index, arm := range manifest.Arms {
+		bundles[index] = historicalTreatmentBundle(arm)
+	}
+	return bundles
+}
+
+// historicalTreatmentBundle reconstructs the hashes needed to prove study/arm
+// identity and validate receipts. It is not a staged bundle and must not be
+// used for report generation.
+func historicalTreatmentBundle(contract studyArmContract) *TreatmentBundle {
+	if contract.Bundle == "" && contract.Adapter == "" && contract.Runtime == "" && contract.RuntimeSource == "" && contract.RuntimeVersion == "" {
+		return nil
+	}
+	return &TreatmentBundle{
+		ManifestHash:      contract.Bundle,
+		AdapterSHA256:     contract.Adapter,
+		LinuxBinarySHA256: contract.Runtime,
+		RuntimeSourceKind: contract.RuntimeSource,
+		RuntimeVersion:    contract.RuntimeVersion,
 	}
 }
 
@@ -547,10 +677,13 @@ func preparationFromCachedStudy(repoRoot string, prepared *preparedStudy, manife
 func cachedAuthenticationPreflight(stateDir string, prepared *preparedStudy) (map[string]AuthenticationPreflight, error) {
 	var report cachedStudyReportDeclaration
 	if err := readStudyJSON(filepath.Join(stateDir, "report", "report.json"), &report); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]AuthenticationPreflight{}, nil
+		}
 		return nil, fmt.Errorf("read completed cached study authentication provenance: %w", err)
 	}
-	if len(report.Experiments) != len(prepared.experiments) {
-		return nil, fmt.Errorf("completed cached study %s report experiments changed during preparation", filepath.Base(stateDir))
+	if !cachedStudyReportMatchesIdentity(report, prepared, filepath.Base(stateDir)) {
+		return nil, fmt.Errorf("completed cached study %s report declaration does not match its immutable study", filepath.Base(stateDir))
 	}
 	authentication := make(map[string]AuthenticationPreflight)
 	for index, item := range report.Experiments {


### PR DESCRIPTION
## Summary

- Regenerate a missing benchmark report without provider authentication when immutable study/arm manifests and complete cell receipts prove one unique completed study.
- Preserve only authentication provenance from a validated prior report and remove the resolved issue.

## Changes

- Add manifest-only completed-study discovery with identity checks, corruption failures, bounded historical scanning, deduplication, and current treatment-bundle verification.
- Keep incomplete work on the normal authenticated path and preserve existing report-claimed fail-closed behavior.
- Add public workflow regression coverage for Codex, Claude, treatment bundles, provenance, sibling identities, corruption, and fallback behavior.

## Verification

- `go test ./internal/benchmark` — passed
- `make dev` — passed; 4,353 Go tests, 90.19% total coverage, browser checks, static/release checks, and tool tests
- pre-commit hooks — passed, including gofmt/goimports, lint, module tidy, and full Go tests

## Notes

- No authentication provenance is synthesized when the prior report is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed benchmark studies can now recover when their report is missing.
  * Cached study recovery validates identity, declarations, treatment settings, and stored evidence more reliably.
  * Authentication provenance is preserved when valid and rejected when it belongs to an unrelated study.
  * Ambiguous or corrupted cached study data is safely rejected.
  * Missing reports no longer unnecessarily trigger full authentication and setup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->