### PR TITLE
feat: support skill diffing, conflict resolution workspaces, and PR comment reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+- `al skills diff <name>` compares live `base`, `local`, `upstream`, and `destination` trees as an ordinary Git unified diff.
+- Pull and push merge conflicts now leave a Git workspace under `.agent-layer/tmp/skill-conflicts/<name>/`. Finish the merge with ordinary git commands and `al skills resolve <name>`.
+- `ship-pr` includes a stateless `read-pr-comments.sh` command that prints every PR comment kind, including review-thread resolved/outdated state, as readable Markdown.
+
 ### Changed
 - The Claude instruction shim is now `.claude/CLAUDE.md` instead of root `CLAUDE.md`. When Grok is enabled, sync sets `[compat.claude] agents = false` in repo-local `.grok-config/config.toml`, and Grok launch/dispatch/VS Code set `GROK_CLAUDE_AGENTS_ENABLED=false`, so Grok does not load both generated instruction files. The `0.17.1` migration deletes Agent Layer-generated root `CLAUDE.md` files; hand-authored files at that path are left untouched.
+- Recreating a deleted contribution branch reuses its prior publication checkpoint when that commit remains in the destination's history, avoiding conflicts with changes already merged from the earlier branch.
 
 ## v0.17.0 - 2026-08-20
 

--- a/cmd/al/skills.go
+++ b/cmd/al/skills.go
@@ -26,11 +26,56 @@ func newSkillsCmd() *cobra.Command {
 		newSkillsAddCmd(),
 		newSkillsRemoveCmd(),
 		newSkillsStatusCmd(),
+		newSkillsDiffCmd(),
 		newSkillsPullCmd(),
 		newSkillsResetCmd(),
+		newSkillsResolveCmd(),
 		newSkillsPushCmd(),
 	)
 	return cmd
+}
+
+func newSkillsDiffCmd() *cobra.Command {
+	var from string
+	var to string
+	cmd := &cobra.Command{
+		Use:   messages.SkillsDiffUse,
+		Short: messages.SkillsDiffShort,
+		Long:  messages.SkillsDiffLong,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root, err := resolveRepoRoot()
+			if err != nil {
+				return err
+			}
+			output, err := skillimport.New(root).Diff(cmd.Context(), args[0], from, to)
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(output)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&from, "from", "local", messages.SkillsDiffFromFlag)
+	cmd.Flags().StringVar(&to, "to", "upstream", messages.SkillsDiffToFlag)
+	return cmd
+}
+
+func newSkillsResolveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   messages.SkillsResolveUse,
+		Short: messages.SkillsResolveShort,
+		Long:  messages.SkillsResolveLong,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root, err := resolveRepoRoot()
+			if err != nil {
+				return err
+			}
+			report, err := skillimport.New(root).Resolve(cmd.Context(), args[0])
+			return finishSkillsOperation(cmd, "resolve", report, err)
+		},
+	}
 }
 
 func newSkillsResetCmd() *cobra.Command {

--- a/cmd/al/skills_test.go
+++ b/cmd/al/skills_test.go
@@ -184,6 +184,19 @@ func TestSkillsCommandSurfaceMatchesTheContract(t *testing.T) {
 	if diff.Flags().Lookup("yes") != nil {
 		t.Fatal("al skills diff should not require confirmation")
 	}
+	var diffHelp bytes.Buffer
+	diff.SetOut(&diffHelp)
+	diff.SetErr(&diffHelp)
+	if err := diff.Help(); err != nil {
+		t.Fatalf("al skills diff --help: %v", err)
+	}
+	help := diffHelp.String()
+	if strings.Contains(help, "(default: local)") || strings.Contains(help, "(default: upstream)") {
+		t.Fatalf("al skills diff --help duplicates pflag defaults:\n%s", help)
+	}
+	if !strings.Contains(help, `(default "local")`) || !strings.Contains(help, `(default "upstream")`) {
+		t.Fatalf("al skills diff --help omitted pflag defaults:\n%s", help)
+	}
 
 	reset := find("reset")
 	if err := reset.Args(reset, nil); err == nil {

--- a/cmd/al/skills_test.go
+++ b/cmd/al/skills_test.go
@@ -117,7 +117,7 @@ func TestSkillsCommandSurfaceMatchesTheContract(t *testing.T) {
 	for _, sub := range skills.Commands() {
 		got[sub.Name()] = true
 	}
-	for _, want := range []string{"add", "remove", "status", "pull", "reset", "push"} {
+	for _, want := range []string{"add", "remove", "status", "diff", "pull", "reset", "resolve", "push"} {
 		if !got[want] {
 			t.Fatalf("missing subcommand %q", want)
 		}
@@ -125,8 +125,8 @@ func TestSkillsCommandSurfaceMatchesTheContract(t *testing.T) {
 	if got["sync"] {
 		t.Fatal("an al skills sync alias was added")
 	}
-	if len(skills.Commands()) != 6 {
-		t.Fatalf("subcommands = %d, want exactly 6", len(skills.Commands()))
+	if len(skills.Commands()) != 8 {
+		t.Fatalf("subcommands = %d, want exactly 8", len(skills.Commands()))
 	}
 
 	find := func(name string) *cobra.Command {
@@ -171,6 +171,20 @@ func TestSkillsCommandSurfaceMatchesTheContract(t *testing.T) {
 		t.Fatal("al skills status accepted an argument")
 	}
 
+	diff := find("diff")
+	if err := diff.Args(diff, nil); err == nil {
+		t.Fatal("al skills diff accepted no name")
+	}
+	if err := diff.Args(diff, []string{"alpha", "beta"}); err == nil {
+		t.Fatal("al skills diff accepted more than one name")
+	}
+	if diff.Flags().Lookup("from") == nil || diff.Flags().Lookup("to") == nil {
+		t.Fatal("al skills diff is missing --from/--to")
+	}
+	if diff.Flags().Lookup("yes") != nil {
+		t.Fatal("al skills diff should not require confirmation")
+	}
+
 	reset := find("reset")
 	if err := reset.Args(reset, nil); err == nil {
 		t.Fatal("al skills reset accepted no name")
@@ -186,6 +200,17 @@ func TestSkillsCommandSurfaceMatchesTheContract(t *testing.T) {
 	}
 	if reset.Flags().Lookup("yes") == nil {
 		t.Fatal("al skills reset is missing --yes")
+	}
+
+	resolve := find("resolve")
+	if err := resolve.Args(resolve, nil); err == nil {
+		t.Fatal("al skills resolve accepted no name")
+	}
+	if err := resolve.Args(resolve, []string{"alpha", "beta"}); err == nil {
+		t.Fatal("al skills resolve accepted more than one name")
+	}
+	if resolve.Flags().Lookup("yes") != nil {
+		t.Fatal("al skills resolve should not require confirmation")
 	}
 
 	push := find("push")

--- a/cmd/publish-site/main.go
+++ b/cmd/publish-site/main.go
@@ -858,11 +858,12 @@ type redirectManifestEntry struct {
 
 // pruneDroppedVersionArtifacts records redirects for dropped docs pages, then
 // removes versioned docs and sidebars for each dropped version from the website
-// repository checkout.
-func pruneDroppedVersionArtifacts(repoB string, dropped []string) error {
+// repository checkout. retained is newest-first; its first entry is the docs
+// tree Docusaurus serves at un-prefixed /docs/<slug> routes.
+func pruneDroppedVersionArtifacts(repoB string, retained, dropped []string) error {
 	for _, v := range dropped {
 		versionedDocsPath := filepath.Join(repoB, "versioned_docs", "version-"+v)
-		if err := recordDroppedVersionRedirects(repoB, v, versionedDocsPath); err != nil {
+		if err := recordDroppedVersionRedirects(repoB, v, versionedDocsPath, retained); err != nil {
 			return fmt.Errorf("record redirects for dropped version %s: %w", v, err)
 		}
 
@@ -879,7 +880,7 @@ func pruneDroppedVersionArtifacts(repoB string, dropped []string) error {
 	return nil
 }
 
-func recordDroppedVersionRedirects(repoB, version, versionedDocsPath string) error {
+func recordDroppedVersionRedirects(repoB, version, versionedDocsPath string, retained []string) error {
 	droppedSlugs, err := collectDocSlugs(versionedDocsPath)
 	if err != nil {
 		return err
@@ -888,7 +889,7 @@ func recordDroppedVersionRedirects(repoB, version, versionedDocsPath string) err
 		return nil
 	}
 
-	latestSlugs, err := collectDocSlugs(filepath.Join(repoB, "docs"))
+	latestSlugs, err := collectDocSlugs(latestDocsRoot(repoB, retained))
 	if err != nil {
 		return fmt.Errorf("read latest docs: %w", err)
 	}
@@ -952,6 +953,22 @@ func readRedirectManifest(path string) ([]redirectManifestEntry, error) {
 		}
 	}
 	return entries, nil
+}
+
+// latestDocsRoot is the docs tree served at un-prefixed /docs/<slug> routes.
+// With versioning that is the newest retained version, not repoB/docs (the
+// unpublished current snapshot). Missing versioned docs fall back to docs/.
+func latestDocsRoot(repoB string, retained []string) string {
+	currentDocs := filepath.Join(repoB, "docs")
+	if len(retained) == 0 {
+		return currentDocs
+	}
+	versionedLatest := filepath.Join(repoB, "versioned_docs", "version-"+retained[0])
+	info, err := osStatFunc(versionedLatest)
+	if err != nil || !info.IsDir() {
+		return currentDocs
+	}
+	return versionedLatest
 }
 
 func collectDocSlugs(root string) (map[string]struct{}, error) {
@@ -1133,7 +1150,7 @@ func normalizeVersionsJSON(repoB string) error {
 		return err
 	}
 
-	if err := pruneDroppedVersionArtifacts(repoB, dropped); err != nil {
+	if err := pruneDroppedVersionArtifacts(repoB, retained, dropped); err != nil {
 		return err
 	}
 

--- a/cmd/publish-site/main_test.go
+++ b/cmd/publish-site/main_test.go
@@ -140,6 +140,9 @@ func TestNormalizeVersionsJSON(t *testing.T) {
 		t.Fatalf("write versions.json: %v", err)
 	}
 
+	droppedVersions := map[string]struct{}{
+		"0.8.3": {}, "0.8.2": {}, "0.8.1": {}, "0.8.0": {}, "0.6.0": {},
+	}
 	for _, v := range []string{
 		"0.8.7", "0.8.6", "0.8.5", "0.8.4", "0.8.3", "0.8.2", "0.8.1", "0.8.0", "0.7.0", "0.6.1", "0.6.0",
 	} {
@@ -150,8 +153,13 @@ func TestNormalizeVersionsJSON(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(docsDir, "doc.mdx"), []byte("x"), 0o600); err != nil {
 			t.Fatalf("write docs file for %s: %v", v, err)
 		}
-		if err := os.WriteFile(filepath.Join(docsDir, "old-only.mdx"), []byte("x"), 0o600); err != nil {
-			t.Fatalf("write old-only docs file for %s: %v", v, err)
+		if _, dropped := droppedVersions[v]; dropped {
+			if err := os.WriteFile(filepath.Join(docsDir, "old-only.mdx"), []byte("x"), 0o600); err != nil {
+				t.Fatalf("write old-only docs file for %s: %v", v, err)
+			}
+			if err := os.WriteFile(filepath.Join(docsDir, "current-only.mdx"), []byte("x"), 0o600); err != nil {
+				t.Fatalf("write current-only docs file for %s: %v", v, err)
+			}
 		}
 
 		sidebarsDir := filepath.Join(repo, "versioned_sidebars")
@@ -168,6 +176,9 @@ func TestNormalizeVersionsJSON(t *testing.T) {
 	}
 	if err := os.WriteFile(filepath.Join(latestDocs, "doc.mdx"), []byte("x"), 0o600); err != nil {
 		t.Fatalf("write latest docs file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(latestDocs, "current-only.mdx"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write current-only docs file: %v", err)
 	}
 
 	if err := normalizeVersionsJSON(repo); err != nil {
@@ -214,16 +225,21 @@ func TestNormalizeVersionsJSON(t *testing.T) {
 		t.Fatalf("unmarshal redirect manifest: %v", err)
 	}
 	wantRedirects := map[string]string{
-		"/docs/0.6.0/doc":      "/docs/doc",
-		"/docs/0.6.0/old-only": "/docs/",
-		"/docs/0.8.0/doc":      "/docs/doc",
-		"/docs/0.8.0/old-only": "/docs/",
-		"/docs/0.8.1/doc":      "/docs/doc",
-		"/docs/0.8.1/old-only": "/docs/",
-		"/docs/0.8.2/doc":      "/docs/doc",
-		"/docs/0.8.2/old-only": "/docs/",
-		"/docs/0.8.3/doc":      "/docs/doc",
-		"/docs/0.8.3/old-only": "/docs/",
+		"/docs/0.6.0/current-only": "/docs/",
+		"/docs/0.6.0/doc":          "/docs/doc",
+		"/docs/0.6.0/old-only":     "/docs/",
+		"/docs/0.8.0/current-only": "/docs/",
+		"/docs/0.8.0/doc":          "/docs/doc",
+		"/docs/0.8.0/old-only":     "/docs/",
+		"/docs/0.8.1/current-only": "/docs/",
+		"/docs/0.8.1/doc":          "/docs/doc",
+		"/docs/0.8.1/old-only":     "/docs/",
+		"/docs/0.8.2/current-only": "/docs/",
+		"/docs/0.8.2/doc":          "/docs/doc",
+		"/docs/0.8.2/old-only":     "/docs/",
+		"/docs/0.8.3/current-only": "/docs/",
+		"/docs/0.8.3/doc":          "/docs/doc",
+		"/docs/0.8.3/old-only":     "/docs/",
 	}
 	if len(redirects) != len(wantRedirects) {
 		t.Fatalf("got %d redirects, want %d: %#v", len(redirects), len(wantRedirects), redirects)
@@ -367,7 +383,7 @@ func TestPruneDroppedVersionArtifacts_RemoveSidebarError(t *testing.T) {
 		t.Fatalf("write nested file: %v", err)
 	}
 
-	if err := pruneDroppedVersionArtifacts(repo, []string{"1.2.3"}); err == nil {
+	if err := pruneDroppedVersionArtifacts(repo, nil, []string{"1.2.3"}); err == nil {
 		t.Fatal("expected remove sidebar error when sidebar path is a directory")
 	}
 }
@@ -407,7 +423,7 @@ func TestPruneDroppedVersionArtifacts_RecordsRedirectsBeforeDeleting(t *testing.
 		t.Fatalf("write dropped removed doc: %v", err)
 	}
 
-	if err := pruneDroppedVersionArtifacts(repo, []string{"1.2.3"}); err != nil {
+	if err := pruneDroppedVersionArtifacts(repo, nil, []string{"1.2.3"}); err != nil {
 		t.Fatalf("prune: %v", err)
 	}
 
@@ -438,6 +454,64 @@ func TestPruneDroppedVersionArtifacts_RecordsRedirectsBeforeDeleting(t *testing.
 	}
 }
 
+func TestPruneDroppedVersionArtifacts_UsesLatestRetainedVersionedDocs(t *testing.T) {
+	repo := t.TempDir()
+	latestDocs := filepath.Join(repo, "docs")
+	if err := os.MkdirAll(latestDocs, 0o700); err != nil {
+		t.Fatalf("mkdir current docs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(latestDocs, "intro.mdx"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write current intro: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(latestDocs, "agent-dispatch.mdx"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write current-only page: %v", err)
+	}
+
+	retainedDocs := filepath.Join(repo, "versioned_docs", "version-0.16.3")
+	if err := os.MkdirAll(retainedDocs, 0o700); err != nil {
+		t.Fatalf("mkdir retained docs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(retainedDocs, "intro.mdx"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write retained intro: %v", err)
+	}
+
+	droppedDocs := filepath.Join(repo, "versioned_docs", "version-0.0.0")
+	if err := os.MkdirAll(droppedDocs, 0o700); err != nil {
+		t.Fatalf("mkdir dropped docs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(droppedDocs, "intro.mdx"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write dropped intro: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(droppedDocs, "agent-dispatch.mdx"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write dropped current-only page: %v", err)
+	}
+
+	if err := pruneDroppedVersionArtifacts(repo, []string{"0.16.3"}, []string{"0.0.0"}); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+
+	manifestData, err := os.ReadFile(filepath.Join(repo, redirectManifestName)) // #nosec G304 -- path is constructed from test-controlled inputs.
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var got []redirectManifestEntry
+	if err := json.Unmarshal(manifestData, &got); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	want := []redirectManifestEntry{
+		{From: "/docs/0.0.0/agent-dispatch", To: "/docs/"},
+		{From: "/docs/0.0.0/intro", To: "/docs/intro"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got redirects %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("redirect %d = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
 func TestPruneDroppedVersionArtifacts_ManifestWriteErrorSkipsPrune(t *testing.T) {
 	repo := t.TempDir()
 	droppedDocs := filepath.Join(repo, "versioned_docs", "version-1.2.3")
@@ -457,7 +531,7 @@ func TestPruneDroppedVersionArtifacts_ManifestWriteErrorSkipsPrune(t *testing.T)
 	}
 
 	withWriteFileError(t, filepath.Join(repo, redirectManifestName), os.ErrPermission)
-	if err := pruneDroppedVersionArtifacts(repo, []string{"1.2.3"}); err == nil || !errors.Is(err, os.ErrPermission) {
+	if err := pruneDroppedVersionArtifacts(repo, nil, []string{"1.2.3"}); err == nil || !errors.Is(err, os.ErrPermission) {
 		t.Fatalf("expected manifest write error, got %v", err)
 	}
 

--- a/docs/AGENT-DISPATCH.md
+++ b/docs/AGENT-DISPATCH.md
@@ -54,11 +54,11 @@ handler always releases the caller. Both are optional positive integers; when
 omitted they resolve to 30 and 40. The tool timeout must be greater than the
 wait timeout, and an invalid relationship fails configuration validation.
 
-Codex also receives the hard bound natively as `tool_timeout_sec`. Claude Code
-documents only a client-wide `MCP_TOOL_TIMEOUT`, which Agent Layer does not
-change because that would affect every unrelated MCP server; Antigravity
-documents no per-server timeout key. For those clients the server-side guard is
-the recovery bound.
+Codex and Grok also receive the hard bound natively as `tool_timeout_sec`.
+Claude Code documents only a client-wide `MCP_TOOL_TIMEOUT`, which Agent Layer
+does not change because that would affect every unrelated MCP server;
+Antigravity documents no per-server timeout key. For those clients the
+server-side guard is the recovery bound.
 
 ### Cancelling a request is not cancelling a dispatch
 

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -189,7 +189,7 @@ func (e *CommandError) Unwrap() error { return e.Err }
 
 // run executes git in dir and returns its standard output.
 func (r *Runner) run(ctx context.Context, dir string, args ...string) ([]byte, error) {
-	stdout, _, err := r.runAllowExitInput(ctx, dir, nil, nil, args...)
+	stdout, _, err := r.runAllowExitInput(ctx, dir, nil, nil, nil, args...)
 	return stdout, err
 }
 
@@ -197,7 +197,15 @@ func (r *Runner) run(ctx context.Context, dir string, args ...string) ([]byte, e
 // publication uses it to hash exact blob bytes without materializing a remote
 // tree or passing content through checkout filters.
 func (r *Runner) runInput(ctx context.Context, dir string, input []byte, args ...string) ([]byte, error) {
-	stdout, _, err := r.runAllowExitInput(ctx, dir, input, nil, args...)
+	stdout, _, err := r.runAllowExitInput(ctx, dir, input, nil, nil, args...)
+	return stdout, err
+}
+
+// runEnv executes git with extra environment variables overlaid on the runner's
+// fixed non-interactive environment. Workspace commits use it to apply an
+// isolated synthetic identity without changing publication identity.
+func (r *Runner) runEnv(ctx context.Context, dir string, extraEnv []string, args ...string) ([]byte, error) {
+	stdout, _, err := r.runAllowExitInput(ctx, dir, nil, nil, extraEnv, args...)
 	return stdout, err
 }
 
@@ -206,13 +214,34 @@ func (r *Runner) runInput(ctx context.Context, dir string, input []byte, args ..
 // treat a specific exit code as meaningful (for example `git merge-file`
 // reporting conflict counts) use this form.
 func (r *Runner) runAllowExit(ctx context.Context, dir string, allowedExitCodes []int, args ...string) ([]byte, int, error) {
-	return r.runAllowExitInput(ctx, dir, nil, allowedExitCodes, args...)
+	return r.runAllowExitInput(ctx, dir, nil, allowedExitCodes, nil, args...)
+}
+
+// overlayEnv returns base with extra entries taking precedence by variable name.
+func overlayEnv(base []string, extra []string) []string {
+	if len(extra) == 0 {
+		return base
+	}
+	replace := make(map[string]struct{}, len(extra))
+	for _, entry := range extra {
+		name, _, _ := strings.Cut(entry, "=")
+		replace[name] = struct{}{}
+	}
+	out := make([]string, 0, len(base)+len(extra))
+	for _, entry := range base {
+		name, _, _ := strings.Cut(entry, "=")
+		if _, skip := replace[name]; skip {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return append(out, extra...)
 }
 
 // runAllowExitInput is the single process boundary for Git invocation. It
 // applies fixed hook/template protections, optional standard input, redaction,
 // and caller-declared non-zero result handling.
-func (r *Runner) runAllowExitInput(ctx context.Context, dir string, input []byte, allowedExitCodes []int, args ...string) ([]byte, int, error) {
+func (r *Runner) runAllowExitInput(ctx context.Context, dir string, input []byte, allowedExitCodes []int, extraEnv []string, args ...string) ([]byte, int, error) {
 	// These protections apply to every invocation, including `git init`, so a
 	// global template cannot seed hooks into a disposable repository and no Git
 	// command can discover or run repository hooks.
@@ -221,7 +250,7 @@ func (r *Runner) runAllowExitInput(ctx context.Context, dir string, input []byte
 	effectiveArgs = append(effectiveArgs, args...)
 	cmd := exec.CommandContext(ctx, r.path, effectiveArgs...) // #nosec G204 -- args are built from validated configuration and resolved object ids, never a shell string.
 	cmd.Dir = dir
-	cmd.Env = r.env
+	cmd.Env = overlayEnv(r.env, extraEnv)
 	if input != nil {
 		cmd.Stdin = bytes.NewReader(input)
 	}

--- a/internal/gitrepo/tree.go
+++ b/internal/gitrepo/tree.go
@@ -1,0 +1,119 @@
+package gitrepo
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/conn-castle/agent-layer/internal/skilltree"
+)
+
+// DiffTrees returns an ordinary Git unified diff of two skill trees. Prefixes
+// are `a/<from>/` and `b/<to>/`. Identical trees produce no output.
+func (r *Runner) DiffTrees(ctx context.Context, fromName string, from skilltree.Tree, toName string, to skilltree.Tree) ([]byte, error) {
+	if err := validateDiffSideName(fromName); err != nil {
+		return nil, err
+	}
+	if err := validateDiffSideName(toName); err != nil {
+		return nil, err
+	}
+	dir, err := os.MkdirTemp("", "al-skill-diff-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a git working directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	if _, err := r.run(ctx, dir, "init", "--quiet"); err != nil {
+		return nil, err
+	}
+	fromTree, err := r.writeSkillTree(ctx, dir, from)
+	if err != nil {
+		return nil, err
+	}
+	toTree, err := r.writeSkillTree(ctx, dir, to)
+	if err != nil {
+		return nil, err
+	}
+	if fromTree == toTree {
+		return nil, nil
+	}
+	output, err := r.run(ctx, dir,
+		"diff-tree", "-r", "-p", "--no-color", "--no-ext-diff", "--no-renames",
+		"--src-prefix=a/"+fromName+"/",
+		"--dst-prefix=b/"+toName+"/",
+		fromTree, toTree)
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func validateDiffSideName(name string) error {
+	if name == "" || strings.ContainsAny(name, "/\\ \t\r\n") {
+		return fmt.Errorf("invalid diff side label %q", name)
+	}
+	return nil
+}
+
+// writeSkillTree stores a skill tree as a Git tree object and returns its id.
+func (r *Runner) writeSkillTree(ctx context.Context, dir string, tree skilltree.Tree) (string, error) {
+	if _, err := r.run(ctx, dir, "read-tree", "--empty"); err != nil {
+		return "", err
+	}
+	for _, file := range tree.Files() {
+		if err := skilltree.ValidateRelativePath(file.Path); err != nil {
+			return "", fmt.Errorf("skill path %q is unsafe: %w", file.Path, err)
+		}
+		object, err := r.runInput(ctx, dir, file.Data, "hash-object", "-w", "--no-filters", "--stdin")
+		if err != nil {
+			return "", fmt.Errorf("failed to write blob for %s: %w", file.Path, err)
+		}
+		mode := "100644"
+		if file.Executable {
+			mode = "100755"
+		}
+		if _, err := r.run(ctx, dir, "update-index", "--add", "--cacheinfo", mode, strings.TrimSpace(string(object)), file.Path); err != nil {
+			return "", fmt.Errorf("failed to stage %s: %w", file.Path, err)
+		}
+	}
+	written, err := r.run(ctx, dir, "write-tree")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(written)), nil
+}
+
+// readSkillTreeObject reads a Git tree object as a canonical skill tree.
+func (r *Runner) readSkillTreeObject(ctx context.Context, dir string, treeID string) (skilltree.Tree, error) {
+	output, err := r.run(ctx, dir, "ls-tree", "-r", "-z", "--full-tree", treeID)
+	if err != nil {
+		return skilltree.Tree{}, err
+	}
+	var files []skilltree.File
+	for _, record := range strings.Split(string(output), "\x00") {
+		if strings.TrimSpace(record) == "" {
+			continue
+		}
+		mode, objectType, object, name, parseErr := parseTreeRecord(record)
+		if parseErr != nil {
+			return skilltree.Tree{}, parseErr
+		}
+		if isIgnoredTreePath(name) {
+			continue
+		}
+		switch {
+		case objectType == gitObjectCommit:
+			return skilltree.Tree{}, fmt.Errorf("%s is a gitlink (submodule); imported skills may contain only directories and regular files", name)
+		case mode == "120000":
+			return skilltree.Tree{}, fmt.Errorf("%s is a symbolic link; imported skills may contain only directories and regular files", name)
+		case objectType != gitObjectBlob:
+			return skilltree.Tree{}, fmt.Errorf("%s is an unsupported git object type %q", name, objectType)
+		}
+		data, catErr := r.run(ctx, dir, "cat-file", gitObjectBlob, object)
+		if catErr != nil {
+			return skilltree.Tree{}, catErr
+		}
+		files = append(files, skilltree.File{Path: name, Data: data, Executable: mode == "100755"})
+	}
+	return skilltree.NewTree(files)
+}

--- a/internal/gitrepo/tree_test.go
+++ b/internal/gitrepo/tree_test.go
@@ -1,0 +1,79 @@
+package gitrepo
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/conn-castle/agent-layer/internal/skilltree"
+)
+
+func testSkillTree(t *testing.T, files []skilltree.File) skilltree.Tree {
+	t.Helper()
+	tree, err := skilltree.NewTree(files)
+	if err != nil {
+		t.Fatalf("NewTree: %v", err)
+	}
+	return tree
+}
+
+func TestDiffTreesWritesPrefixedUnifiedDiff(t *testing.T) {
+	runner, err := NewRunner(nil)
+	if err != nil {
+		t.Skipf("git runner unavailable: %v", err)
+	}
+	from := testSkillTree(t, []skilltree.File{
+		{Path: "SKILL.md", Data: []byte("one\n")},
+		{Path: "notes.md", Data: []byte("local\n")},
+	})
+	to := testSkillTree(t, []skilltree.File{
+		{Path: "SKILL.md", Data: []byte("one\n")},
+		{Path: "notes.md", Data: []byte("upstream\n")},
+	})
+
+	diff, err := runner.DiffTrees(context.Background(), "local", from, "upstream", to)
+	if err != nil {
+		t.Fatalf("DiffTrees: %v", err)
+	}
+	text := string(diff)
+	for _, fragment := range []string{
+		"diff --git a/local/notes.md b/upstream/notes.md",
+		"--- a/local/notes.md",
+		"+++ b/upstream/notes.md",
+		"-local",
+		"+upstream",
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("diff %q does not contain %q", text, fragment)
+		}
+	}
+	if strings.Contains(text, "SKILL.md") {
+		t.Fatalf("unchanged file appeared in the diff: %s", text)
+	}
+}
+
+func TestDiffTreesSilentWhenIdentical(t *testing.T) {
+	runner, err := NewRunner(nil)
+	if err != nil {
+		t.Skipf("git runner unavailable: %v", err)
+	}
+	tree := testSkillTree(t, []skilltree.File{{Path: "SKILL.md", Data: []byte("one\n")}})
+	diff, err := runner.DiffTrees(context.Background(), "base", tree, "local", tree)
+	if err != nil {
+		t.Fatalf("DiffTrees: %v", err)
+	}
+	if len(diff) != 0 {
+		t.Fatalf("identical trees produced output %q", diff)
+	}
+}
+
+func TestDiffTreesRejectsUnsafeLabels(t *testing.T) {
+	runner, err := NewRunner(nil)
+	if err != nil {
+		t.Skipf("git runner unavailable: %v", err)
+	}
+	tree := testSkillTree(t, nil)
+	if _, err := runner.DiffTrees(context.Background(), "../ours", tree, "local", tree); err == nil {
+		t.Fatal("expected an unsafe label to fail")
+	}
+}

--- a/internal/gitrepo/workspace.go
+++ b/internal/gitrepo/workspace.go
@@ -1,0 +1,185 @@
+package gitrepo
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/conn-castle/agent-layer/internal/skilltree"
+)
+
+// Named branches in a skill conflict workspace.
+const (
+	ConflictBranchBase        = "base"
+	ConflictBranchLocal       = "local"
+	ConflictBranchUpstream    = "upstream"
+	ConflictBranchDestination = "destination"
+)
+
+// syntheticIdentity is used only for conflict-workspace plumbing commits so a
+// user's Git identity never authors those temporary objects.
+var syntheticIdentity = []string{
+	"GIT_AUTHOR_NAME=Agent Layer",
+	"GIT_AUTHOR_EMAIL=agent-layer@invalid",
+	"GIT_COMMITTER_NAME=Agent Layer",
+	"GIT_COMMITTER_EMAIL=agent-layer@invalid",
+}
+
+const gitFalse = "false"
+
+// ConflictWorkspaceSpec is the three skill trees materialized as a synthetic
+// Git repository so an ordinary merge can be finished with git.
+type ConflictWorkspaceSpec struct {
+	Base         skilltree.Tree
+	Local        skilltree.Tree
+	Theirs       skilltree.Tree
+	TheirsBranch string
+}
+
+// CreateConflictWorkspace replaces dir with a synthetic Git repository of one
+// skill, checks out local, and runs a no-commit no-rename diff3 merge.
+func (r *Runner) CreateConflictWorkspace(ctx context.Context, dir string, spec ConflictWorkspaceSpec) error {
+	switch spec.TheirsBranch {
+	case ConflictBranchUpstream, ConflictBranchDestination:
+	default:
+		return fmt.Errorf("conflict workspace theirs branch must be %q or %q", ConflictBranchUpstream, ConflictBranchDestination)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	if _, err := r.run(ctx, dir, "init", "--quiet"); err != nil {
+		return err
+	}
+	for _, kv := range [][2]string{
+		{"core.autocrlf", gitFalse},
+		{"core.eol", "lf"},
+		{"core.safecrlf", gitFalse},
+		{"core.symlinks", gitFalse},
+		{"merge.conflictStyle", "diff3"},
+		{"merge.renames", gitFalse},
+		{"diff.renames", gitFalse},
+		{"user.name", "Agent Layer"},
+		{"user.email", "agent-layer@invalid"},
+	} {
+		if _, err := r.run(ctx, dir, "config", kv[0], kv[1]); err != nil {
+			return err
+		}
+	}
+	infoDir := filepath.Join(dir, ".git", "info")
+	if err := os.MkdirAll(infoDir, 0o750); err != nil {
+		return fmt.Errorf("failed to create conflict workspace attributes directory: %w", err)
+	}
+	// info/attributes outranks in-tree .gitattributes. Unspecified merge/diff/eol
+	// keep Git's defaults so a skill cannot select a globally configured custom
+	// driver; -text/-ident/-filter still disable conversion and ident expansion.
+	attributes := []byte("* -text -ident -filter !eol !merge !diff\n")
+	if err := os.WriteFile(filepath.Join(infoDir, "attributes"), attributes, 0o600); err != nil {
+		return fmt.Errorf("failed to write conflict workspace attributes: %w", err)
+	}
+
+	baseTree, err := r.writeSkillTree(ctx, dir, spec.Base)
+	if err != nil {
+		return err
+	}
+	baseCommit, err := r.commitTree(ctx, dir, baseTree, ConflictBranchBase)
+	if err != nil {
+		return err
+	}
+	localTree, err := r.writeSkillTree(ctx, dir, spec.Local)
+	if err != nil {
+		return err
+	}
+	localCommit, err := r.commitTree(ctx, dir, localTree, ConflictBranchLocal, baseCommit)
+	if err != nil {
+		return err
+	}
+	theirsTree, err := r.writeSkillTree(ctx, dir, spec.Theirs)
+	if err != nil {
+		return err
+	}
+	theirsCommit, err := r.commitTree(ctx, dir, theirsTree, spec.TheirsBranch, baseCommit)
+	if err != nil {
+		return err
+	}
+
+	for _, ref := range [][2]string{
+		{"refs/heads/" + ConflictBranchBase, baseCommit},
+		{"refs/heads/" + ConflictBranchLocal, localCommit},
+		{"refs/heads/" + spec.TheirsBranch, theirsCommit},
+	} {
+		if _, err := r.run(ctx, dir, "update-ref", ref[0], ref[1]); err != nil {
+			return err
+		}
+	}
+	if _, err := r.run(ctx, dir, "symbolic-ref", "HEAD", "refs/heads/"+ConflictBranchLocal); err != nil {
+		return err
+	}
+	if _, err := r.run(ctx, dir, "read-tree", "--reset", "-u", "HEAD"); err != nil {
+		return err
+	}
+	// merge.renames=false and -X no-renames disable rename detection. Some Git
+	// builds (including Apple Git) reject git merge --no-renames.
+	_, _, err = r.runAllowExit(ctx, dir, []int{1},
+		"merge", "--no-commit", "--no-ff", "-X", "no-renames", spec.TheirsBranch)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ConflictIndexReady reports whether the workspace index is a fully staged
+// resolution. Unmerged paths and unstaged tracked changes are refused;
+// untracked files are ignored.
+func (r *Runner) ConflictIndexReady(ctx context.Context, dir string) error {
+	unmerged, err := r.run(ctx, dir, "ls-files", "-u", "-z")
+	if err != nil {
+		return err
+	}
+	if len(bytes.Trim(unmerged, "\x00 \t\n\r")) > 0 {
+		return fmt.Errorf("conflict workspace still has unmerged git entries; finish the merge and git add the result")
+	}
+	if _, _, err := r.runAllowExit(ctx, dir, []int{1}, "update-index", "--refresh"); err != nil {
+		return err
+	}
+	_, code, err := r.runAllowExit(ctx, dir, []int{1}, "diff-files", "--quiet")
+	if err != nil {
+		return err
+	}
+	if code == 1 {
+		return fmt.Errorf("conflict workspace has unstaged tracked changes; git add the resolved files")
+	}
+	return nil
+}
+
+// ReadConflictIndex returns the staged skill tree. The working tree is not
+// read, so untracked mergetool files cannot enter the result.
+func (r *Runner) ReadConflictIndex(ctx context.Context, dir string) (skilltree.Tree, error) {
+	if err := r.ConflictIndexReady(ctx, dir); err != nil {
+		return skilltree.Tree{}, err
+	}
+	treeID, err := r.run(ctx, dir, "write-tree")
+	if err != nil {
+		return skilltree.Tree{}, err
+	}
+	return r.readSkillTreeObject(ctx, dir, strings.TrimSpace(string(treeID)))
+}
+
+func (r *Runner) commitTree(ctx context.Context, dir string, tree string, message string, parents ...string) (string, error) {
+	args := make([]string, 0, 6+2*len(parents))
+	args = append(args, "-c", "commit.gpgSign=false", "commit-tree", tree)
+	for _, parent := range parents {
+		args = append(args, "-p", parent)
+	}
+	args = append(args, "-m", message)
+	output, err := r.runEnv(ctx, dir, syntheticIdentity, args...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/internal/gitrepo/workspace.go
+++ b/internal/gitrepo/workspace.go
@@ -135,8 +135,15 @@ func (r *Runner) CreateConflictWorkspace(ctx context.Context, dir string, spec C
 
 // ConflictIndexReady reports whether the workspace index is a fully staged
 // resolution. Unmerged paths and unstaged tracked changes are refused;
-// untracked files are ignored.
+// untracked files are ignored. An aborted or committed merge is refused so
+// resolve cannot treat the pre-merge local tree as an accepted result.
 func (r *Runner) ConflictIndexReady(ctx context.Context, dir string) error {
+	if _, err := os.Stat(filepath.Join(dir, ".git", "MERGE_HEAD")); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("conflict workspace merge is no longer in progress; finish the merge with git add, or recreate the workspace with the original command")
+		}
+		return err
+	}
 	unmerged, err := r.run(ctx, dir, "ls-files", "-u", "-z")
 	if err != nil {
 		return err

--- a/internal/gitrepo/workspace_test.go
+++ b/internal/gitrepo/workspace_test.go
@@ -90,6 +90,35 @@ func TestCreateConflictWorkspaceMaterializesGitMerge(t *testing.T) {
 	}
 }
 
+func TestConflictIndexReadyRejectsAnAbortedMerge(t *testing.T) {
+	runner, err := NewRunner(nil)
+	if err != nil {
+		t.Skipf("git runner unavailable: %v", err)
+	}
+	dir := filepath.Join(t.TempDir(), "workspace")
+	base := testSkillTree(t, []skilltree.File{
+		{Path: "SKILL.md", Data: []byte("---\nname: alpha\ndescription: d\n---\nBody\n")},
+		{Path: "notes.md", Data: []byte("shared\n")},
+	})
+	local := testSkillTree(t, []skilltree.File{
+		{Path: "SKILL.md", Data: []byte("---\nname: alpha\ndescription: d\n---\nBody\n")},
+		{Path: "notes.md", Data: []byte("local\n")},
+	})
+	upstream := testSkillTree(t, []skilltree.File{
+		{Path: "SKILL.md", Data: []byte("---\nname: alpha\ndescription: d\n---\nBody\n")},
+		{Path: "notes.md", Data: []byte("upstream\n")},
+	})
+	if err := runner.CreateConflictWorkspace(context.Background(), dir, ConflictWorkspaceSpec{
+		Base: base, Local: local, Theirs: upstream, TheirsBranch: ConflictBranchUpstream,
+	}); err != nil {
+		t.Fatalf("CreateConflictWorkspace: %v", err)
+	}
+	gitOutput(t, dir, "merge", "--abort")
+	if err := runner.ConflictIndexReady(context.Background(), dir); err == nil || !strings.Contains(err.Error(), "no longer in progress") {
+		t.Fatalf("aborted merge ready = %v", err)
+	}
+}
+
 func TestCreateConflictWorkspaceRejectsUnknownOtherBranch(t *testing.T) {
 	runner, err := NewRunner(nil)
 	if err != nil {

--- a/internal/gitrepo/workspace_test.go
+++ b/internal/gitrepo/workspace_test.go
@@ -1,0 +1,272 @@
+package gitrepo
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/conn-castle/agent-layer/internal/gitenv"
+	"github.com/conn-castle/agent-layer/internal/skilltree"
+)
+
+func TestCreateConflictWorkspaceMaterializesGitMerge(t *testing.T) {
+	runner, err := NewRunner(nil)
+	if err != nil {
+		t.Skipf("git runner unavailable: %v", err)
+	}
+	dir := filepath.Join(t.TempDir(), "workspace")
+	base := testSkillTree(t, []skilltree.File{
+		{Path: "SKILL.md", Data: []byte("---\nname: alpha\ndescription: d\n---\nBody\n")},
+		{Path: "notes.md", Data: []byte("shared\n")},
+	})
+	local := testSkillTree(t, []skilltree.File{
+		{Path: "SKILL.md", Data: []byte("---\nname: alpha\ndescription: d\n---\nBody\n")},
+		{Path: "notes.md", Data: []byte("local\n")},
+	})
+	upstream := testSkillTree(t, []skilltree.File{
+		{Path: "SKILL.md", Data: []byte("---\nname: alpha\ndescription: d\n---\nBody\n")},
+		{Path: "notes.md", Data: []byte("upstream\n")},
+	})
+	if err := runner.CreateConflictWorkspace(context.Background(), dir, ConflictWorkspaceSpec{
+		Base: base, Local: local, Theirs: upstream, TheirsBranch: ConflictBranchUpstream,
+	}); err != nil {
+		t.Fatalf("CreateConflictWorkspace: %v", err)
+	}
+
+	head := gitOutput(t, dir, "rev-parse", "--abbrev-ref", "HEAD")
+	if head != ConflictBranchLocal {
+		t.Fatalf("HEAD = %q, want local", head)
+	}
+	for _, branch := range []string{ConflictBranchBase, ConflictBranchLocal, ConflictBranchUpstream} {
+		if gitOutput(t, dir, "rev-parse", "--verify", branch) == "" {
+			t.Fatalf("missing branch %s", branch)
+		}
+	}
+	marked, err := os.ReadFile(filepath.Join(dir, "notes.md")) // #nosec G304 -- test-owned temp path.
+	if err != nil || !strings.Contains(string(marked), "<<<<<<<") || !strings.Contains(string(marked), "|||||||") {
+		t.Fatalf("conflicted file = %q, err %v", marked, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git", "info", "attributes")); err != nil {
+		t.Fatalf("missing attributes: %v", err)
+	}
+	if err := runner.ConflictIndexReady(context.Background(), dir); err == nil || !strings.Contains(err.Error(), "unmerged") {
+		t.Fatalf("ConflictIndexReady = %v", err)
+	}
+	if _, err := runner.ReadConflictIndex(context.Background(), dir); err == nil || !strings.Contains(err.Error(), "unmerged") {
+		t.Fatalf("ReadConflictIndex before resolution = %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "notes.md"), []byte("resolved\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "notes.md.orig"), []byte("junk\n"), 0o600); err != nil {
+		t.Fatalf("write untracked: %v", err)
+	}
+	if err := runner.ConflictIndexReady(context.Background(), dir); err == nil || !strings.Contains(err.Error(), "unmerged") {
+		t.Fatalf("edited unmerged index = %v", err)
+	}
+	gitOutput(t, dir, "add", "--", "notes.md")
+	if err := os.WriteFile(filepath.Join(dir, "notes.md"), []byte("unstaged\n"), 0o600); err != nil {
+		t.Fatalf("write unstaged resolution: %v", err)
+	}
+	if err := runner.ConflictIndexReady(context.Background(), dir); err == nil || !strings.Contains(err.Error(), "unstaged") {
+		t.Fatalf("ConflictIndexReady with unstaged edit = %v", err)
+	}
+	gitOutput(t, dir, "checkout", "--", "notes.md")
+	tree, err := runner.ReadConflictIndex(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("ReadConflictIndex: %v", err)
+	}
+	file, ok := tree.File("notes.md")
+	if !ok || string(file.Data) != "resolved\n" {
+		t.Fatalf("resolved notes = %v, %q", ok, file.Data)
+	}
+	if _, ok := tree.File("notes.md.orig"); ok {
+		t.Fatal("untracked mergetool file entered the staged tree")
+	}
+}
+
+func TestCreateConflictWorkspaceRejectsUnknownOtherBranch(t *testing.T) {
+	runner, err := NewRunner(nil)
+	if err != nil {
+		t.Skipf("git runner unavailable: %v", err)
+	}
+	err = runner.CreateConflictWorkspace(context.Background(), filepath.Join(t.TempDir(), "workspace"), ConflictWorkspaceSpec{
+		TheirsBranch: "other",
+	})
+	if err == nil || !strings.Contains(err.Error(), "theirs branch") {
+		t.Fatalf("CreateConflictWorkspace unknown branch = %v", err)
+	}
+}
+
+func TestReadConflictIndexRejectsAStagedSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink fixture requires Unix semantics")
+	}
+	runner, err := NewRunner(nil)
+	if err != nil {
+		t.Skipf("git runner unavailable: %v", err)
+	}
+	dir := filepath.Join(t.TempDir(), "workspace")
+	manifest := testSkillTree(t, []skilltree.File{
+		{Path: "SKILL.md", Data: []byte("---\nname: alpha\ndescription: d\n---\nBody\n")},
+		{Path: "tool.sh", Data: []byte("#!/bin/sh\n"), Executable: true},
+	})
+	if err := runner.CreateConflictWorkspace(context.Background(), dir, ConflictWorkspaceSpec{
+		Base: manifest, Local: manifest, Theirs: manifest, TheirsBranch: ConflictBranchUpstream,
+	}); err != nil {
+		t.Fatalf("CreateConflictWorkspace: %v", err)
+	}
+	if err := os.Symlink("SKILL.md", filepath.Join(dir, "link.md")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	gitOutput(t, dir, "add", "--", "link.md")
+	if _, err := runner.ReadConflictIndex(context.Background(), dir); err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("ReadConflictIndex symlink = %v", err)
+	}
+	gitOutput(t, dir, "rm", "--cached", "--", "link.md")
+	if err := os.Remove(filepath.Join(dir, "link.md")); err != nil {
+		t.Fatalf("remove symlink: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".DS_Store"), []byte("ignored\n"), 0o600); err != nil {
+		t.Fatalf("write ignored file: %v", err)
+	}
+	gitOutput(t, dir, "add", "--", ".DS_Store")
+	tree, err := runner.ReadConflictIndex(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("ReadConflictIndex regular tree: %v", err)
+	}
+	tool, ok := tree.File("tool.sh")
+	if !ok || !tool.Executable {
+		t.Fatalf("executable file = %+v, present %v", tool, ok)
+	}
+	if _, ok := tree.File(".DS_Store"); ok {
+		t.Fatal("ignored artifact entered resolved tree")
+	}
+	head := gitOutput(t, dir, "rev-parse", "HEAD")
+	gitOutput(t, dir, "update-index", "--add", "--cacheinfo", "160000", head, "nested")
+	gitOutput(t, dir, "update-index", "--skip-worktree", "nested")
+	if _, err := runner.ReadConflictIndex(context.Background(), dir); err == nil || !strings.Contains(err.Error(), "gitlink") {
+		t.Fatalf("ReadConflictIndex gitlink = %v", err)
+	}
+}
+
+func TestGitTreeHelpersSurfaceRepositoryFailures(t *testing.T) {
+	runner, err := NewRunner(nil)
+	if err != nil {
+		t.Skipf("git runner unavailable: %v", err)
+	}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	tree := testSkillTree(t, nil)
+	if _, err := runner.DiffTrees(canceled, "local", tree, "upstream", tree); err == nil {
+		t.Fatal("DiffTrees with canceled context succeeded")
+	}
+	dir := t.TempDir()
+	if _, err := runner.writeSkillTree(context.Background(), dir, tree); err == nil {
+		t.Fatal("writeSkillTree outside a repository succeeded")
+	}
+	if _, err := runner.readSkillTreeObject(context.Background(), dir, "missing"); err == nil {
+		t.Fatal("readSkillTreeObject outside a repository succeeded")
+	}
+	if err := runner.CreateConflictWorkspace(canceled, filepath.Join(t.TempDir(), "workspace"), ConflictWorkspaceSpec{
+		TheirsBranch: ConflictBranchUpstream,
+	}); err == nil {
+		t.Fatal("CreateConflictWorkspace with canceled context succeeded")
+	}
+	if err := runner.ConflictIndexReady(context.Background(), dir); err == nil {
+		t.Fatal("ConflictIndexReady outside a repository succeeded")
+	}
+	if _, err := runner.ReadConflictIndex(context.Background(), dir); err == nil {
+		t.Fatal("ReadConflictIndex outside a repository succeeded")
+	}
+}
+
+func TestCreateConflictWorkspaceIgnoresInTreeMergeDriver(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "driver-ran")
+	driver := filepath.Join(t.TempDir(), "failing-merge.sh")
+	script := "#!/bin/sh\necho ran >\"$AL_MERGE_DRIVER_MARKER\"\nexit 1\n"
+	if err := os.WriteFile(driver, []byte(script), 0o700); err != nil { // #nosec G306 -- executable test stub requires owner execute permission.
+		t.Fatalf("write driver: %v", err)
+	}
+	t.Setenv("AL_MERGE_DRIVER_MARKER", marker)
+	t.Setenv("GIT_CONFIG_COUNT", "2")
+	t.Setenv("GIT_CONFIG_KEY_0", "merge.failing.driver")
+	t.Setenv("GIT_CONFIG_VALUE_0", driver+" %O %A %B")
+	t.Setenv("GIT_CONFIG_KEY_1", "merge.failing.required")
+	t.Setenv("GIT_CONFIG_VALUE_1", "true")
+
+	runner, err := NewRunner(nil)
+	if err != nil {
+		t.Skipf("git runner unavailable: %v", err)
+	}
+	attrs := skilltree.File{Path: ".gitattributes", Data: []byte("notes.md merge=failing\n")}
+	manifest := skilltree.File{Path: "SKILL.md", Data: []byte("---\nname: alpha\ndescription: d\n---\nBody\n")}
+	dir := filepath.Join(t.TempDir(), "workspace")
+	base := testSkillTree(t, []skilltree.File{manifest, attrs, {Path: "notes.md", Data: []byte("shared\n")}})
+	local := testSkillTree(t, []skilltree.File{manifest, attrs, {Path: "notes.md", Data: []byte("local\n")}})
+	upstream := testSkillTree(t, []skilltree.File{manifest, attrs, {Path: "notes.md", Data: []byte("upstream\n")}})
+	if err := runner.CreateConflictWorkspace(context.Background(), dir, ConflictWorkspaceSpec{
+		Base: base, Local: local, Theirs: upstream, TheirsBranch: ConflictBranchUpstream,
+	}); err != nil {
+		t.Fatalf("CreateConflictWorkspace: %v", err)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("in-tree merge driver ran during the workspace merge")
+	}
+	got := gitOutput(t, dir, "check-attr", "merge", "--", "notes.md")
+	if strings.Contains(got, "merge: failing") {
+		t.Fatalf("custom merge driver still selected: %q", got)
+	}
+	marked, err := os.ReadFile(filepath.Join(dir, "notes.md")) // #nosec G304 -- test-owned temp path.
+	if err != nil || !strings.Contains(string(marked), "<<<<<<<") {
+		t.Fatalf("expected a default text merge, got %q, err %v", marked, err)
+	}
+}
+
+func TestCreateConflictWorkspaceCoversDeleteModify(t *testing.T) {
+	runner, err := NewRunner(nil)
+	if err != nil {
+		t.Skipf("git runner unavailable: %v", err)
+	}
+	dir := filepath.Join(t.TempDir(), "workspace")
+	base := testSkillTree(t, []skilltree.File{
+		{Path: "SKILL.md", Data: []byte("base\n")},
+		{Path: "gone.md", Data: []byte("x\n")},
+	})
+	local := testSkillTree(t, []skilltree.File{
+		{Path: "SKILL.md", Data: []byte("base\n")},
+	})
+	theirs := testSkillTree(t, []skilltree.File{
+		{Path: "SKILL.md", Data: []byte("base\n")},
+		{Path: "gone.md", Data: []byte("changed\n")},
+	})
+	if err := runner.CreateConflictWorkspace(context.Background(), dir, ConflictWorkspaceSpec{
+		Base: base, Local: local, Theirs: theirs, TheirsBranch: ConflictBranchDestination,
+	}); err != nil {
+		t.Fatalf("CreateConflictWorkspace: %v", err)
+	}
+	if err := runner.ConflictIndexReady(context.Background(), dir); err == nil || !strings.Contains(err.Error(), "unmerged") {
+		t.Fatalf("delete/modify workspace ready = %v", err)
+	}
+	unmerged := gitOutput(t, dir, "ls-files", "-u")
+	if !strings.Contains(unmerged, "gone.md") {
+		t.Fatalf("unmerged entries = %q", unmerged)
+	}
+}
+
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...) // #nosec G204 -- test-controlled arguments.
+	cmd.Dir = dir
+	cmd.Env = gitenv.WithoutDiscovery()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
+}

--- a/internal/messages/cli.go
+++ b/internal/messages/cli.go
@@ -310,9 +310,10 @@ Imported skills live in .agent-layer/skills-imported/<skill-name>/ and are
 projected through ordinary 'al sync' alongside .agent-layer/skills/. Recorded
 upstream state lives in .agent-layer/skills.lock.json.
 
-Add, pull, reset, and push contact remote repositories. Remove also contacts a
-remote when its block retains a positive selector; removing the last positive
-selector stays local. Status, 'al sync', and agent launch stay local.`
+Add, pull, reset, push, and diff (when a requested side is remote) contact
+remote repositories. Remove also contacts a remote when its block retains a
+positive selector; removing the last positive selector stays local. Status,
+resolve, 'al sync', and agent launch stay local.`
 
 	SkillsAddUse   = "add <repository> <selector>..."
 	SkillsAddShort = "Import skills from a Git repository"
@@ -344,7 +345,26 @@ before changing project configuration; pass --yes for non-interactive use.`
 network or Git fetch.
 
 Use --all to expand the summary into one entry per resolved skill plus the
-configured exclusion selectors.`
+configured exclusion selectors. A skill with an active matching conflict
+workspace is reported as conflicted; --all includes that workspace path.`
+
+	SkillsDiffUse   = "diff <name>"
+	SkillsDiffShort = "Show a Git diff between two live skill sides"
+	SkillsDiffLong  = `Compare two live sides of one imported skill and print an ordinary Git unified
+diff.
+
+Supported sides are base (the locked source tree), local (the live imported
+tree), upstream (the current configured source target), and destination (the
+current configured push destination tree). Defaults are local to upstream.
+Fetch runs only for sides that require it. Identical trees produce no output.
+For a pinned import, upstream is the current ref tip even though ordinary pull
+does not follow that tip until the configured ref changes.
+
+The destination side requires a writable import whose configured branch exists.
+An absent skill path on that branch is treated as an empty tree.`
+
+	SkillsDiffFromFlag = "Source side: base, local, upstream, or destination (default: local)"
+	SkillsDiffToFlag   = "Destination side: base, local, upstream, or destination (default: upstream)"
 
 	SkillsPullUse   = "pull"
 	SkillsPullShort = "Fetch and reconcile configured skill sources"
@@ -353,10 +373,29 @@ state, and project the results.
 
 This is the only command that advances tracked imports. Pinned imports stay at
 their locked commits unless the configured ref itself changed. Local edits are
-merged against the locked upstream tree and are never overwritten; a conflict
-fails only that skill.
+merged against the locked upstream tree and are never overwritten. A conflict
+leaves a Git workspace under .agent-layer/tmp/skill-conflicts/<name>/ for
+'al skills resolve'; it fails only that skill.
 
 'al skills pull' never commits or pushes upstream.`
+
+	SkillsResolveUse   = "resolve <name>"
+	SkillsResolveShort = "Finish a conflicted skill pull or push"
+	SkillsResolveLong  = `Apply the staged Git index of a conflict workspace left by a conflicted
+'al skills pull' or 'al skills push'.
+
+Resolve the merge with ordinary git commands in the workspace path printed by
+the failed operation, git add the result, then run this command with the exact
+skill name. Resolve uses the staged index only: unmerged or unstaged tracked
+changes are refused, and untracked mergetool files are ignored. It validates
+the tree and that recorded lock and configuration still match.
+
+A pull resolution applies the staged tree and advances the recorded upstream
+lock. A push resolution applies the staged tree locally and records the
+destination head that was reconciled as the publication checkpoint without
+moving the source lock; rerun 'al skills push' afterwards. Successful resolve
+removes the workspace and projects the imported skill. It does not fetch,
+prompt, commit, or push.`
 
 	SkillsResetUse   = "reset <name>"
 	SkillsResetShort = "Discard one imported skill's local edits"
@@ -378,8 +417,10 @@ destination.
 Blocks with write_policy = "none" (the default) are skipped. Changes for one
 destination repository and branch are committed and pushed together. Agent
 Layer never force-pushes, never generates a branch name, and never falls back
-to another destination or mode. The command prompts before publishing; pass
---yes for non-interactive use.
+to another destination or mode. A destination merge conflict leaves the same
+kind of Git workspace as pull; finish it with 'al skills resolve' and rerun
+push. The command prompts before publishing; pass --yes for non-interactive
+use.
 
 'al skills push' never pulls first.`
 

--- a/internal/messages/cli.go
+++ b/internal/messages/cli.go
@@ -363,8 +363,8 @@ does not follow that tip until the configured ref changes.
 The destination side requires a writable import whose configured branch exists.
 An absent skill path on that branch is treated as an empty tree.`
 
-	SkillsDiffFromFlag = "Source side: base, local, upstream, or destination (default: local)"
-	SkillsDiffToFlag   = "Destination side: base, local, upstream, or destination (default: upstream)"
+	SkillsDiffFromFlag = "Source side: base, local, upstream, or destination"
+	SkillsDiffToFlag   = "Destination side: base, local, upstream, or destination"
 
 	SkillsPullUse   = "pull"
 	SkillsPullShort = "Fetch and reconcile configured skill sources"

--- a/internal/skillimport/conflict.go
+++ b/internal/skillimport/conflict.go
@@ -21,14 +21,15 @@ const (
 )
 
 type conflictState struct {
-	Kind                  string          `json:"kind"`
-	Lock                  skilllock.Entry `json:"lock"`
-	LocalTreeHash         string          `json:"local_tree_hash"`
-	Next                  skilllock.Entry `json:"next"`
-	DestinationRepository string          `json:"destination_repository,omitempty"`
-	DestinationBranch     string          `json:"destination_branch,omitempty"`
-	DestinationHead       string          `json:"destination_head,omitempty"`
-	DestinationTreeHash   string          `json:"destination_tree_hash,omitempty"`
+	Kind                   string          `json:"kind"`
+	Lock                   skilllock.Entry `json:"lock"`
+	LocalTreeHash          string          `json:"local_tree_hash"`
+	Next                   skilllock.Entry `json:"next"`
+	DestinationRepository  string          `json:"destination_repository,omitempty"`
+	DestinationBranch      string          `json:"destination_branch,omitempty"`
+	DestinationHead        string          `json:"destination_head,omitempty"`
+	DestinationTreeHash    string          `json:"destination_tree_hash,omitempty"`
+	DestinationWritePolicy string          `json:"destination_write_policy,omitempty"`
 }
 
 // Resolve applies the staged Git index of a skill conflict workspace.
@@ -126,18 +127,24 @@ func writePullConflictWorkspace(ctx context.Context, runner *gitrepo.Runner, st 
 }
 
 func writePushConflictWorkspace(ctx context.Context, runner *gitrepo.Runner, st *state, name string, local, baseTree, destination skilltree.Tree, lock skilllock.Entry, group *pushGroup, head string) (string, error) {
+	block, _, configured := st.configuredBlockForEntry(lock)
+	writePolicy := ""
+	if configured {
+		writePolicy = block.EffectiveWritePolicy()
+	}
 	return writeConflictWorkspace(ctx, runner, st, name, gitrepo.ConflictWorkspaceSpec{
 		Base:         baseTree,
 		Local:        local,
 		Theirs:       destination,
 		TheirsBranch: gitrepo.ConflictBranchDestination,
 	}, conflictState{
-		Kind:                  conflictKindPush,
-		Lock:                  lock,
-		DestinationRepository: group.Repository.String(),
-		DestinationBranch:     group.Branch,
-		DestinationHead:       head,
-		DestinationTreeHash:   destination.Hash(),
+		Kind:                   conflictKindPush,
+		Lock:                   lock,
+		DestinationRepository:  group.Repository.String(),
+		DestinationBranch:      group.Branch,
+		DestinationHead:        head,
+		DestinationTreeHash:    destination.Hash(),
+		DestinationWritePolicy: writePolicy,
 	})
 }
 
@@ -154,6 +161,7 @@ func writeConflictWorkspace(ctx context.Context, runner *gitrepo.Runner, st *sta
 		if conflictMatches(st, state.Lock, existing) {
 			return "", fmt.Errorf("active %s conflict workspace %s already exists; finish it with git and run 'al skills resolve %s'", existing.Kind, relativeTo(st.paths.Root, dir), name)
 		}
+		return "", fmt.Errorf("existing conflict workspace %s is stale; move or remove it before retrying", relativeTo(st.paths.Root, dir))
 	} else if !os.IsNotExist(statErr) {
 		return "", fmt.Errorf("inspect conflict workspace %s: %w", relativeTo(st.paths.Root, dir), statErr)
 	}
@@ -245,7 +253,10 @@ func conflictMatches(st *state, entry skilllock.Entry, state conflictState) bool
 		if config.NormalizeSkillRepository(block.EffectivePushRepository()) != state.DestinationRepository {
 			return false
 		}
-		if block.EffectiveWritePolicy() == config.SkillWritePolicyBranch {
+		if block.EffectiveWritePolicy() != state.DestinationWritePolicy {
+			return false
+		}
+		if state.DestinationWritePolicy == config.SkillWritePolicyBranch {
 			return strings.TrimSpace(block.PushBranch) == state.DestinationBranch
 		}
 		// Direct writes follow the live default branch, which cannot be rechecked
@@ -284,9 +295,23 @@ func pullNextMatchesConfig(st *state, entry skilllock.Entry, next skilllock.Entr
 	if block.Ref != next.ConfiguredRef {
 		return false
 	}
-	if tracking := strings.TrimSpace(block.Tracking); tracking != "" && tracking != next.Tracking {
+	if configuredTracking(block, next.RefKind) != next.Tracking {
 		return false
 	}
 	_, selected := selectingPositiveSelector(block, next.SelectedPath)
 	return selected
+}
+
+// configuredTracking is the tracking mode resolve must compare against the
+// recorded lock. An omitted config value is derived from the recorded ref kind
+// the same way the first networked pull would: branches track, tags and
+// commits pin.
+func configuredTracking(block config.SkillImport, recordedRefKind string) string {
+	if tracking := strings.TrimSpace(block.Tracking); tracking != "" {
+		return tracking
+	}
+	if recordedRefKind == skilllock.RefKindBranch {
+		return config.SkillTrackingTracked
+	}
+	return config.SkillTrackingPinned
 }

--- a/internal/skillimport/conflict.go
+++ b/internal/skillimport/conflict.go
@@ -1,0 +1,292 @@
+package skillimport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/conn-castle/agent-layer/internal/config"
+	"github.com/conn-castle/agent-layer/internal/gitrepo"
+	"github.com/conn-castle/agent-layer/internal/skilllock"
+	"github.com/conn-castle/agent-layer/internal/skilltree"
+)
+
+const (
+	conflictKindPull = "pull"
+	conflictKindPush = "push"
+	conflictMetaFile = "agent-layer.json"
+)
+
+type conflictState struct {
+	Kind                  string          `json:"kind"`
+	Lock                  skilllock.Entry `json:"lock"`
+	LocalTreeHash         string          `json:"local_tree_hash"`
+	Next                  skilllock.Entry `json:"next"`
+	DestinationRepository string          `json:"destination_repository,omitempty"`
+	DestinationBranch     string          `json:"destination_branch,omitempty"`
+	DestinationHead       string          `json:"destination_head,omitempty"`
+	DestinationTreeHash   string          `json:"destination_tree_hash,omitempty"`
+}
+
+// Resolve applies the staged Git index of a skill conflict workspace.
+func (s *Service) Resolve(ctx context.Context, name string) (*Report, error) {
+	report := &Report{}
+	err := s.withLockedState(func(st *state) error {
+		if err := failOnOrphans(st); err != nil {
+			return err
+		}
+		entry, ok := st.lock.Entry(name)
+		if !ok {
+			return fmt.Errorf("imported skill %q has no lock entry", name)
+		}
+		state, workspace, err := readConflictMetadata(st, name)
+		if err != nil {
+			return err
+		}
+		if !conflictMatches(st, entry, state) {
+			return fmt.Errorf("conflict workspace for %q is stale; run the original %s again", name, conflictRetryCommand(state.Kind))
+		}
+
+		runner, err := s.newRunner(st.env)
+		if err != nil {
+			return err
+		}
+		tree, err := runner.ReadConflictIndex(ctx, workspace)
+		if err != nil {
+			return err
+		}
+		if _, err := skilltree.ValidateSkill(tree, entry.SelectedPath); err != nil {
+			return fmt.Errorf("resolved tree is not a valid skill: %w", err)
+		}
+
+		txn := newTransaction(pathSetFor(st), st.lock)
+		txn.WriteSkill(name, tree)
+		next := entry
+		detail := ""
+		switch state.Kind {
+		case conflictKindPull:
+			next = preservePublication(state.Next, entry)
+		case conflictKindPush:
+			next.Publication = &skilllock.Publication{
+				Repository: state.DestinationRepository,
+				Branch:     state.DestinationBranch,
+				Commit:     state.DestinationHead,
+				TreeHash:   state.DestinationTreeHash,
+			}
+			detail = "rerun 'al skills push'"
+		default:
+			return fmt.Errorf("conflict workspace for %q has unknown kind %q", name, state.Kind)
+		}
+		txn.SetLockEntry(next)
+		if err := txn.Commit(); err != nil {
+			return err
+		}
+		if err := os.RemoveAll(workspace); err != nil {
+			return fmt.Errorf("resolved skill but could not remove conflict workspace: %w", err)
+		}
+		report.Add(SkillResult{
+			Name:         name,
+			Repository:   entry.Repository,
+			SelectedPath: entry.SelectedPath,
+			Outcome:      OutcomeResolved,
+			Detail:       detail,
+		})
+		s.project(report)
+		return nil
+	})
+	report.Sort()
+	return report, err
+}
+
+func conflictRetryCommand(kind string) string {
+	if kind == conflictKindPush {
+		return "'al skills push'"
+	}
+	return "'al skills pull'"
+}
+
+func conflictWorkspace(root, name string) (string, error) {
+	if err := skilltree.ValidateRelativePath(name); err != nil {
+		return "", fmt.Errorf("invalid skill name %q: %w", name, err)
+	}
+	return filepath.Join(root, ".agent-layer", "tmp", "skill-conflicts", name), nil
+}
+
+func writePullConflictWorkspace(ctx context.Context, runner *gitrepo.Runner, st *state, name string, local, baseTree, upstream skilltree.Tree, lock, next skilllock.Entry) (string, error) {
+	next.Publication = nil
+	return writeConflictWorkspace(ctx, runner, st, name, gitrepo.ConflictWorkspaceSpec{
+		Base:         baseTree,
+		Local:        local,
+		Theirs:       upstream,
+		TheirsBranch: gitrepo.ConflictBranchUpstream,
+	}, conflictState{Kind: conflictKindPull, Lock: lock, Next: next})
+}
+
+func writePushConflictWorkspace(ctx context.Context, runner *gitrepo.Runner, st *state, name string, local, baseTree, destination skilltree.Tree, lock skilllock.Entry, group *pushGroup, head string) (string, error) {
+	return writeConflictWorkspace(ctx, runner, st, name, gitrepo.ConflictWorkspaceSpec{
+		Base:         baseTree,
+		Local:        local,
+		Theirs:       destination,
+		TheirsBranch: gitrepo.ConflictBranchDestination,
+	}, conflictState{
+		Kind:                  conflictKindPush,
+		Lock:                  lock,
+		DestinationRepository: group.Repository.String(),
+		DestinationBranch:     group.Branch,
+		DestinationHead:       head,
+		DestinationTreeHash:   destination.Hash(),
+	})
+}
+
+func writeConflictWorkspace(ctx context.Context, runner *gitrepo.Runner, st *state, name string, spec gitrepo.ConflictWorkspaceSpec, state conflictState) (string, error) {
+	dir, err := conflictWorkspace(st.paths.Root, name)
+	if err != nil {
+		return "", err
+	}
+	if _, statErr := os.Stat(dir); statErr == nil {
+		existing, _, readErr := readConflictMetadata(st, name)
+		if readErr != nil {
+			return "", fmt.Errorf("existing conflict workspace %s is unreadable; move or remove it before retrying: %w", relativeTo(st.paths.Root, dir), readErr)
+		}
+		if conflictMatches(st, state.Lock, existing) {
+			return "", fmt.Errorf("active %s conflict workspace %s already exists; finish it with git and run 'al skills resolve %s'", existing.Kind, relativeTo(st.paths.Root, dir), name)
+		}
+	} else if !os.IsNotExist(statErr) {
+		return "", fmt.Errorf("inspect conflict workspace %s: %w", relativeTo(st.paths.Root, dir), statErr)
+	}
+	if err := runner.CreateConflictWorkspace(ctx, dir, spec); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+	state.LocalTreeHash = spec.Local.Hash()
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".git", conflictMetaFile), append(data, '\n'), 0o600); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+	return dir, nil
+}
+
+func validateConflictWorkspaceMetadata(st *state, name string) error {
+	dir, err := conflictWorkspace(st.paths.Root, name)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("inspect conflict workspace %s: %w", relativeTo(st.paths.Root, dir), err)
+	}
+	if _, _, err := readConflictMetadata(st, name); err != nil {
+		return fmt.Errorf("conflict workspace %s is unreadable; move or remove it before retrying: %w", relativeTo(st.paths.Root, dir), err)
+	}
+	return nil
+}
+
+func readConflictMetadata(st *state, name string) (conflictState, string, error) {
+	dir, err := conflictWorkspace(st.paths.Root, name)
+	if err != nil {
+		return conflictState{}, "", err
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".git", conflictMetaFile)) // #nosec G304 -- name is validated above.
+	if err != nil {
+		if os.IsNotExist(err) {
+			return conflictState{}, "", fmt.Errorf("imported skill %q has no conflict workspace; run 'al skills pull' or 'al skills push' first", name)
+		}
+		return conflictState{}, "", err
+	}
+	var state conflictState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return conflictState{}, "", fmt.Errorf("invalid conflict workspace for %q: %w", name, err)
+	}
+	if state.Kind != conflictKindPull && state.Kind != conflictKindPush {
+		return conflictState{}, "", fmt.Errorf("invalid conflict workspace for %q: unknown kind %q", name, state.Kind)
+	}
+	return state, dir, nil
+}
+
+func matchingConflictWorkspace(st *state, entry skilllock.Entry) (string, bool) {
+	state, dir, err := readConflictMetadata(st, entry.Name)
+	if err != nil {
+		return "", false
+	}
+	if !conflictMatches(st, entry, state) {
+		return "", false
+	}
+	return dir, true
+}
+
+func conflictMatches(st *state, entry skilllock.Entry, state conflictState) bool {
+	if !conflictLockMatches(state.Lock, entry, state.Kind) {
+		return false
+	}
+	local := st.skill(entry.Name)
+	if !local.Present || local.Err != nil || local.Tree.Hash() != state.LocalTreeHash {
+		return false
+	}
+	block, _, configured := st.configuredBlockForEntry(entry)
+	if !configured {
+		return false
+	}
+	switch state.Kind {
+	case conflictKindPull:
+		return pullNextMatchesConfig(st, entry, state.Next)
+	case conflictKindPush:
+		if !block.WriteEnabled() {
+			return false
+		}
+		if config.NormalizeSkillRepository(block.EffectivePushRepository()) != state.DestinationRepository {
+			return false
+		}
+		if block.EffectiveWritePolicy() == config.SkillWritePolicyBranch {
+			return strings.TrimSpace(block.PushBranch) == state.DestinationBranch
+		}
+		// Direct writes follow the live default branch, which cannot be rechecked
+		// by this deliberately offline workspace validation.
+		return true
+	default:
+		return false
+	}
+}
+
+func conflictLockMatches(recorded, current skilllock.Entry, kind string) bool {
+	if kind == conflictKindPull {
+		// Publication checkpoints affect only destination-side push merges. A push
+		// completed while a pull conflict is being resolved does not invalidate the
+		// pull workspace's source base or result.
+		recorded.Publication = nil
+		current.Publication = nil
+	}
+	return recorded.Equal(current)
+}
+
+// pullNextMatchesConfig reports whether current configuration still owns the
+// recorded next source selection, so resolve cannot apply an obsolete lock
+// after a ref or selector edit.
+func pullNextMatchesConfig(st *state, entry skilllock.Entry, next skilllock.Entry) bool {
+	if next.Name != entry.Name || next.SelectedPath != entry.SelectedPath {
+		return false
+	}
+	block, _, configured := st.configuredBlockForEntry(next)
+	if !configured {
+		return false
+	}
+	if config.NormalizeSkillRepository(block.Repository) != next.Repository {
+		return false
+	}
+	if block.Ref != next.ConfiguredRef {
+		return false
+	}
+	if tracking := strings.TrimSpace(block.Tracking); tracking != "" && tracking != next.Tracking {
+		return false
+	}
+	_, selected := selectingPositiveSelector(block, next.SelectedPath)
+	return selected
+}

--- a/internal/skillimport/conflict_test.go
+++ b/internal/skillimport/conflict_test.go
@@ -1,0 +1,460 @@
+package skillimport
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/conn-castle/agent-layer/internal/skilllock"
+)
+
+func TestPullConflictWorkspaceCoversBinaryAndDeleteModify(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/data.bin", string([]byte{0, 1, 2}), 0o644)
+	source.WriteFile("skills/alpha/gone.md", "keep\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+
+	proj.WriteImportedFile("alpha", "data.bin", string([]byte{0, 1, 9}))
+	if err := os.Remove(filepath.Join(proj.paths.ImportedSkillsDir, "alpha", "gone.md")); err != nil {
+		t.Fatalf("delete local gone.md: %v", err)
+	}
+	source.WriteFile("skills/alpha/data.bin", string([]byte{0, 3, 4}), 0o644)
+	source.WriteFile("skills/alpha/gone.md", "changed\n", 0o644)
+	source.Commit("conflict")
+
+	report, err := proj.Service().Pull(context.Background())
+	if err != nil {
+		t.Fatalf("conflicted pull: %v", err)
+	}
+	failed := requireOutcome(t, report, "alpha", OutcomeFailed)
+	if !strings.Contains(failed.Err.Error(), "al skills resolve alpha") {
+		t.Fatalf("conflict error is not actionable: %v", failed.Err)
+	}
+	workspace, err := conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	unmerged := runGit(t, workspace, "ls-files", "-u")
+	for _, path := range []string{"data.bin", "gone.md"} {
+		if !strings.Contains(unmerged, path) {
+			t.Fatalf("unmerged entries %q do not include %s", unmerged, path)
+		}
+	}
+	if _, err := proj.Service().Resolve(context.Background(), "alpha"); err == nil || !strings.Contains(err.Error(), "unmerged") {
+		t.Fatalf("Resolve before finishing merge = %v", err)
+	}
+}
+
+func TestResolveIgnoresUntrackedFilesAndRejectsStaleWorkspaces(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "shared\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	proj.WriteImportedFile("alpha", "notes.md", "local\n")
+	source.WriteFile("skills/alpha/notes.md", "upstream\n", 0o644)
+	source.Commit("conflict")
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("conflicted pull: %v", err)
+	}
+	workspace, err := conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	writeProjectFile(t, filepath.Join(workspace, "notes.md"), "resolved\n")
+	writeProjectFile(t, filepath.Join(workspace, "notes.md.orig"), "junk\n")
+	runGit(t, workspace, "add", "--", "notes.md")
+
+	report, err := proj.Service().Resolve(context.Background(), "alpha")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	requireOutcome(t, report, "alpha", OutcomeResolved)
+	if _, err := os.Stat(filepath.Join(proj.paths.ImportedSkillsDir, "alpha", "notes.md.orig")); !os.IsNotExist(err) {
+		t.Fatal("untracked mergetool file was imported")
+	}
+
+	proj.WriteImportedFile("alpha", "notes.md", "local-again\n")
+	source.WriteFile("skills/alpha/notes.md", "upstream-again\n", 0o644)
+	source.Commit("conflict again")
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("second conflicted pull: %v", err)
+	}
+	workspace, err = conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("second workspace: %v", err)
+	}
+	writeProjectFile(t, filepath.Join(workspace, "notes.md"), "second\n")
+	runGit(t, workspace, "add", "--", "notes.md")
+
+	proj.WriteImportedFile("alpha", "notes.md", "upstream-again\n")
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("alignment pull: %v", err)
+	}
+	if _, err := proj.Service().Resolve(context.Background(), "alpha"); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("stale workspace error = %v", err)
+	}
+}
+
+func TestResolveRejectsPullWorkspaceAfterConfigRefChange(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "shared\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	proj.WriteImportedFile("alpha", "notes.md", "local\n")
+	source.WriteFile("skills/alpha/notes.md", "upstream\n", 0o644)
+	source.Commit("conflict")
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("conflicted pull: %v", err)
+	}
+	workspace, err := conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	writeProjectFile(t, filepath.Join(workspace, "notes.md"), "resolved\n")
+	runGit(t, workspace, "add", "--", "notes.md")
+
+	proj.ReplaceInConfig(`selectors = ["skills/alpha"]`, "selectors = [\"skills/alpha\"]\nref = \"other\"")
+	if _, err := proj.Service().Resolve(context.Background(), "alpha"); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("config-changed workspace error = %v", err)
+	}
+	status, err := proj.Service().Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if len(status.Entries) != 1 || status.Entries[0].Condition == ConditionConflicted {
+		t.Fatalf("status after config change = %+v", status.Entries)
+	}
+}
+
+func TestStatusReportsMatchingConflictWorkspace(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "shared\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	proj.WriteImportedFile("alpha", "notes.md", "local\n")
+	source.WriteFile("skills/alpha/notes.md", "upstream\n", 0o644)
+	source.Commit("conflict")
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("conflicted pull: %v", err)
+	}
+
+	status, err := proj.Service().Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if len(status.Entries) != 1 || status.Entries[0].Condition != ConditionConflicted {
+		t.Fatalf("entries = %+v, want one conflicted skill", status.Entries)
+	}
+	if status.Entries[0].Workspace == "" {
+		t.Fatal("conflicted status omitted the workspace path")
+	}
+	expanded := status.Render(true)
+	if !strings.Contains(expanded, "alpha\tconflicted") || !strings.Contains(expanded, status.Entries[0].Workspace) {
+		t.Fatalf("--all output = %q", expanded)
+	}
+	summary := status.Render(false)
+	if !strings.Contains(summary, "1 conflicted") {
+		t.Fatalf("summary = %q", summary)
+	}
+}
+
+func TestRetryPreservesAnActiveConflictWorkspace(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "shared\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	proj.WriteImportedFile("alpha", "notes.md", "local\n")
+	source.WriteFile("skills/alpha/notes.md", "upstream\n", 0o644)
+	source.Commit("conflict")
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("conflicted pull: %v", err)
+	}
+	workspace, err := conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	writeProjectFile(t, filepath.Join(workspace, "notes.md"), "work in progress\n")
+	runGit(t, workspace, "add", "--", "notes.md")
+	lock := proj.Lock()
+	lock.Skills[0].Publication = &skilllock.Publication{
+		Repository: source.URL(),
+		Branch:     "skill-updates",
+		Commit:     lock.Skills[0].Commit,
+		TreeHash:   lock.Skills[0].TreeHash,
+	}
+	if err := lock.Save(proj.paths.SkillsLockPath); err != nil {
+		t.Fatalf("record publication while resolving pull: %v", err)
+	}
+	status, err := proj.Service().Status()
+	if err != nil {
+		t.Fatalf("Status after publication change: %v", err)
+	}
+	if len(status.Entries) != 1 || status.Entries[0].Condition != ConditionConflicted {
+		t.Fatalf("publication-only change invalidated pull workspace: %+v", status.Entries)
+	}
+
+	report, err := proj.Service().Pull(context.Background())
+	if err != nil {
+		t.Fatalf("retry pull: %v", err)
+	}
+	failed := requireOutcome(t, report, "alpha", OutcomeFailed)
+	if !strings.Contains(failed.Err.Error(), "active pull conflict workspace") {
+		t.Fatalf("retry error = %v", failed.Err)
+	}
+	data, err := os.ReadFile(filepath.Join(workspace, "notes.md")) // #nosec G304 -- workspace is rooted in t.TempDir().
+	if err != nil {
+		t.Fatalf("read staged resolution: %v", err)
+	}
+	if got := string(data); got != "work in progress\n" {
+		t.Fatalf("retry replaced staged resolution with %q", got)
+	}
+	if _, err := proj.Service().Resolve(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Resolve after publication change: %v", err)
+	}
+	resolved, _ := proj.Lock().Entry("alpha")
+	if resolved.Publication == nil || resolved.Publication.Branch != "skill-updates" {
+		t.Fatalf("pull resolve lost current publication: %+v", resolved.Publication)
+	}
+}
+
+func TestStatusFailsForCorruptConflictMetadata(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	if _, err := proj.Service().Resolve(context.Background(), "alpha"); err == nil || !strings.Contains(err.Error(), "no conflict workspace") {
+		t.Fatalf("Resolve without workspace = %v", err)
+	}
+	workspace, err := conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspace, ".git"), 0o750); err != nil {
+		t.Fatalf("mkdir corrupt workspace: %v", err)
+	}
+	writeProjectFile(t, filepath.Join(workspace, ".git", conflictMetaFile), "{")
+	if _, err := proj.Service().Status(); err == nil || !strings.Contains(err.Error(), ".agent-layer/tmp/skill-conflicts/alpha") || !strings.Contains(err.Error(), "move or remove it") {
+		t.Fatalf("Status corrupt workspace error = %v", err)
+	}
+}
+
+func TestResolveRejectsUnknownSkillAndWorkspaceKind(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.Commit("add alpha")
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	if _, err := proj.Service().Resolve(context.Background(), "missing"); err == nil || !strings.Contains(err.Error(), "no lock entry") {
+		t.Fatalf("unknown skill resolve error = %v", err)
+	}
+	workspace, err := conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspace, ".git"), 0o750); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	writeProjectFile(t, filepath.Join(workspace, ".git", conflictMetaFile), `{"kind":"unknown"}`)
+	if _, err := proj.Service().Resolve(context.Background(), "alpha"); err == nil || !strings.Contains(err.Error(), "unknown kind") {
+		t.Fatalf("unknown workspace kind error = %v", err)
+	}
+}
+
+func TestResolveAppliesAConflictedPushWithoutMovingSource(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "shared\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"},
+		`write_policy = "branch"`, `push_branch = "skill-updates"`))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	locked, _ := proj.Lock().Entry("alpha")
+
+	source.Checkout("skill-updates", true)
+	source.WriteFile("skills/alpha/notes.md", "destination change\n", 0o644)
+	destinationHead := source.Commit("destination change")
+	source.Checkout("main", false)
+	proj.WriteImportedFile("alpha", "notes.md", "local change\n")
+
+	report, err := proj.Service().Push(context.Background())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	failed := requireOutcome(t, report, "alpha", OutcomeFailed)
+	if !strings.Contains(failed.Err.Error(), "al skills resolve alpha") {
+		t.Fatalf("conflict error is not actionable: %v", failed.Err)
+	}
+	if source.Head("skill-updates") != destinationHead {
+		t.Fatal("a conflicted push still wrote to the destination")
+	}
+
+	workspace, err := conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	if runGit(t, workspace, "rev-parse", "--abbrev-ref", "HEAD") != "local" {
+		t.Fatal("push workspace did not check out local")
+	}
+	if runGit(t, workspace, "rev-parse", "--verify", "destination") == "" {
+		t.Fatal("push workspace is missing the destination branch")
+	}
+	writeProjectFile(t, filepath.Join(workspace, "notes.md"), "resolved\n")
+	runGit(t, workspace, "add", "--", "notes.md")
+
+	report, err = proj.Service().Resolve(context.Background(), "alpha")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	resolved := requireOutcome(t, report, "alpha", OutcomeResolved)
+	if !strings.Contains(resolved.Detail, "al skills push") {
+		t.Fatalf("push resolve did not ask for a rerun: %q", resolved.Detail)
+	}
+	if got := proj.ImportedFile("alpha", "notes.md"); got != "resolved\n" {
+		t.Fatalf("resolved content = %q", got)
+	}
+	entry, _ := proj.Lock().Entry("alpha")
+	if entry.Commit != locked.Commit {
+		t.Fatalf("push resolve moved the source lock from %s to %s", locked.Commit, entry.Commit)
+	}
+	if entry.Publication == nil || entry.Publication.Commit != destinationHead || entry.Publication.TreeHash == "" {
+		t.Fatalf("push resolve did not checkpoint the destination: %+v", entry.Publication)
+	}
+
+	report, err = proj.Service().Push(context.Background())
+	if err != nil {
+		t.Fatalf("rerun Push: %v\n%s", err, report.Render("push"))
+	}
+	requireOutcome(t, report, "alpha", OutcomePushed)
+	if got := source.FileAt("skill-updates", "skills/alpha/notes.md"); got != "resolved" {
+		t.Fatalf("destination content = %q", got)
+	}
+}
+
+func TestResolvedPushConflictCanCreateAMissingContributionBranch(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "shared\n", 0o644)
+	source.Commit("add alpha")
+
+	destination := newGitRepo(t, "main")
+	destination.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	destination.WriteFile("skills/alpha/notes.md", "destination change\n", 0o644)
+	destination.Commit("destination change")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"},
+		`write_policy = "branch"`, `push_branch = "skill-updates"`,
+		`push_repository = "`+destination.URL()+`"`))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	proj.WriteImportedFile("alpha", "notes.md", "local change\n")
+
+	report, err := proj.Service().Push(context.Background())
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	requireOutcome(t, report, "alpha", OutcomeFailed)
+	workspace, err := conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	writeProjectFile(t, filepath.Join(workspace, "notes.md"), "resolved\n")
+	runGit(t, workspace, "add", "--", "notes.md")
+
+	if _, err := proj.Service().Resolve(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	report, err = proj.Service().Push(context.Background())
+	if err != nil {
+		t.Fatalf("rerun Push: %v\n%s", err, report.Render("push"))
+	}
+	requireOutcome(t, report, "alpha", OutcomePushed)
+	if got := destination.FileAt("skill-updates", "skills/alpha/notes.md"); got != "resolved" {
+		t.Fatalf("destination content = %q", got)
+	}
+}
+
+func TestResetInvalidatesAConflictedPushWorkspace(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "shared\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"},
+		`write_policy = "branch"`, `push_branch = "skill-updates"`))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	source.Checkout("skill-updates", true)
+	source.WriteFile("skills/alpha/notes.md", "destination change\n", 0o644)
+	source.Commit("destination change")
+	source.Checkout("main", false)
+	proj.WriteImportedFile("alpha", "notes.md", "local change\n")
+
+	if _, err := proj.Service().Push(context.Background()); err != nil {
+		t.Fatalf("conflicted Push: %v", err)
+	}
+	if _, err := proj.Service().Reset(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	if got := proj.ImportedFile("alpha", "notes.md"); got != "shared\n" {
+		t.Fatalf("reset content = %q", got)
+	}
+	if _, err := proj.Service().Resolve(context.Background(), "alpha"); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("Resolve after reset error = %v", err)
+	}
+	status, err := proj.Service().Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if len(status.Entries) != 1 || status.Entries[0].Condition == ConditionConflicted {
+		t.Fatalf("status after reset = %+v", status.Entries)
+	}
+}

--- a/internal/skillimport/conflict_test.go
+++ b/internal/skillimport/conflict_test.go
@@ -458,3 +458,119 @@ func TestResetInvalidatesAConflictedPushWorkspace(t *testing.T) {
 		t.Fatalf("status after reset = %+v", status.Entries)
 	}
 }
+
+func TestWriteConflictWorkspacePreservesAStaleWorkspace(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "shared\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	proj.WriteImportedFile("alpha", "notes.md", "local\n")
+	source.WriteFile("skills/alpha/notes.md", "upstream\n", 0o644)
+	source.Commit("conflict")
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("conflicted pull: %v", err)
+	}
+	workspace, err := conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	writeProjectFile(t, filepath.Join(workspace, "notes.md"), "in-progress\n")
+	marker := filepath.Join(workspace, "keep-me.txt")
+	writeProjectFile(t, marker, "staged work\n")
+
+	proj.WriteImportedFile("alpha", "notes.md", "local-changed\n")
+	report, err := proj.Service().Pull(context.Background())
+	if err != nil {
+		t.Fatalf("retry pull: %v", err)
+	}
+	failed := requireOutcome(t, report, "alpha", OutcomeFailed)
+	if !strings.Contains(failed.Err.Error(), "stale") || !strings.Contains(failed.Err.Error(), "move or remove") {
+		t.Fatalf("retry pull error = %v", failed.Err)
+	}
+	if got := proj.ImportedFile("alpha", "notes.md"); got != "local-changed\n" {
+		t.Fatalf("local skill changed while the stale workspace was protected: %q", got)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("stale workspace was replaced: %v", err)
+	}
+	kept, err := os.ReadFile(filepath.Join(workspace, "notes.md")) // #nosec G304 -- test-owned workspace path.
+	if err != nil {
+		t.Fatalf("read in-progress resolution: %v", err)
+	}
+	if string(kept) != "in-progress\n" {
+		t.Fatalf("in-progress resolution was overwritten: %q", kept)
+	}
+}
+
+func TestResolveRejectsPushWorkspaceAfterWritePolicyChange(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "shared\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"},
+		`write_policy = "branch"`, `push_branch = "skill-updates"`))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	source.Checkout("skill-updates", true)
+	source.WriteFile("skills/alpha/notes.md", "destination change\n", 0o644)
+	source.Commit("destination change")
+	source.Checkout("main", false)
+	proj.WriteImportedFile("alpha", "notes.md", "local change\n")
+	if _, err := proj.Service().Push(context.Background()); err != nil {
+		t.Fatalf("conflicted Push: %v", err)
+	}
+	workspace, err := conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	writeProjectFile(t, filepath.Join(workspace, "notes.md"), "resolved\n")
+	runGit(t, workspace, "add", "--", "notes.md")
+
+	proj.ReplaceInConfig("write_policy = \"branch\"\npush_branch = \"skill-updates\"\n", "write_policy = \"direct\"\n")
+	if _, err := proj.Service().Resolve(context.Background(), "alpha"); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("write-policy-changed workspace error = %v", err)
+	}
+}
+
+func TestResolveRejectsPullWorkspaceAfterClearingPinnedTracking(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "shared\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"},
+		`tracking = "pinned"`))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	proj.WriteImportedFile("alpha", "notes.md", "local\n")
+	source.Checkout("other", true)
+	source.WriteFile("skills/alpha/notes.md", "upstream\n", 0o644)
+	source.Commit("retarget conflict")
+	source.Checkout("main", false)
+	proj.ReplaceInConfig(`selectors = ["skills/alpha"]`, "selectors = [\"skills/alpha\"]\nref = \"other\"")
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("conflicted pull: %v", err)
+	}
+	workspace, err := conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	writeProjectFile(t, filepath.Join(workspace, "notes.md"), "resolved\n")
+	runGit(t, workspace, "add", "--", "notes.md")
+
+	proj.ReplaceInConfig("\ntracking = \"pinned\"\n", "\n")
+	if _, err := proj.Service().Resolve(context.Background(), "alpha"); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("cleared-tracking workspace error = %v", err)
+	}
+}

--- a/internal/skillimport/conflict_test.go
+++ b/internal/skillimport/conflict_test.go
@@ -271,7 +271,7 @@ func TestStatusFailsForCorruptConflictMetadata(t *testing.T) {
 		t.Fatalf("mkdir corrupt workspace: %v", err)
 	}
 	writeProjectFile(t, filepath.Join(workspace, ".git", conflictMetaFile), "{")
-	if _, err := proj.Service().Status(); err == nil || !strings.Contains(err.Error(), ".agent-layer/tmp/skill-conflicts/alpha") || !strings.Contains(err.Error(), "move or remove it") {
+	if _, err := proj.Service().Status(); err == nil || !strings.Contains(err.Error(), filepath.Join(".agent-layer", "tmp", "skill-conflicts", "alpha")) || !strings.Contains(err.Error(), "move or remove it") {
 		t.Fatalf("Status corrupt workspace error = %v", err)
 	}
 }

--- a/internal/skillimport/diff.go
+++ b/internal/skillimport/diff.go
@@ -1,0 +1,182 @@
+package skillimport
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/conn-castle/agent-layer/internal/config"
+	"github.com/conn-castle/agent-layer/internal/gitrepo"
+	"github.com/conn-castle/agent-layer/internal/skilllock"
+	"github.com/conn-castle/agent-layer/internal/skilltree"
+)
+
+const (
+	diffSideBase        = "base"
+	diffSideLocal       = "local"
+	diffSideUpstream    = "upstream"
+	diffSideDestination = "destination"
+)
+
+// Diff compares two live sides of an imported skill and returns an ordinary
+// Git unified diff. Identical trees produce no output.
+func (s *Service) Diff(ctx context.Context, name string, from string, to string) ([]byte, error) {
+	from = defaultDiffSide(from, diffSideLocal)
+	to = defaultDiffSide(to, diffSideUpstream)
+	if err := validateDiffSide(from); err != nil {
+		return nil, err
+	}
+	if err := validateDiffSide(to); err != nil {
+		return nil, err
+	}
+
+	var output []byte
+	err := s.withLockedState(func(st *state) error {
+		if err := failOnOrphans(st); err != nil {
+			return err
+		}
+		entry, ok := st.lock.Entry(name)
+		if !ok {
+			return fmt.Errorf("imported skill %q has no lock entry", name)
+		}
+		diff, err := s.diffLocked(ctx, st, entry, from, to)
+		if err != nil {
+			return err
+		}
+		output = diff
+		return nil
+	})
+	return output, err
+}
+
+func defaultDiffSide(value string, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func validateDiffSide(side string) error {
+	switch side {
+	case diffSideBase, diffSideLocal, diffSideUpstream, diffSideDestination:
+		return nil
+	default:
+		return fmt.Errorf("unsupported diff side %q; use base, local, upstream, or destination", side)
+	}
+}
+
+func (s *Service) diffLocked(ctx context.Context, st *state, entry skilllock.Entry, from string, to string) ([]byte, error) {
+	runner, err := s.newRunner(st.env)
+	if err != nil {
+		return nil, err
+	}
+	workRoot, err := os.MkdirTemp("", "al-skill-diff-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a git working directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(workRoot) }()
+
+	fromTree, err := s.resolveDiffSide(ctx, runner, workRoot, st, entry, from)
+	if err != nil {
+		return nil, err
+	}
+	toTree, err := s.resolveDiffSide(ctx, runner, workRoot, st, entry, to)
+	if err != nil {
+		return nil, err
+	}
+	return runner.DiffTrees(ctx, from, fromTree, to, toTree)
+}
+
+func (s *Service) resolveDiffSide(ctx context.Context, runner *gitrepo.Runner, workRoot string, st *state, entry skilllock.Entry, side string) (skilltree.Tree, error) {
+	switch side {
+	case diffSideLocal:
+		observed := st.skill(entry.Name)
+		if !observed.Present {
+			return skilltree.Tree{}, fmt.Errorf("imported directory %s is missing", relativeTo(st.paths.Root, observed.Dir))
+		}
+		if observed.Err != nil {
+			return skilltree.Tree{}, observed.Err
+		}
+		return observed.Tree, nil
+	case diffSideBase:
+		source, err := s.openLockedSource(ctx, runner, workRoot, entry.Repository)
+		if err != nil {
+			return skilltree.Tree{}, err
+		}
+		if err := source.Fetch(ctx, entry.Commit); err != nil {
+			return skilltree.Tree{}, err
+		}
+		return source.ReadTree(ctx, entry.Commit, entry.SelectedPath)
+	case diffSideUpstream:
+		block, index, configured := st.configuredBlockForEntry(entry)
+		if !configured {
+			return skilltree.Tree{}, fmt.Errorf("imported skill %q is not in the current configuration", entry.Name)
+		}
+		blockCtx, err := s.openBlock(ctx, runner, workRoot, index, block)
+		if err != nil {
+			return skilltree.Tree{}, err
+		}
+		return blockCtx.Source.ReadTree(ctx, blockCtx.Resolution.Commit, entry.SelectedPath)
+	case diffSideDestination:
+		return s.readLiveDestinationTree(ctx, runner, workRoot, st, entry)
+	default:
+		return skilltree.Tree{}, fmt.Errorf("unhandled diff side %q", side)
+	}
+}
+
+func (s *Service) openLockedSource(ctx context.Context, runner *gitrepo.Runner, workRoot string, repository string) (*gitrepo.Source, error) {
+	dir := filepath.Join(workRoot, "lock-source")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create git working directory %s: %w", dir, err)
+	}
+	resolved, err := runner.Secrets().Resolve(config.NormalizeSkillRepository(repository))
+	if err != nil {
+		return nil, err
+	}
+	return gitrepo.OpenSource(ctx, runner, dir, resolved)
+}
+
+func (s *Service) readLiveDestinationTree(ctx context.Context, runner *gitrepo.Runner, workRoot string, st *state, entry skilllock.Entry) (skilltree.Tree, error) {
+	block, _, configured := st.configuredBlockForEntry(entry)
+	if !configured || !block.WriteEnabled() {
+		return skilltree.Tree{}, fmt.Errorf("imported skill %q has no writable destination", entry.Name)
+	}
+	dir := filepath.Join(workRoot, "destination")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return skilltree.Tree{}, fmt.Errorf("failed to create git working directory %s: %w", dir, err)
+	}
+	destinationRef, err := runner.Secrets().Resolve(config.NormalizeSkillRepository(block.EffectivePushRepository()))
+	if err != nil {
+		return skilltree.Tree{}, err
+	}
+	destination, err := gitrepo.OpenDestination(ctx, runner, dir, destinationRef)
+	if err != nil {
+		return skilltree.Tree{}, err
+	}
+	branch, err := liveDestinationBranch(ctx, destination, destinationRef, block)
+	if err != nil {
+		return skilltree.Tree{}, err
+	}
+	head, exists, err := destination.Head(ctx, branch)
+	if err != nil {
+		return skilltree.Tree{}, err
+	}
+	if !exists {
+		return skilltree.Tree{}, fmt.Errorf("destination %s has no branch %s", destinationRef, branch)
+	}
+	if err := destination.FetchCommit(ctx, destinationRef, head); err != nil {
+		return skilltree.Tree{}, err
+	}
+	return destination.ReadTree(ctx, head, entry.SelectedPath)
+}
+
+func liveDestinationBranch(ctx context.Context, destination *gitrepo.Destination, destinationRef gitrepo.Repository, block config.SkillImport) (string, error) {
+	defaultBranch, err := destination.DefaultBranch(ctx)
+	if err != nil {
+		return "", err
+	}
+	branch, _, err := pushBranchForDefault(block, destinationRef, defaultBranch)
+	return branch, err
+}

--- a/internal/skillimport/diff_test.go
+++ b/internal/skillimport/diff_test.go
@@ -1,0 +1,186 @@
+package skillimport
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiffComparesLiveLocalAndUpstreamTrees(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "base\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	proj.WriteImportedFile("alpha", "notes.md", "local\n")
+	source.WriteFile("skills/alpha/notes.md", "upstream\n", 0o644)
+	source.Commit("advance")
+
+	diff, err := proj.Service().Diff(context.Background(), "alpha", "local", "upstream")
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	defaulted, err := proj.Service().Diff(context.Background(), "alpha", "", "")
+	if err != nil {
+		t.Fatalf("Diff defaults: %v", err)
+	}
+	if string(defaulted) != string(diff) {
+		t.Fatalf("default diff differs from local/upstream diff:\n%s", defaulted)
+	}
+	text := string(diff)
+	for _, fragment := range []string{
+		"diff --git a/local/notes.md b/upstream/notes.md",
+		"-local",
+		"+upstream",
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("diff %q does not contain %q", text, fragment)
+		}
+	}
+
+	baseDiff, err := proj.Service().Diff(context.Background(), "alpha", "base", "local")
+	if err != nil {
+		t.Fatalf("Diff base local: %v", err)
+	}
+	if !strings.Contains(string(baseDiff), "a/base/notes.md") || !strings.Contains(string(baseDiff), "b/local/notes.md") {
+		t.Fatalf("base/local prefixes missing: %q", baseDiff)
+	}
+
+	identical, err := proj.Service().Diff(context.Background(), "alpha", "local", "local")
+	if err != nil {
+		t.Fatalf("Diff identical: %v", err)
+	}
+	if len(identical) != 0 {
+		t.Fatalf("identical sides produced output %q", identical)
+	}
+}
+
+func TestDiffRejectsUnknownSidesAndMissingDestination(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+
+	if _, err := proj.Service().Diff(context.Background(), "alpha", "ours", "upstream"); err == nil || !strings.Contains(err.Error(), "unsupported diff side") {
+		t.Fatalf("unknown side error = %v", err)
+	}
+	if _, err := proj.Service().Diff(context.Background(), "alpha", "local", "destination"); err == nil || !strings.Contains(err.Error(), "no writable destination") {
+		t.Fatalf("read-only destination error = %v", err)
+	}
+
+	proj.ReplaceInConfig(`selectors = ["skills/alpha"]`, `selectors = ["skills/alpha"]
+write_policy = "branch"
+push_branch = "missing-branch"`)
+	if _, err := proj.Service().Diff(context.Background(), "alpha", "local", "destination"); err == nil || !strings.Contains(err.Error(), "has no branch") {
+		t.Fatalf("missing destination branch error = %v", err)
+	}
+}
+
+func TestDiffRejectsBranchPolicyTargetingDefaultBranch(t *testing.T) {
+	source := newGitRepo(t, "trunk")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"},
+		`write_policy = "branch"`, `push_branch = "trunk"`))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	_, err := proj.Service().Diff(context.Background(), "alpha", "local", "destination")
+	if err == nil || !strings.Contains(err.Error(), "default branch") {
+		t.Fatalf("default-branch destination error = %v", err)
+	}
+}
+
+func TestDiffTreatsAbsentDestinationPathAsEmptyTree(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "present\n", 0o644)
+	source.Commit("add alpha")
+	source.Checkout("skill-updates", true)
+	source.RemovePath("skills/alpha")
+	source.Commit("remove skill on destination branch")
+	source.Checkout("main", false)
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"},
+		`write_policy = "branch"`, `push_branch = "skill-updates"`))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+
+	diff, err := proj.Service().Diff(context.Background(), "alpha", "local", "destination")
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	text := string(diff)
+	if !strings.Contains(text, "a/local/notes.md") || !strings.Contains(text, "b/destination/notes.md") {
+		t.Fatalf("empty destination diff missing prefixes: %q", text)
+	}
+	if !strings.Contains(text, "-present") {
+		t.Fatalf("empty destination did not show the local addition as a deletion: %q", text)
+	}
+}
+
+func TestDiffReadsAnExistingWritableDestination(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "base\n", 0o644)
+	source.Commit("add alpha")
+	source.Checkout("skill-updates", true)
+	source.WriteFile("skills/alpha/notes.md", "destination\n", 0o644)
+	source.Commit("destination change")
+	source.Checkout("main", false)
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"},
+		`write_policy = "branch"`, `push_branch = "skill-updates"`))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+
+	diff, err := proj.Service().Diff(context.Background(), "alpha", "base", "destination")
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	text := string(diff)
+	for _, fragment := range []string{"a/base/notes.md", "b/destination/notes.md", "-base", "+destination"} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("destination diff %q does not contain %q", text, fragment)
+		}
+	}
+}
+
+func TestDiffReportsUnavailableLocalAndUpstreamSides(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.Commit("add alpha")
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(proj.paths.ImportedSkillsDir, "alpha")); err != nil {
+		t.Fatalf("remove local skill: %v", err)
+	}
+	if _, err := proj.Service().Diff(context.Background(), "alpha", "local", "base"); err == nil || !strings.Contains(err.Error(), "is missing") {
+		t.Fatalf("missing local diff error = %v", err)
+	}
+	writeProjectFile(t, proj.paths.ConfigPath, baseConfigTOML)
+	if _, err := proj.Service().Diff(context.Background(), "alpha", "base", "upstream"); err == nil || !strings.Contains(err.Error(), "not in the current configuration") {
+		t.Fatalf("unconfigured upstream diff error = %v", err)
+	}
+}

--- a/internal/skillimport/harness_test.go
+++ b/internal/skillimport/harness_test.go
@@ -88,15 +88,20 @@ func (r *gitRepo) URL() string { return r.dir }
 
 func (r *gitRepo) run(args ...string) string {
 	r.t.Helper()
+	return runGit(r.t, r.dir, args...)
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
 	cmd := exec.Command("git", args...) // #nosec G204 -- test-controlled arguments.
-	cmd.Dir = r.dir
+	cmd.Dir = dir
 	// Resolve the repository from the directory above, never from an inherited
 	// GIT_DIR: git exports it to hooks, so under pre-commit this fixture would
 	// otherwise commit into the developer's own checkout.
 	cmd.Env = append(gitenv.WithoutDiscovery(), "GIT_TERMINAL_PROMPT=0")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		r.t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
 	}
 	return strings.TrimSpace(string(output))
 }

--- a/internal/skillimport/pull.go
+++ b/internal/skillimport/pull.go
@@ -335,7 +335,13 @@ func (s *Service) advanceExisting(ctx context.Context, runner *gitrepo.Runner, s
 	}
 	if len(conflicts) > 0 {
 		result.Outcome = OutcomeFailed
-		result.Err = fmt.Errorf("upstream and local changes conflict in %s", describeConflicts(conflicts))
+		workspace, workspaceErr := writePullConflictWorkspace(ctx, runner, st, skill.Name, observed.Tree, base, skill.Tree, entry, nextEntry)
+		switch {
+		case workspaceErr != nil:
+			result.Err = fmt.Errorf("upstream and local changes conflict in %s; could not write resolution workspace: %w", describeConflicts(conflicts), workspaceErr)
+		default:
+			result.Err = fmt.Errorf("upstream and local changes conflict in %s; resolve %s with git and run 'al skills resolve %s'", describeConflicts(conflicts), relativeTo(st.paths.Root, workspace), skill.Name)
+		}
 		report.Add(result)
 		return
 	}

--- a/internal/skillimport/pull_test.go
+++ b/internal/skillimport/pull_test.go
@@ -224,6 +224,69 @@ func TestPullConflictPreservesLocalContentAndLock(t *testing.T) {
 	}
 }
 
+// TestResolveAppliesAConflictedPull proves the conflict workspace is the public
+// handoff between pull and resolve, without a snapshot or second fetch.
+func TestResolveAppliesAConflictedPull(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Alpha body")
+	source.WriteFile("skills/alpha/notes.md", "shared\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"}))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("initial pull: %v", err)
+	}
+	locked, _ := proj.Lock().Entry("alpha")
+	proj.WriteImportedFile("alpha", "notes.md", "local\n")
+	source.WriteFile("skills/alpha/notes.md", "upstream\n", 0o644)
+	advanced := source.Commit("conflict")
+
+	report, err := proj.Service().Pull(context.Background())
+	if err != nil {
+		t.Fatalf("conflicted pull: %v", err)
+	}
+	failed := requireOutcome(t, report, "alpha", OutcomeFailed)
+	if !strings.Contains(failed.Err.Error(), "al skills resolve alpha") {
+		t.Fatalf("conflict error is not actionable: %v", failed.Err)
+	}
+	workspace, err := conflictWorkspace(proj.root, "alpha")
+	if err != nil {
+		t.Fatalf("conflict workspace path: %v", err)
+	}
+	marked, err := os.ReadFile(filepath.Join(workspace, "notes.md")) // #nosec G304 -- test-owned temp path.
+	if err != nil || !strings.Contains(string(marked), "<<<<<<<") {
+		t.Fatalf("workspace content = %q, error %v", marked, err)
+	}
+	if _, err := proj.Service().Resolve(context.Background(), "alpha"); err == nil || !strings.Contains(err.Error(), "unmerged") {
+		t.Fatalf("unresolved workspace error = %v", err)
+	}
+	writeProjectFile(t, filepath.Join(workspace, "notes.md"), "resolved\n")
+	runGit(t, workspace, "add", "--", "notes.md")
+	writeProjectFile(t, filepath.Join(workspace, "notes.md"), "unstaged\n")
+	if _, err := proj.Service().Resolve(context.Background(), "alpha"); err == nil || !strings.Contains(err.Error(), "unstaged") {
+		t.Fatalf("edited but unstaged workspace error = %v", err)
+	}
+	writeProjectFile(t, filepath.Join(workspace, "notes.md"), "resolved\n")
+	runGit(t, workspace, "add", "--", "notes.md")
+
+	report, err = proj.Service().Resolve(context.Background(), "alpha")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	requireOutcome(t, report, "alpha", OutcomeResolved)
+	if got := proj.ImportedFile("alpha", "notes.md"); got != "resolved\n" {
+		t.Fatalf("resolved content = %q", got)
+	}
+	entry, _ := proj.Lock().Entry("alpha")
+	if entry.Commit != advanced || entry.Commit == locked.Commit {
+		t.Fatalf("resolved lock commit = %s, want %s", entry.Commit, advanced)
+	}
+	if _, err := os.Stat(workspace); !os.IsNotExist(err) {
+		t.Fatalf("conflict workspace remains after resolve: %v", err)
+	}
+}
+
 // TestPullRetiresCleanAndPreservesModifiedDisappearances proves the one
 // retirement rule: a clean skill that leaves the desired set is deleted, and a
 // modified one is preserved and reported as a failure with instructions.

--- a/internal/skillimport/push.go
+++ b/internal/skillimport/push.go
@@ -194,7 +194,7 @@ func (s *Service) pushLocked(ctx context.Context, st *state, report *Report) err
 	sort.Strings(order)
 	txn := newTransaction(pathSetFor(st), st.lock)
 	for _, key := range order {
-		s.publishGroup(ctx, runner, workRoot, txn, groups[key], report)
+		s.publishGroup(ctx, runner, workRoot, st, txn, groups[key], report)
 	}
 
 	if txn.NeedsCommit(st.lock, st.lockPresent) {
@@ -284,15 +284,22 @@ func resolvePushBranch(ctx context.Context, branches *defaultBranchCache, block 
 	if err != nil {
 		return "", "", false, err
 	}
+	branch, configured, err = pushBranchForDefault(block, destination, defaultBranch)
+	return branch, defaultBranch, configured, err
+}
+
+// pushBranchForDefault applies write-policy branch selection against an already
+// resolved destination default branch. Branch policy may not target that default.
+func pushBranchForDefault(block config.SkillImport, destination gitrepo.Repository, defaultBranch string) (branch string, configured bool, err error) {
 	configuredBranch := strings.TrimSpace(block.PushBranch)
 	if configuredBranch == "" {
-		return defaultBranch, defaultBranch, false, nil
+		return defaultBranch, false, nil
 	}
 	if configuredBranch == defaultBranch {
-		return "", "", false, fmt.Errorf("push_branch %q is the default branch of %s; write_policy = %q never writes to a destination's primary branch, so use write_policy = %q or configure a different branch",
+		return "", false, fmt.Errorf("push_branch %q is the default branch of %s; write_policy = %q never writes to a destination's primary branch, so use write_policy = %q or configure a different branch",
 			configuredBranch, destination, config.SkillWritePolicyBranch, config.SkillWritePolicyDirect)
 	}
-	return configuredBranch, defaultBranch, true, nil
+	return configuredBranch, true, nil
 }
 
 // reportBlockedSkills records the required failed result for every skill a
@@ -337,7 +344,7 @@ func buildPushCandidate(ctx context.Context, st *state, source *gitrepo.Source, 
 
 // publishGroup reconciles every candidate in one destination group against the
 // destination head and, when anything changed, commits and pushes them together.
-func (s *Service) publishGroup(ctx context.Context, runner *gitrepo.Runner, workRoot string, txn *transaction, group *pushGroup, report *Report) {
+func (s *Service) publishGroup(ctx context.Context, runner *gitrepo.Runner, workRoot string, st *state, txn *transaction, group *pushGroup, report *Report) {
 	if len(group.Candidates) == 0 {
 		return
 	}
@@ -416,28 +423,23 @@ func (s *Service) publishGroup(ctx context.Context, runner *gitrepo.Runner, work
 			report.Add(result)
 			continue
 		}
-		mergeBase := candidate.Base
-		checkpointed := false
-		if branchExisted {
-			var baseErr error
-			mergeBase, checkpointed, baseErr = publicationMergeBase(ctx, destination, group, candidate, head)
-			if errors.Is(baseErr, errPublicationUnavailable) {
-				candidate.Entry.Publication = nil
-				txn.SetLockEntry(candidate.Entry)
-				mergeBase = candidate.Base
-				baseErr = nil
-			}
-			if baseErr != nil {
-				result.Outcome = OutcomeFailed
-				result.Err = baseErr
-				report.Add(result)
-				continue
-			}
-		} else if publicationMatches(group, candidate.Entry.Publication) {
-			// A deleted branch has no destination history left to reconcile. Drop
-			// its obsolete checkpoint before optionally creating the branch anew.
+		// Check the prior publication even when the contribution branch is absent.
+		// Hosts commonly delete a branch after merging it; when that publication is
+		// still an ancestor of the default head, it remains the correct merge base
+		// for recreating the contribution branch. Unreachable or rewritten history
+		// falls back to the locked source below.
+		mergeBase, checkpointed, baseErr := publicationMergeBase(ctx, destination, group, candidate, head)
+		if errors.Is(baseErr, errPublicationUnavailable) {
 			candidate.Entry.Publication = nil
 			txn.SetLockEntry(candidate.Entry)
+			mergeBase = candidate.Base
+			baseErr = nil
+		}
+		if baseErr != nil {
+			result.Outcome = OutcomeFailed
+			result.Err = baseErr
+			report.Add(result)
+			continue
 		}
 		candidate.Base = mergeBase
 		candidate.CanCheckpoint = checkpointed
@@ -457,7 +459,7 @@ func (s *Service) publishGroup(ctx context.Context, runner *gitrepo.Runner, work
 		// modified local content is a delete/modify conflict.
 		merged := candidate.Local
 		if branchExisted || !destinationTree.IsEmpty() {
-			result, merged = mergeAgainstDestination(ctx, runner, candidate, destinationTree, result)
+			result, merged = mergeAgainstDestination(ctx, runner, st, group, head, candidate, destinationTree, result)
 			if result.Outcome == OutcomeFailed {
 				report.Add(result)
 				continue
@@ -658,7 +660,7 @@ func advanceUnchangedLocks(txn *transaction, group *pushGroup, head string, comm
 // mergeAgainstDestination reconciles one candidate's local change with the
 // content the destination already carries. A failure is reported on the
 // returned result, which the caller detects through OutcomeFailed.
-func mergeAgainstDestination(ctx context.Context, runner *gitrepo.Runner, candidate pushCandidate, destinationTree skilltree.Tree, result SkillResult) (SkillResult, skilltree.Tree) {
+func mergeAgainstDestination(ctx context.Context, runner *gitrepo.Runner, st *state, group *pushGroup, head string, candidate pushCandidate, destinationTree skilltree.Tree, result SkillResult) (SkillResult, skilltree.Tree) {
 	merged, conflicts, mergeErr := skilltree.Merge(candidate.Base, candidate.Local, destinationTree, runner.TextMerger(ctx))
 	if mergeErr != nil {
 		result.Outcome = OutcomeFailed
@@ -667,7 +669,13 @@ func mergeAgainstDestination(ctx context.Context, runner *gitrepo.Runner, candid
 	}
 	if len(conflicts) > 0 {
 		result.Outcome = OutcomeFailed
-		result.Err = fmt.Errorf("local and destination changes conflict in %s", describeConflicts(conflicts))
+		workspace, workspaceErr := writePushConflictWorkspace(ctx, runner, st, candidate.Entry.Name, candidate.Local, candidate.Base, destinationTree, candidate.Entry, group, head)
+		switch {
+		case workspaceErr != nil:
+			result.Err = fmt.Errorf("local and destination changes conflict in %s; could not write resolution workspace: %w", describeConflicts(conflicts), workspaceErr)
+		default:
+			result.Err = fmt.Errorf("local and destination changes conflict in %s; resolve %s with git and run 'al skills resolve %s'", describeConflicts(conflicts), relativeTo(st.paths.Root, workspace), candidate.Entry.Name)
+		}
 		return result, skilltree.Tree{}
 	}
 	return result, merged

--- a/internal/skillimport/push.go
+++ b/internal/skillimport/push.go
@@ -444,7 +444,7 @@ func (s *Service) publishGroup(ctx context.Context, runner *gitrepo.Runner, work
 		candidate.Base = mergeBase
 		candidate.CanCheckpoint = checkpointed
 		// An absent destination path means two different things, and only the
-		// branch's history distinguishes them.
+		// branch's history (or a restored publication checkpoint) distinguishes them.
 		//
 		// On a branch this publication just created from the destination's
 		// default branch, a path absent from that base was never present on the
@@ -453,12 +453,13 @@ func (s *Service) publishGroup(ctx context.Context, runner *gitrepo.Runner, work
 		// group coherent — merging against an empty tree would read every
 		// unchanged file as a destination deletion and publish a partial skill.
 		//
-		// On a branch that already existed, an absent path is a destination-side
-		// whole-skill deletion relative to the locked base, which is ordinary
-		// three-way input: unchanged local content preserves the deletion, and
-		// modified local content is a delete/modify conflict.
+		// On a branch that already existed, or when recreating a deleted branch
+		// from a prior publication checkpoint, an absent path is a
+		// destination-side whole-skill deletion relative to the merge base:
+		// unchanged local content preserves the deletion, and modified local
+		// content is a delete/modify conflict.
 		merged := candidate.Local
-		if branchExisted || !destinationTree.IsEmpty() {
+		if branchExisted || checkpointed || !destinationTree.IsEmpty() {
 			result, merged = mergeAgainstDestination(ctx, runner, st, group, head, candidate, destinationTree, result)
 			if result.Outcome == OutcomeFailed {
 				report.Add(result)

--- a/internal/skillimport/push_test.go
+++ b/internal/skillimport/push_test.go
@@ -163,6 +163,96 @@ func TestPushRecreatesADeletedMergedBranchFromItsPublication(t *testing.T) {
 	}
 }
 
+// TestPushPreservesADestinationDeletionWhenRecreatingACheckpointedBranch proves
+// that restoring a publication checkpoint is not enough to skip destination
+// reconciliation. After the contribution branch is deleted and the skill is
+// then removed from the default branch, an unchanged local tree must preserve
+// that deletion instead of republishing the checkpointed skill onto a new
+// branch.
+func TestPushPreservesADestinationDeletionWhenRecreatingACheckpointedBranch(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Original body")
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"},
+		`tracking = "pinned"`, `write_policy = "branch"`, `push_branch = "skill-updates"`))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	proj.WriteImportedFile("alpha", "SKILL.md", skillManifest("alpha", "First body"))
+	first, err := proj.Service().Push(context.Background())
+	if err != nil {
+		t.Fatalf("first Push: %v\n%s", err, first.Render("push"))
+	}
+	requireOutcome(t, first, "alpha", OutcomePushed)
+
+	source.run("merge", "--quiet", "--no-ff", "--no-edit", "skill-updates")
+	source.run("branch", "--delete", "skill-updates")
+	source.RemovePath("skills/alpha")
+	defaultHead := source.Commit("remove alpha from default")
+
+	second, err := proj.Service().Push(context.Background())
+	if err != nil {
+		t.Fatalf("second Push: %v\n%s", err, second.Render("push"))
+	}
+	alpha := requireOutcome(t, second, "alpha", OutcomeUnchanged)
+	if !strings.Contains(alpha.Detail, "removal is preserved") {
+		t.Fatalf("alpha detail = %q, want the preserved destination removal", alpha.Detail)
+	}
+	if source.HasPath("skill-updates", "skills/alpha/SKILL.md") {
+		t.Fatal("recreating the branch resurrected a destination-side whole-skill deletion")
+	}
+	if source.Head("main") != defaultHead || source.HasPath("main", "skills/alpha/SKILL.md") {
+		t.Fatal("preserving the deletion changed the default branch")
+	}
+	if !strings.Contains(proj.ImportedFile("alpha", "SKILL.md"), "First body") {
+		t.Fatal("preserving a destination deletion removed the managed local skill")
+	}
+}
+
+func TestPushReportsADeleteModifyConflictWhenRecreatingACheckpointedBranch(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Original body")
+	source.WriteFile("skills/alpha/notes.md", "shared\n", 0o644)
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"},
+		`tracking = "pinned"`, `write_policy = "branch"`, `push_branch = "skill-updates"`))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	proj.WriteImportedFile("alpha", "SKILL.md", skillManifest("alpha", "First body"))
+	first, err := proj.Service().Push(context.Background())
+	if err != nil {
+		t.Fatalf("first Push: %v\n%s", err, first.Render("push"))
+	}
+	requireOutcome(t, first, "alpha", OutcomePushed)
+
+	source.run("merge", "--quiet", "--no-ff", "--no-edit", "skill-updates")
+	source.run("branch", "--delete", "skill-updates")
+	source.RemovePath("skills/alpha")
+	defaultHead := source.Commit("remove alpha from default")
+
+	proj.WriteImportedFile("alpha", "notes.md", "local change\n")
+
+	second, err := proj.Service().Push(context.Background())
+	if err != nil {
+		t.Fatalf("second Push: %v", err)
+	}
+	failed := requireOutcome(t, second, "alpha", OutcomeFailed)
+	if !strings.Contains(failed.Err.Error(), "delete/modify") {
+		t.Fatalf("failure %q does not report the delete/modify conflict", failed.Err)
+	}
+	if source.Head("main") != defaultHead {
+		t.Fatal("a conflicted push still wrote to the destination")
+	}
+	if source.HasPath("skill-updates", "skills/alpha/SKILL.md") {
+		t.Fatal("a conflicted push re-added the deleted skill")
+	}
+}
+
 // TestPushBranchPublishesAReversionToTheSourceVersion proves returning a file
 // to its original source content is still a change relative to what Agent
 // Layer last published. Without publication state, three-way merge treats the

--- a/internal/skillimport/push_test.go
+++ b/internal/skillimport/push_test.go
@@ -126,6 +126,43 @@ func TestPushBranchUsesThePriorPublicationForFollowUpEdits(t *testing.T) {
 	}
 }
 
+func TestPushRecreatesADeletedMergedBranchFromItsPublication(t *testing.T) {
+	source := newGitRepo(t, "main")
+	source.WriteSkill("skills/alpha", "alpha", "Original body")
+	source.Commit("add alpha")
+
+	proj := newProject(t)
+	proj.AppendConfig(importBlock(source.URL(), []string{"skills/alpha"},
+		`tracking = "pinned"`, `write_policy = "branch"`, `push_branch = "skill-updates"`))
+	if _, err := proj.Service().Pull(context.Background()); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	proj.WriteImportedFile("alpha", "SKILL.md", skillManifest("alpha", "First body"))
+	first, err := proj.Service().Push(context.Background())
+	if err != nil {
+		t.Fatalf("first Push: %v\n%s", err, first.Render("push"))
+	}
+	requireOutcome(t, first, "alpha", OutcomePushed)
+	firstPublication := source.Head("skill-updates")
+
+	source.run("merge", "--quiet", "--no-ff", "--no-edit", "skill-updates")
+	source.run("branch", "--delete", "skill-updates")
+	proj.WriteImportedFile("alpha", "SKILL.md", skillManifest("alpha", "Second body"))
+
+	second, err := proj.Service().Push(context.Background())
+	if err != nil {
+		t.Fatalf("second Push: %v\n%s", err, second.Render("push"))
+	}
+	requireOutcome(t, second, "alpha", OutcomePushed)
+	if got := source.FileAt("skill-updates", "skills/alpha/SKILL.md"); !strings.Contains(got, "Second body") {
+		t.Fatalf("recreated destination content = %q", got)
+	}
+	entry, _ := proj.Lock().Entry("alpha")
+	if entry.Publication == nil || entry.Publication.Commit == firstPublication {
+		t.Fatalf("publication was not advanced after branch recreation: %+v", entry.Publication)
+	}
+}
+
 // TestPushBranchPublishesAReversionToTheSourceVersion proves returning a file
 // to its original source content is still a change relative to what Agent
 // Layer last published. Without publication state, three-way merge treats the

--- a/internal/skillimport/report.go
+++ b/internal/skillimport/report.go
@@ -39,6 +39,8 @@ const (
 	OutcomeSkipped Outcome = "skipped"
 	// OutcomeFailed reports a skill-level failure that blocked only that skill.
 	OutcomeFailed Outcome = "failed"
+	// OutcomeResolved reports a conflicted pull or push completed from its workspace.
+	OutcomeResolved Outcome = "resolved"
 )
 
 // SkillResult is one skill's outcome.

--- a/internal/skillimport/state.go
+++ b/internal/skillimport/state.go
@@ -29,6 +29,9 @@ const (
 	ConditionInvalid Condition = "invalid"
 	// ConditionCollided means a user-managed skill owns the same name.
 	ConditionCollided Condition = "collided"
+	// ConditionConflicted means an active Git conflict workspace still matches
+	// the recorded lock and configuration.
+	ConditionConflicted Condition = "conflicted"
 )
 
 // localSkill is one imported directory's observed state.
@@ -209,11 +212,14 @@ func (s *state) classify(entry skilllock.Entry) Condition {
 		return ConditionMissing
 	case observed.Err != nil:
 		return ConditionInvalid
-	case observed.Tree.Hash() == entry.TreeHash:
-		return ConditionClean
-	default:
-		return ConditionModified
 	}
+	if _, ok := matchingConflictWorkspace(s, entry); ok {
+		return ConditionConflicted
+	}
+	if observed.Tree.Hash() == entry.TreeHash {
+		return ConditionClean
+	}
+	return ConditionModified
 }
 
 // orphanDirectories lists imported directories with no lock entry, sorted.

--- a/internal/skillimport/status.go
+++ b/internal/skillimport/status.go
@@ -22,6 +22,9 @@ type StatusEntry struct {
 	WritePolicy  string
 	Condition    Condition
 	WriteEnabled bool
+	// Workspace is the conflict workspace path relative to the repository root
+	// when Condition is conflicted.
+	Workspace string
 }
 
 // StatusExclusion is one configured exclusion selector.
@@ -75,12 +78,22 @@ func buildStatus(st *state) (*Status, error) {
 	}
 
 	for _, entry := range st.lock.Skills {
+		if err := validateConflictWorkspaceMetadata(st, entry.Name); err != nil {
+			return nil, err
+		}
 		block, _, configured := st.configuredBlockForEntry(entry)
 		writePolicy := config.SkillWritePolicyNone
 		writeEnabled := false
 		if configured {
 			writePolicy = block.EffectiveWritePolicy()
 			writeEnabled = block.WriteEnabled()
+		}
+		condition := st.classify(entry)
+		workspace := ""
+		if condition == ConditionConflicted {
+			if path, ok := matchingConflictWorkspace(st, entry); ok {
+				workspace = relativeTo(st.paths.Root, path)
+			}
 		}
 		status.Entries = append(status.Entries, StatusEntry{
 			Name:         entry.Name,
@@ -89,8 +102,9 @@ func buildStatus(st *state) (*Status, error) {
 			Ref:          entry.ResolvedRef,
 			Tracking:     entry.Tracking,
 			WritePolicy:  writePolicy,
-			Condition:    st.classify(entry),
+			Condition:    condition,
 			WriteEnabled: writeEnabled,
+			Workspace:    workspace,
 		})
 	}
 
@@ -124,17 +138,21 @@ func (s *Status) Render(all bool) string {
 		}
 	}
 
-	fmt.Fprintf(&builder, "imported skills: %d total, %d clean, %d modified, %d missing, %d invalid, %d collided\n",
+	fmt.Fprintf(&builder, "imported skills: %d total, %d clean, %d modified, %d missing, %d invalid, %d collided, %d conflicted\n",
 		len(s.Entries), counts[ConditionClean], counts[ConditionModified], counts[ConditionMissing],
-		counts[ConditionInvalid], counts[ConditionCollided])
+		counts[ConditionInvalid], counts[ConditionCollided], counts[ConditionConflicted])
 	fmt.Fprintf(&builder, "tracking: %d tracked, %d pinned, %d write-enabled\n", tracked, pinned, writeEnabled)
 	fmt.Fprintf(&builder, "configured exclusions: %d\n", len(s.Exclusions))
 
 	if all {
 		for _, entry := range s.Entries {
-			fmt.Fprintf(&builder, "%s\t%s\t%s\t%s\t%s\t%s\twrite=%s\n",
+			fmt.Fprintf(&builder, "%s\t%s\t%s\t%s\t%s\t%s\twrite=%s",
 				entry.Name, entry.Condition, entry.Repository, entry.SelectedPath,
 				entry.Ref, entry.Tracking, entry.WritePolicy)
+			if entry.Workspace != "" {
+				fmt.Fprintf(&builder, "\t%s", entry.Workspace)
+			}
+			builder.WriteString("\n")
 		}
 		for _, exclusion := range s.Exclusions {
 			fmt.Fprintf(&builder, "exclusion\t%s\t!%s\n", exclusion.Repository, exclusion.Selector)

--- a/internal/skilllock/skilllock.go
+++ b/internal/skilllock/skilllock.go
@@ -97,9 +97,10 @@ type Entry struct {
 	// TreeHash is the canonical hash of the upstream skill tree at Commit. It is
 	// the immutable merge base; local edits never replace it.
 	TreeHash string `json:"tree_hash"`
-	// Publication records the last tree Agent Layer successfully published to a
-	// contribution destination. It is independent of the source lock so a later
-	// push can reconcile against its own prior result without changing pull or
+	// Publication records the last destination tree Agent Layer can trust as a
+	// merge base: either a successful push, or a destination state reconciled
+	// during conflict resolution. It is independent of the source lock so a
+	// later push can merge against that destination without changing pull or
 	// local-modification semantics.
 	Publication *Publication `json:"publication,omitempty"`
 }

--- a/internal/templates/instructions/00_rules.md
+++ b/internal/templates/instructions/00_rules.md
@@ -25,7 +25,7 @@
 - **Destructive actions:** Never run or recommend destructive operations that can remove or overwrite large amounts of data without explicit confirmation from the user.
 - **Subagents:** Give each subagent a self-contained task and only the context it needs; preserve any intended independence.
 - **Git safety:** Do not stage, unstage, or commit unless authorized by the user's request or an active skill. Authorization is request-specific.
-- **Wait efficiently:** Prefer event-driven waiting for operations that continue without agent input. Wait for completion when possible; otherwise wait for the next meaningful event. Fall back to time-based polling only when no event-driven option exists. When polling, minimize model turns and tokens by checking no more often than meaningful change is expected.
+- **Wait efficiently:** When waiting for an operation that can proceed without agent input, minimize unnecessary model turns and token use. Use an event-driven wait that returns when it completes or another meaningful event occurs; if none is available, poll no more often than meaningful change is expected.
 - **Protect secrets:** Minimize data shared with external tools. Never send secrets or credentials to MCP tools or pass them on the command line; use environment variables or configured credentials.
 - **Missing tokens:** If a tool requires a token and it's missing, instruct the user to set it in `.agent-layer/.env` (never in repo-tracked files).
 
@@ -58,4 +58,4 @@ Repeat the option block as needed. Ask routine questions without meaningful trad
 
 - Be concise.
 - Do not invent terminology.
-- Give the user enough context to respond or act without assuming they have read the code, command output, or prior implementation details.
+- When the user needs to respond or act, include enough context without assuming they have read the code, command output, or prior implementation details.

--- a/internal/templates/manifests/0.17.1.json
+++ b/internal/templates/manifests/0.17.1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "version": "0.17.1",
-  "generated_at_utc": "2026-08-20T16:08:48Z",
+  "generated_at_utc": "2026-08-21T18:22:06Z",
   "files": [
     {
       "path": ".agent-layer/commands.allow",
@@ -145,7 +145,7 @@
     },
     {
       "path": ".agent-layer/skills/ship-pr/SKILL.md",
-      "full_hash_normalized": "7e12f40c0fe5792fdfe06490f92f4779e64a2b4116e89cb5fa458fa330fa8009"
+      "full_hash_normalized": "85a1f5a1a7396a251085c881f1cefb6763548e302850242a0ad667c2c2a919e6"
     },
     {
       "path": ".agent-layer/skills/ship-pr/assets/pr-body-template.md",
@@ -153,11 +153,15 @@
     },
     {
       "path": ".agent-layer/skills/ship-pr/references/address-pr-comments.md",
-      "full_hash_normalized": "d68d2325dcee7060604a0b57d485848fdb326ff0267cf21e011ef78d9016bf90"
+      "full_hash_normalized": "a9b60d0c4f03a6b19e9f956676670211ec4a69af663f3be237d03ff84a84d26b"
     },
     {
       "path": ".agent-layer/skills/ship-pr/references/fix-ci.md",
       "full_hash_normalized": "53f9fd2e3d6189d3fd7a6067c26429048ff49609169804b3686f2791d50d2ec8"
+    },
+    {
+      "path": ".agent-layer/skills/ship-pr/scripts/read-pr-comments.sh",
+      "full_hash_normalized": "89a47a170725a3a813b85626bfb24d2d5f9229d5e38a0dc805c3abc762692503"
     },
     {
       "path": ".agent-layer/skills/ship-pr/scripts/watch-pr-events.sh",
@@ -165,7 +169,7 @@
     },
     {
       "path": ".agent-layer/skills/skill-sync/SKILL.md",
-      "full_hash_normalized": "ac150018fb683be8d82a71eaa1889836c0c2204f915f03380634715de8715dbb",
+      "full_hash_normalized": "c059c06dfbdb309db2b5d0c4b7fddf87e6bbde148e0c38def80681a2ceea02a5",
       "policy_id": "catalog_skills_v1"
     },
     {

--- a/internal/templates/read_pr_comments_test.go
+++ b/internal/templates/read_pr_comments_test.go
@@ -1,0 +1,176 @@
+package templates
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func readPRCommentsScript(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(file), "skills", "ship-pr", "scripts", "read-pr-comments.sh")
+}
+
+func requireJQ(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skipf("jq is required: %v", err)
+	}
+}
+
+func runReadPRComments(t *testing.T, env []string, args ...string) (string, string, error) {
+	t.Helper()
+	cmd := exec.Command("bash", append([]string{readPRCommentsScript(t)}, args...)...)
+	cmd.Env = env
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+func ghStubEnv(t *testing.T, mode string) []string {
+	t.Helper()
+	bin := t.TempDir()
+	stub := filepath.Join(bin, "gh")
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+mode="${GH_STUB_MODE:-ok}"
+if [[ "$mode" == "fail" ]]; then
+  printf 'gh: boom\n' >&2
+  exit 1
+fi
+if [[ "$mode" == "malformed" ]]; then
+  printf '{'
+  exit 0
+fi
+if [[ "$args" == *graphql* ]]; then
+  cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
+  {"isResolved":true,"isOutdated":false,"comments":{"nodes":[{"databaseId":11}]}},
+  {"isResolved":false,"isOutdated":true,"comments":{"nodes":[{"databaseId":13}]}}
+]}}}}}
+JSON
+  exit 0
+fi
+if [[ "$args" == *"/issues/"*"/comments"* ]]; then
+  if [[ "$args" != *"--paginate"* ]]; then
+    printf 'missing --paginate\n' >&2
+    exit 1
+  fi
+  printf '%s\n' '[{"id":1,"html_url":"https://example.test/issue/1","user":{"login":"alex"},"body":"Conversation $(whoami)\n> quoted"}]'
+  printf '%s\n' '[{"id":2,"html_url":"https://example.test/issue/2","user":{"login":"blair"},"body":""}]'
+  exit 0
+fi
+if [[ "$args" == *"/pulls/"*"/comments"* ]]; then
+  if [[ "$args" != *"--paginate"* ]]; then
+    printf 'missing --paginate\n' >&2
+    exit 1
+  fi
+  printf '%s\n' '[{"id":11,"html_url":"https://example.test/inline/11","user":{"login":"riley"},"path":"internal/widget.go","line":42,"side":"RIGHT","pull_request_review_id":21,"body":"Please fix this"}]'
+  printf '%s\n' '[{"id":12,"html_url":"https://example.test/inline/12","user":{"login":"sam"},"in_reply_to_id":11,"path":"internal/widget.go","original_line":42,"original_side":"RIGHT","pull_request_review_id":21,"body":"Done"},{"id":13,"html_url":"https://example.test/inline/13","user":{"login":"riley"},"path":"internal/old.go","original_line":9,"original_side":"LEFT","pull_request_review_id":22,"body":"Still open"}]'
+  exit 0
+fi
+if [[ "$args" == *"/pulls/"*"/reviews"* ]]; then
+  printf '%s\n' '[{"id":21,"html_url":"https://example.test/review/21","user":{"login":"casey"},"state":"CHANGES_REQUESTED","body":"Needs work"}]'
+  exit 0
+fi
+printf 'unexpected gh invocation: %s\n' "$args" >&2
+exit 1
+`
+	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil { // #nosec G306 -- executable test stub requires owner execute permission.
+		t.Fatalf("write gh stub: %v", err)
+	}
+	env := append([]string{}, os.Environ()...)
+	env = append(env, "PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"), "GH_STUB_MODE="+mode)
+	return env
+}
+
+func TestReadPRCommentsRequiresRepoAndPR(t *testing.T) {
+	requireJQ(t)
+	_, stderr, err := runReadPRComments(t, os.Environ())
+	if err == nil || !strings.Contains(stderr, "--repo must be in owner/name form") {
+		t.Fatalf("missing args error = %v, stderr %q", err, stderr)
+	}
+	_, stderr, err = runReadPRComments(t, os.Environ(), "--repo", "not-a-repo", "--pr", "1")
+	if err == nil || !strings.Contains(stderr, "--repo must be in owner/name form") {
+		t.Fatalf("bad repo error = %v, stderr %q", err, stderr)
+	}
+	_, stderr, err = runReadPRComments(t, os.Environ(), "--repo", "o/n", "--pr", "x")
+	if err == nil || !strings.Contains(stderr, "--pr must be a numeric PR number") {
+		t.Fatalf("bad pr error = %v, stderr %q", err, stderr)
+	}
+	_, stderr, err = runReadPRComments(t, os.Environ(), "--repo")
+	if err == nil || !strings.Contains(stderr, "--repo requires a value") {
+		t.Fatalf("missing repo value error = %v, stderr %q", err, stderr)
+	}
+}
+
+func TestReadPRCommentsRendersKindsPaginationRepliesAndQuoting(t *testing.T) {
+	requireJQ(t)
+	out, stderr, err := runReadPRComments(t, ghStubEnv(t, "ok"), "--repo", "acme/widgets", "--pr", "7")
+	if err != nil {
+		t.Fatalf("read-pr-comments: %v\n%s", err, stderr)
+	}
+	for _, fragment := range []string{
+		"# PR comments for acme/widgets #7",
+		"## conversation",
+		"- Author: alex",
+		"- ID: 1",
+		"- URL: https://example.test/issue/1",
+		"> Conversation $(whoami)",
+		"> > quoted",
+		"- Author: blair",
+		"> (empty)",
+		"## review",
+		"- Author: casey",
+		"- Review state: CHANGES_REQUESTED",
+		"> Needs work",
+		"## inline",
+		"- Author: riley",
+		"- ID: 11",
+		"- Thread: resolved=true; outdated=false",
+		"- Path: internal/widget.go",
+		"- Line: 42",
+		"- Side: RIGHT",
+		"- Review ID: 21",
+		"> Please fix this",
+		"## inline-reply",
+		"- Author: sam",
+		"- Reply to: 11",
+		"> Done",
+		"- ID: 13",
+		"- Thread: resolved=false; outdated=true",
+		"> Still open",
+	} {
+		if !strings.Contains(out, fragment) {
+			t.Fatalf("output does not contain %q:\n%s", fragment, out)
+		}
+	}
+	if strings.Count(out, "## inline\n") != 2 {
+		t.Fatalf("expected two inline roots, got:\n%s", out)
+	}
+	if strings.Count(out, "## inline-reply\n") != 1 {
+		t.Fatalf("expected one inline reply via in_reply_to_id, got:\n%s", out)
+	}
+}
+
+func TestReadPRCommentsFailsOnAPIAndMalformedJSON(t *testing.T) {
+	requireJQ(t)
+	_, stderr, err := runReadPRComments(t, ghStubEnv(t, "fail"), "--repo", "acme/widgets", "--pr", "7")
+	if err == nil || !strings.Contains(stderr, "boom") {
+		t.Fatalf("api failure = %v, stderr %q", err, stderr)
+	}
+	_, _, err = runReadPRComments(t, ghStubEnv(t, "malformed"), "--repo", "acme/widgets", "--pr", "7")
+	if err == nil {
+		t.Fatal("malformed JSON succeeded")
+	}
+}

--- a/internal/templates/skills-catalog/skill-sync/SKILL.md
+++ b/internal/templates/skills-catalog/skill-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-sync
-description: Manage local skills backed by known remote Git repositories. Use when the user wants to import, inspect, pull, push, reset, or remove them, or project current local skills to enabled clients with `al sync`. Do not use to discover new skills or create user-owned skills.
+description: Manage local skills backed by known remote Git repositories. Use when the user wants to import, inspect, diff, pull, resolve, push, reset, or remove them, or project current local skills to enabled clients with `al sync`. Do not use to discover new skills or create user-owned skills.
 compatibility: Requires `al` in an initialized Agent Layer project and Git access for remote operations.
 allowed-tools: Bash(al skills *) Bash(al sync)
 ---
@@ -23,17 +23,23 @@ Git. Use `al sync` only to copy the current local skills into enabled client
 directories.
 
 1. Start with `al skills status --all`. It reads local state without using the
-   network.
-2. To import skills, run `al skills add <repository> <selector>... --yes` only
+   network. A `conflicted` skill includes its Git workspace path.
+2. To compare live trees, run `al skills diff <name>` with `--from`/`--to`
+   `base`, `local`, `upstream`, or `destination`. Defaults are local to
+   upstream. The output is an ordinary Git unified diff.
+3. To import skills, run `al skills add <repository> <selector>... --yes` only
    when the user explicitly requests the import and the repository and
    selectors are known. Quote selectors that contain wildcards or start with
    `!`. The command does not search for, recommend, or preview skills. Run `al
    skills add --help` before choosing source, tracking, or publishing options.
-3. To update imported skills, run `al skills pull`. It fetches every configured
+4. To update imported skills, run `al skills pull`. It fetches every configured
    source and merges upstream changes with local edits. Pinned imports stay at
    their locked versions unless their configured `ref` changes. Treat any
-   partial or conflicted result as a failure and report every result.
-4. To stop managing one selector, run `al skills remove <repository>
+   partial or conflicted result as a failure and report every result. For a
+   conflict, finish the Git merge in the workspace named in the error, `git add`
+   the result, then run `al skills resolve <name>`. Do not hand-edit the
+   lockfile.
+5. To stop managing one selector, run `al skills remove <repository>
    <selector> --yes` only when the user explicitly requests the removal, using
    the exact values from `.agent-layer/config.toml`. Skills still matched by
    another selector remain managed. Clean skills that are no longer matched
@@ -61,8 +67,9 @@ destination matches the user's request. If one does not match, stop and ask.
 Do not change write settings silently.
 
 Push uses only configured destinations and branches. It never pulls first,
-force-pushes, or opens a pull request. If it fails, report each failed skill and
-the required action.
+force-pushes, or opens a pull request. A destination merge conflict leaves the
+same kind of Git workspace as pull; finish it with `al skills resolve <name>`
+and rerun push. If it fails, report each failed skill and the required action.
 
 Use existing Git authentication. Repository URLs must not contain literal
 credentials. Use `${AL_*}` placeholders whose values are stored in

--- a/internal/templates/skills/ship-pr/SKILL.md
+++ b/internal/templates/skills/ship-pr/SKILL.md
@@ -9,41 +9,29 @@ description: >-
 
 Invoking this skill authorizes branch creation, staging, commits, pushes, PR
 creation or updates, and eligible comment replies needed to prepare one PR for
-the merge-authorization gate. It does not authorize the merge itself.
+merge. It does not authorize the merge itself.
 
 If `references/repo-specific-pr-policy.md` exists, read it before starting the
 workflow and treat it as authoritative.
 
 ## Inputs
 
-Require a `pr_worker` dispatch target. Use `/dispatch-agent` for every dispatch.
+Require a `pr_worker` dispatch target and use `/dispatch-agent` for every
+dispatch. Relay any additional caller input in every `pr_worker` prompt.
 
-## PR worker
-
-The `pr_worker` fixes review feedback and failed CI checks in the local working
-tree without committing or pushing. It returns proposed comment replies without
-posting them. Relay any additional caller input in every `pr_worker` prompt.
-
-After committing accepted fixes, post each supported reply in its original
-thread, one at a time. Then refetch the reply IDs and URLs. Before closeout,
-correct any reply that current evidence shows is missing or unsupported.
-
-## Determining the intended changes
-
-Unless the user defines a narrower scope, include every change in the current
-working tree in the PR.
+Unless the user narrows the scope, include the entire current working tree.
 
 ## Workflow
 
-1. Create a branch if required by repository norms. Commit the intended changes,
-   push the branch, and create or reuse a PR. Derive the PR title from the
-   intended changes. Fill `assets/pr-body-template.md`, removing placeholders
-   and unused sections.
+1. Create a branch when repository norms require one. Commit the intended
+   changes, push, and create or reuse the PR. Derive its title from the changes
+   and fill `assets/pr-body-template.md`, removing unused sections and
+   placeholders.
 
-2. Start the polling watcher in a managed background session. Keep one watcher
-   running until the PR is merged or the workflow stops, then stop it explicitly.
-   If the watcher ends unexpectedly, refetch authoritative state and restart it
-   with the same append-only log after a transient transport failure.
+2. Start one watcher in a managed background session. Keep it running until the
+   PR merges or the workflow stops, then stop it. If it exits after a transient
+   transport failure, refetch authoritative state and restart it with the same
+   append-only log.
 
    ```bash
    bash <skill_dir>/scripts/watch-pr-events.sh \
@@ -53,15 +41,20 @@ working tree in the PR.
      --interval-seconds 300
    ```
 
-3. Fetch the current head, comments, reviews, checks, and mergeability with
-   `gh`. Never infer current state from the polling log. Determine the next steps
-   based on the following rules:
+3. Fetch the current head, checks, and mergeability with `gh`. Read comments
+   with this stateless command; never infer current state from the watcher log:
 
-   - For unresolved feedback, dispatch `pr_worker` with the exact PR and head,
-     all feedback, and `references/address-pr-comments.md`.
-   - For a failed required check, dispatch `pr_worker` with the exact PR and
-     head, failure evidence, and `references/fix-ci.md`.
-   - Resolve mechanical conflicts automatically.
+   ```bash
+   bash <skill_dir>/scripts/read-pr-comments.sh \
+     --repo <owner/name> \
+     --pr <pr-number>
+   ```
+
+   Dispatch `pr_worker` for unresolved feedback with the exact PR, head, and
+   `references/address-pr-comments.md`; for a failed required check, also
+   provide its evidence and `references/fix-ci.md`. The worker edits the local
+   tree but does not commit, push, or post replies. Resolve mechanical conflicts
+   automatically.
 
    The PR is ready to merge only when:
 
@@ -74,26 +67,24 @@ working tree in the PR.
      is met.
 
    If no agent or human reviewer posts feedback within 10 minutes of PR
-   creation, stop and tell the user that no reviewer feedback was received. If
-   the PR is ready, proceed to step 5. Otherwise, address every actionable item
-   locally before proceeding to step 4. Do not commit midway through a round of
-   fixes.
+   creation, stop and report that no feedback was received. If ready, continue
+   to step 5. Otherwise, address the full actionable round before committing.
 
-4. Commit and push any local fixes, then post supported replies as described
-   above. Return to step 3 until the PR is ready to merge. If nothing is
-   actionable while checks or reviews are pending, wait for the watcher to
-   report a change or reach its next polling interval.
+4. Commit and push accepted fixes. Post each supported worker-proposed reply one
+   at a time: reply natively to inline comments; for conversation comments or
+   review summaries, post an issue comment linking the source. Rerun the comment
+   command and correct any missing or unsupported reply. Return to step 3 until
+   ready. If only checks or reviews are pending, wait for the watcher.
 
 5. Request single-use merge authorization for the exact PR and head. Report any
-   substantive findings, the comment disposition summary, and the evidence that
-   the PR is ready to merge.
+   substantive findings, a concise comment disposition summary, and readiness
+   evidence.
 
-6. After merge authorization, refetch the expected head, checks, mergeability,
-   and comments, then confirm the local tree is complete and every eligible
-   comment has a supported posted reply. If anything changed, return to step 3
-   and obtain fresh merge authorization when reaching step 5. Otherwise, merge
-   the PR.
+6. After authorization, refetch the head, checks, mergeability, and comments.
+   Confirm the local tree is complete and every eligible comment has a supported
+   posted reply. If anything changed, return to step 3 and obtain new
+   authorization for the resulting PR head; otherwise merge.
 
-7. Confirm the checkout is clean, switch to the default branch, and fast-forward
-   it to the latest commit. Delete any branch or worktree created by this
-   workflow. Preserve state and report any unsafe cleanup that was skipped.
+7. Confirm the checkout is clean, switch to the default branch, fast-forward it,
+   and delete branches or worktrees created by this workflow. Preserve state and
+   report any cleanup that is unsafe to perform.

--- a/internal/templates/skills/ship-pr/references/address-pr-comments.md
+++ b/internal/templates/skills/ship-pr/references/address-pr-comments.md
@@ -10,9 +10,16 @@ replies.
 
 ## Workflow
 
-Fetch every comment type and existing native replies from fresh GitHub data.
-Exclude only status or CI messages, factual statements, and verdicts without a
-new request. Stop if no eligible unresolved feedback remains.
+Rerun this command yourself for fresh comment state; do not wait for the caller
+to paste it:
+
+```bash
+bash <skill_dir>/scripts/read-pr-comments.sh --repo <owner/name> --pr <number>
+```
+
+Reason about eligibility and supported replies from that output. Exclude only
+status or CI messages, factual statements, and verdicts without a new request.
+Stop if no eligible unresolved feedback remains.
 
 Validate each remaining comment against the current tree:
 
@@ -28,13 +35,14 @@ Repair accepted root causes and required tests, documentation, or memory. Group
 coupled work and run focused checks. Track deferrals locally without external
 issue creation unless authorized.
 
-Prepare one reply per eligible, unblocked comment:
+Prepare one reply per eligible, unblocked comment, keyed by its stable ID or
+URL:
 
 - **Fixed.** Describe the fix.
 - **No change — `<reason>`.** Give evidence.
 - **Deferred — tracked in `<location>`.** Explain the boundary.
 
 Finish when every eligible comment has a supported disposition and no unblocked
-local work remains. Return counts, stable comment IDs or URLs, dispositions,
-fixes and checks, trackers, proposed replies, blockers, and confirmation that
-nothing was published.
+local work remains. Return dispositions, stable comment IDs or URLs, fixes and
+checks, trackers, proposed replies, blockers, and confirmation that nothing was
+published.

--- a/internal/templates/skills/ship-pr/scripts/read-pr-comments.sh
+++ b/internal/templates/skills/ship-pr/scripts/read-pr-comments.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: read-pr-comments.sh --repo <owner/name> --pr <number>
+
+Fetch every GitHub pull-request conversation comment, review summary, inline
+review comment, and inline reply, including review-thread resolved/outdated
+state, and print readable Markdown. The command writes no files and stores no
+state.
+EOF
+}
+
+repo=""
+pr_number=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      if [[ $# -lt 2 ]]; then
+        printf 'read-pr-comments: --repo requires a value\n' >&2
+        exit 2
+      fi
+      repo="${2:-}"
+      shift 2
+      ;;
+    --pr)
+      if [[ $# -lt 2 ]]; then
+        printf 'read-pr-comments: --pr requires a value\n' >&2
+        exit 2
+      fi
+      pr_number="${2:-}"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'read-pr-comments: unknown argument: %s\n' "$1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! "$repo" =~ ^[^/]+/[^/]+$ ]]; then
+  printf 'read-pr-comments: --repo must be in owner/name form\n' >&2
+  exit 2
+fi
+if [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
+  printf 'read-pr-comments: --pr must be a numeric PR number\n' >&2
+  exit 2
+fi
+for command in gh jq; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    printf 'read-pr-comments: required command not found: %s\n' "$command" >&2
+    exit 2
+  fi
+done
+
+owner="${repo%%/*}"
+name="${repo##*/}"
+
+quote_body() {
+  local body="$1"
+  if [[ -z "$body" ]]; then
+    printf '> (empty)\n'
+    return
+  fi
+  printf '%s\n' "$body" | sed 's/^/> /'
+}
+
+print_item() {
+  local kind="$1"
+  local author="$2"
+  local id="$3"
+  local url="$4"
+  local state="$5"
+  local reply_to="$6"
+  local thread_state="$7"
+  local path="$8"
+  local line="$9"
+  local side="${10}"
+  local review_id="${11}"
+  local body="${12}"
+
+  printf '## %s\n' "$kind"
+  printf -- '- Author: %s\n' "$author"
+  printf -- '- ID: %s\n' "$id"
+  if [[ -n "$url" ]]; then
+    printf -- '- URL: %s\n' "$url"
+  fi
+  if [[ -n "$state" ]]; then
+    printf -- '- Review state: %s\n' "$state"
+  fi
+  if [[ -n "$reply_to" ]]; then
+    printf -- '- Reply to: %s\n' "$reply_to"
+  fi
+  if [[ -n "$thread_state" ]]; then
+    printf -- '- Thread: %s\n' "$thread_state"
+  fi
+  if [[ -n "$path" ]]; then
+    printf -- '- Path: %s\n' "$path"
+  fi
+  if [[ -n "$line" ]]; then
+    printf -- '- Line: %s\n' "$line"
+  fi
+  if [[ -n "$side" ]]; then
+    printf -- '- Side: %s\n' "$side"
+  fi
+  if [[ -n "$review_id" ]]; then
+    printf -- '- Review ID: %s\n' "$review_id"
+  fi
+  printf '\n'
+  quote_body "$body"
+  printf '\n'
+}
+
+issue_comments="$(
+  gh api --paginate "repos/${repo}/issues/${pr_number}/comments?per_page=100" |
+    jq -sc 'add // []'
+)"
+reviews="$(
+  gh api --paginate "repos/${repo}/pulls/${pr_number}/reviews?per_page=100" |
+    jq -sc 'add // []'
+)"
+inline_comments="$(
+  gh api --paginate "repos/${repo}/pulls/${pr_number}/comments?per_page=100" |
+    jq -sc 'add // []'
+)"
+thread_states="$(
+  gh api graphql --paginate \
+    -f owner="$owner" \
+    -f name="$name" \
+    -F number="$pr_number" \
+    -f query='
+query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $endCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          isResolved
+          isOutdated
+          comments(first: 1) {
+            nodes { databaseId }
+          }
+        }
+      }
+    }
+  }
+}' | jq -sc '
+  [.[] | .data.repository.pullRequest.reviewThreads.nodes // []]
+  | add // []
+  | map(select(.comments.nodes[0].databaseId != null) | {
+      key: (.comments.nodes[0].databaseId | tostring),
+      value: "resolved=\(.isResolved); outdated=\(.isOutdated)"
+    })
+  | from_entries
+'
+)"
+
+printf '# PR comments for %s #%s\n\n' "$repo" "$pr_number"
+
+jq -c '.[]' <<<"$issue_comments" | while IFS= read -r item; do
+  print_item \
+    "conversation" \
+    "$(jq -r '.user.login // "(deleted)"' <<<"$item")" \
+    "$(jq -r '.id' <<<"$item")" \
+    "$(jq -r '.html_url // empty' <<<"$item")" \
+    "" \
+    "" \
+    "" \
+    "" \
+    "" \
+    "" \
+    "" \
+    "$(jq -r '.body // empty' <<<"$item")"
+done
+
+jq -c '.[]' <<<"$reviews" | while IFS= read -r item; do
+  print_item \
+    "review" \
+    "$(jq -r '.user.login // "(deleted)"' <<<"$item")" \
+    "$(jq -r '.id' <<<"$item")" \
+    "$(jq -r '.html_url // empty' <<<"$item")" \
+    "$(jq -r '.state // empty' <<<"$item")" \
+    "" \
+    "" \
+    "" \
+    "" \
+    "" \
+    "" \
+    "$(jq -r '.body // empty' <<<"$item")"
+done
+
+jq -c --argjson states "$thread_states" '
+  (map(select(.in_reply_to_id != null) | {(.id | tostring): (.in_reply_to_id | tostring)}) | add // {}) as $parents
+  | def root($id):
+      if ($parents[$id] // null) == null then $id else root($parents[$id]) end;
+  .[]
+  | . + {
+      kind: (if .in_reply_to_id then "inline-reply" else "inline" end),
+      reply_to: (if .in_reply_to_id then (.in_reply_to_id | tostring) else "" end),
+      thread_state: ($states[root(.id | tostring)] // "")
+    }
+' <<<"$inline_comments" | while IFS= read -r item; do
+  print_item \
+    "$(jq -r '.kind' <<<"$item")" \
+    "$(jq -r '.user.login // "(deleted)"' <<<"$item")" \
+    "$(jq -r '.id' <<<"$item")" \
+    "$(jq -r '.html_url // empty' <<<"$item")" \
+    "" \
+    "$(jq -r '.reply_to // empty' <<<"$item")" \
+    "$(jq -r '.thread_state // empty' <<<"$item")" \
+    "$(jq -r '.path // empty' <<<"$item")" \
+    "$(jq -r '.line // .original_line // empty' <<<"$item")" \
+    "$(jq -r '.side // .original_side // empty' <<<"$item")" \
+    "$(jq -r '.pull_request_review_id // empty' <<<"$item")" \
+    "$(jq -r '.body // empty' <<<"$item")"
+done

--- a/site/docs/agent-dispatch.mdx
+++ b/site/docs/agent-dispatch.mdx
@@ -1,0 +1,195 @@
+---
+title: Agent Dispatch
+description: Run and coordinate asynchronous, headless agent conversations through MCP tools or the CLI.
+sidebar_position: 4
+---
+
+Agent Dispatch runs headless provider conversations asynchronously. Use it when one agent needs to delegate a bounded task, or when a person or script needs to start provider work without holding open an interactive session.
+
+It has two surfaces over one backend:
+
+- Agents use tools from Agent Layer's built-in MCP server.
+- Humans and scripts use `al dispatch` commands.
+
+Both surfaces use the same conversation handles, states, result files, continuation behavior, and cancellation semantics.
+
+## In this page
+
+- [How dispatch works](#how-dispatch-works)
+- [MCP tools](#mcp-tools)
+- [CLI commands](#cli-commands)
+- [Conversation lifecycle](#conversation-lifecycle)
+- [Results and errors](#results-and-errors)
+- [Waiting and cancellation](#waiting-and-cancellation)
+- [Configuration](#configuration)
+
+## How dispatch works
+
+Starting a dispatch creates a conversation and its first invocation, then immediately returns an opaque handle. Use that handle to wait for completion, continue the same provider conversation with another prompt, or cancel active work.
+
+Each conversation has at most one running invocation. Parallel work uses independent conversations and handles; there is no fanout operation.
+
+Dispatch distinguishes callers from targets. Any enabled client can call the MCP tools, but only `codex`, `claude`, `antigravity`, and `grok` are valid targets for `agent` or `--agent`. VS Code and Copilot CLI can call dispatch but cannot be dispatched to. A target must be enabled in `.agent-layer/config.toml`; use `dispatch_options` or `al dispatch options` to see what is currently available.
+
+The public lifecycle is intentionally small:
+
+```text
+start -> wait -> completed | failed | cancelled
+                       |
+                       +-> continue -> wait -> ...
+```
+
+`options` is a separate, read-only discovery operation. It reports which providers are available and which model and reasoning-effort overrides each one accepts.
+
+## MCP tools
+
+`al sync` projects a built-in MCP server named `agent-layer` into every enabled Codex, Claude, Antigravity, VS Code, Copilot CLI, and Grok client. The server is derived from Agent Layer configuration, not declared as a `[[mcp.servers]]` entry. Its ID is reserved and cannot be used by a custom server.
+
+The server exposes five Agent Dispatch tools:
+
+| Tool | Purpose |
+| --- | --- |
+| `dispatch_options` | List dispatchable providers and their allowed overrides. |
+| `dispatch_start` | Start a conversation and return its handle immediately. |
+| `dispatch_wait` | Wait for the configured interval, then report the current state. |
+| `dispatch_continue` | Start the next invocation in a terminal conversation. |
+| `dispatch_cancel` | Terminate a running invocation. |
+
+`dispatch_start` accepts an `agent`, optional `model`, `reasoning_effort`, and `skill`, plus exactly one of `prompt` or `prompt_file`. `dispatch_continue` accepts a handle and exactly one prompt source. The wait and cancel tools accept a handle.
+
+The MCP server returns structured results and a serialized text fallback for clients that do not yet consume structured MCP output.
+
+## CLI commands
+
+The CLI exposes the same backend for people and scripts:
+
+```bash
+al dispatch options
+
+al dispatch start --agent codex \
+  [--model <model>] \
+  [--reasoning-effort <effort>] \
+  [--skill <skill>] \
+  (--prompt <text> | --prompt-file <path>)
+
+al dispatch wait <handle>
+
+al dispatch continue <handle> \
+  (--prompt <text> | --prompt-file <path>)
+
+al dispatch cancel <handle>
+```
+
+`start` requires `--agent` and exactly one prompt source. When model or reasoning effort is omitted, Agent Layer uses the configured value; if there is no configured value, the provider uses its own default.
+
+`--prompt-file` avoids shell escaping and command-length limits for substantial prompts. `--skill` names a known user-managed or imported Agent Layer skill. Dispatch prepends the target's native skill invocation to the prompt—for example `$review` for Codex or `/review` for another target. The skill must already be projected for that target; run `al sync` if start reports it missing. `dispatch_continue` does not accept a skill.
+
+`continue` retains the conversation's provider, model, reasoning effort, and provider context. It accepts a new prompt only after the current invocation reaches a terminal state.
+
+Every successful CLI command writes exactly one JSON object to standard output. Diagnostics go to standard error.
+
+A typical CLI flow looks like this:
+
+```bash
+al dispatch start --agent codex --prompt "Summarize docs/AGENT-DISPATCH.md"
+# {"handle":"abc123","state":"running"}
+
+al dispatch wait abc123
+# If the state is still running, wait again with the same handle.
+```
+
+`wait` is bounded rather than “wait until finished.” The CLI returns in at most eight minutes, and the MCP tool returns after `dispatch.mcp_wait_timeout_minutes` (30 by default). If the state is `running`, call `wait` again. Waiting on an already-terminal invocation returns immediately.
+
+## Conversation lifecycle
+
+An invocation has exactly one public state:
+
+```text
+running -> completed | failed | cancelled
+```
+
+Terminal states are immutable. Continuing a terminal conversation creates a new invocation in `running`; it does not rewrite the previous invocation.
+
+| Operation | `running` | `completed` | `failed` | `cancelled` |
+| --- | --- | --- | --- | --- |
+| `wait` | Waits for the bounded interval, then returns `running`. | Returns `result_path`. | Returns the failure. | Returns `cancelled`. |
+| `continue` | Errors. | Starts the next invocation. | Starts the next invocation. | Starts the next invocation. |
+| `cancel` | Cancels the invocation. | Errors: already completed. | Errors: already failed. | Returns `cancelled` successfully. |
+
+Only one invocation can run for a conversation at a time. Concurrent continuation attempts cannot start duplicate provider work.
+
+## Results and errors
+
+`start` and `continue` return the handle and initial state:
+
+```json
+{
+  "handle": "abc123",
+  "state": "running"
+}
+```
+
+A completed wait returns an absolute path to the result:
+
+```json
+{
+  "handle": "abc123",
+  "state": "completed",
+  "result_path": "/absolute/path/to/result.md"
+}
+```
+
+Each invocation has its own immutable Markdown result file. Agent Layer writes that file atomically before reporting `completed`. A completed invocation without a readable result is reported as an error rather than as a false success.
+
+A failed wait includes an actionable error:
+
+```json
+{
+  "handle": "abc123",
+  "state": "failed",
+  "error": "Provider authentication failed"
+}
+```
+
+Failure does not invalidate the conversation. You can continue a failed or cancelled conversation with another prompt.
+
+On the CLI, a failed wait writes this JSON object before exiting non-zero. MCP `dispatch_wait` returns the same failed object as a normal tool result, allowing an agent to inspect the failure and decide what to do next.
+
+## Waiting and cancellation
+
+Waiting is bounded. `al dispatch wait` waits up to eight minutes; `dispatch_wait` uses the configured MCP wait timeout. If work is still active when the interval ends, the operation returns `running` without changing the invocation. Wait again with the same handle.
+
+Abandoning a wait because of a client timeout, disconnect, cancelled tool call, or Ctrl-C during `al dispatch wait` stops only that wait. Provider work continues. Only `dispatch_cancel` or `al dispatch cancel` terminates the active invocation.
+
+Cancellation is idempotent after a successful cancellation. It cannot change a completed or failed invocation into `cancelled`.
+
+`dispatch_options` and `dispatch_wait` are marked read-only. `dispatch_start`, `dispatch_continue`, and `dispatch_cancel` are marked destructive because dispatched work can change the environment. An MCP client may require approval before calling them.
+
+:::caution Transport acknowledgement
+An MCP start or continue call acknowledges work that runs independently. If the transport disconnects after provider work starts but before the caller receives the response, the work remains active and the caller may not know its handle. Recovery evidence remains under `.agent-layer/tmp/runs/`.
+:::
+
+There is no public list or inspect command. If the caller never receives the handle, provider work can continue; `.agent-layer/tmp/runs/` is diagnostic evidence, not a supported handle-recovery interface. Prefer the CLI when a human needs to retain the handle directly.
+
+## Configuration
+
+The optional `[dispatch]` section controls nesting and MCP timeouts:
+
+```toml
+[dispatch]
+max_depth = 3
+mcp_wait_timeout_minutes = 30
+mcp_tool_timeout_minutes = 40
+```
+
+- `max_depth` limits nested dispatch and defaults to 3.
+- `mcp_wait_timeout_minutes` controls how long one `dispatch_wait` call blocks before returning `running`. It defaults to 30.
+- `mcp_tool_timeout_minutes` is the server-side hard limit for every dispatch MCP tool call. It defaults to 40 and must be greater than the wait timeout.
+
+Inside an already-dispatched conversation, prefer the client's built-in subagent for further delegation. A blocked nested start fails rather than queuing. `max_depth` counts the initial start, so the default of 3 permits that start and two nested starts.
+
+Codex and Grok also receive the hard tool timeout as per-server `tool_timeout_sec`. Agent Layer does not set Claude Code's client-wide `MCP_TOOL_TIMEOUT`, because doing so would affect unrelated MCP servers. Antigravity has no per-server timeout key, so the Agent Layer server-side bound remains its recovery limit.
+
+Dispatch honors the repository's configured agents, models, reasoning effort, approvals, environment isolation, and pinned Agent Layer version. Use [`al dispatch options`](./reference#dispatch) to inspect the resolved provider choices before starting work.
+
+For exact configuration fields and CLI summaries, see [Reference](./reference). For the internal implementation contract, see [`docs/AGENT-DISPATCH.md`](https://github.com/conn-castle/agent-layer/blob/main/docs/AGENT-DISPATCH.md).

--- a/site/docs/concepts.mdx
+++ b/site/docs/concepts.mdx
@@ -18,6 +18,7 @@ One important design choice follows from that: Agent Layer is repo-local. Differ
 - [Per-repo isolation](#per-repo-credential-isolation)
 - [Approvals and safety](#approvals-and-safety)
 - [MCP servers](#mcp-servers)
+- [Agent Dispatch](#agent-dispatch)
 - [Project memory](#project-memory)
 - [Version pinning](#version-pinning)
 
@@ -321,6 +322,12 @@ Skills are synced natively to Agent Skills directories with full subdirectory su
 :::tip
 Start with one or two servers, verify with `al doctor`, then expand. It is easier to trust your agents when the tool surface is deliberate and scoped.
 :::
+
+## Agent Dispatch
+
+Agent Dispatch lets an agent, person, or script start a headless provider conversation and coordinate it asynchronously. Starting work returns a handle immediately; callers use that handle to wait for a result, continue the same conversation, or cancel active work. Independent handles make parallel delegation possible without coupling the conversations. Valid dispatch targets are Codex, Claude, Antigravity, and Grok; other enabled clients can call the tools but are not targets.
+
+Agents access dispatch through Agent Layer's built-in `agent-layer` MCP server, while humans and scripts use matching `al dispatch` commands. Both surfaces share the same lifecycle and results. See [Agent Dispatch](./agent-dispatch) for the tools, commands, states, timeouts, and configuration.
 
 ## Project memory
 

--- a/site/docs/getting-started.mdx
+++ b/site/docs/getting-started.mdx
@@ -281,12 +281,14 @@ If you only remember one pattern: `al <client>` is the “do the right thing” 
 | `al vscode` | Sync and launch VS Code. | [Launch a client](./reference#launch-a-client) |
 | `al copilot` | Sync and launch Copilot CLI. | [Launch a client](./reference#launch-a-client) |
 | `al grok` | Sync and launch Grok. | [Launch a client](./reference#launch-a-client) |
+| `al dispatch` | Start, wait for, continue, or cancel a headless provider conversation. | [Agent Dispatch](./agent-dispatch) |
 | `al --version` | Print the installed version. | [Help and version](./reference#help-and-version) |
 | `al help` | Show help for a command. | [Help and version](./reference#help-and-version) |
 
 ## Next steps
 
 - Read [Concepts](./concepts) to understand the mental model, safety boundaries, and how MCP servers fit into the system.
+- Use [Agent Dispatch](./agent-dispatch) to delegate asynchronous, headless provider work through MCP tools or the CLI.
 - Use [Reference](./reference) when you are ready to tune configuration, wire secrets, or understand exactly what a CLI command touches.
 - Read [Upgrades](./upgrades) for the upgrade contract, compatibility guarantees, and migration rules.
 - Visit [Troubleshooting](./troubleshooting) when something does not work; start with `al doctor`.

--- a/site/docs/overview.mdx
+++ b/site/docs/overview.mdx
@@ -10,7 +10,7 @@ Agent Layer is a small CLI that keeps AI-assisted development consistent across 
 
 The payoff is fewer surprises: the same repo behaves the same whether you launch Antigravity, Claude, Codex, Copilot CLI, Grok, or VS Code. No copying configuration between clients. No gradual drift. Just one place to review and refine how your agents work.
 
-Start with [Getting started](./getting-started), then use [Concepts](./concepts) and [Reference](./reference) as you customize. Use [Best Practices](/best-practices) when you are writing skills, CLI skills, or always-loaded instructions, and [Skills approach](./skills-approach) for Agent Layer's own skill model. [Troubleshooting](./troubleshooting) is a fast path when something breaks.
+Start with [Getting started](./getting-started), then use [Concepts](./concepts) and [Reference](./reference) as you customize. Use [Agent Dispatch](./agent-dispatch) when you want to delegate headless provider work through MCP tools or the CLI. Use [Best Practices](/best-practices) when you are writing skills, CLI skills, or always-loaded instructions, and [Skills approach](./skills-approach) for Agent Layer's own skill model. [Troubleshooting](./troubleshooting) is a fast path when something breaks.
 For upgrade policy, compatibility guarantees, and migration rules, use [Upgrades](./upgrades).
 
 ## What you get
@@ -33,11 +33,12 @@ For upgrade policy, compatibility guarantees, and migration rules, use [Upgrades
 1. [Getting started](./getting-started) - run your first agent
 2. [Concepts](./concepts) - learn the mental model and safety boundaries
 3. [Reference](./reference) - config, environment variables, and CLI behavior
-4. [Skills](./skills) - built-in workflows for planning, debugging, shipping, and more
-5. [Skills approach](./skills-approach) - Agent Layer's skill ethos and target root-skill model
-6. [Best Practices](/best-practices) - universal skill, CLI skill, and instruction design guides
-7. [Troubleshooting](./troubleshooting) - common errors and fixes
-8. [Upgrades](./upgrades) - upgrade event model, compatibility guarantees, and migration rules
+4. [Agent Dispatch](./agent-dispatch) - asynchronous, headless provider delegation
+5. [Skills](./skills) - built-in workflows for planning, debugging, shipping, and more
+6. [Skills approach](./skills-approach) - Agent Layer's skill ethos and target root-skill model
+7. [Best Practices](/best-practices) - universal skill, CLI skill, and instruction design guides
+8. [Troubleshooting](./troubleshooting) - common errors and fixes
+9. [Upgrades](./upgrades) - upgrade event model, compatibility guarantees, and migration rules
 
 ## Documentation map
 
@@ -47,11 +48,15 @@ Install Agent Layer, initialize your first repo, and understand what gets genera
 
 ### [Concepts](./concepts)
 
-The mental model and safety boundaries that keep agents consistent. Includes: [Single source of truth](./concepts#single-source-of-truth), [Approvals and safety](./concepts#approvals-and-safety), [MCP servers](./concepts#mcp-servers), [Project memory](./concepts#project-memory), and [Version pinning](./concepts#version-pinning).
+The mental model and safety boundaries that keep agents consistent. Includes: [Single source of truth](./concepts#single-source-of-truth), [Approvals and safety](./concepts#approvals-and-safety), [MCP servers](./concepts#mcp-servers), [Agent Dispatch](./concepts#agent-dispatch), [Project memory](./concepts#project-memory), and [Version pinning](./concepts#version-pinning).
 
 ### [Reference](./reference)
 
 Authoritative configuration, environment variables, and CLI behavior. Includes: [Configuration](./reference#configuration), [Environment variables](./reference#environment-variables), and the [CLI guide](./reference#cli-guide).
+
+### [Agent Dispatch](./agent-dispatch)
+
+Asynchronous, headless provider conversations for agents, people, and scripts. Includes: [MCP tools](./agent-dispatch#mcp-tools), [CLI commands](./agent-dispatch#cli-commands), the [conversation lifecycle](./agent-dispatch#conversation-lifecycle), and [timeouts and cancellation](./agent-dispatch#waiting-and-cancellation).
 
 ### [Skills](./skills)
 

--- a/site/docs/reference.mdx
+++ b/site/docs/reference.mdx
@@ -16,6 +16,7 @@ Agent Layer is explicit by design. It prefers failing fast over guessing, treats
 - [Configuration](#configuration)
 - [Environment variables](#environment-variables)
 - [CLI guide](#cli-guide)
+- [Dispatch](#dispatch)
 - [Skill import commands](#skill-import-commands)
 
 ## Configuration
@@ -45,8 +46,8 @@ max_depth = 3
 # conversation is still running. Optional; defaults to 30.
 mcp_wait_timeout_minutes = 30
 # Hard bound on every Agent Dispatch MCP tool call, also projected as Codex's
-# per-server `tool_timeout_sec`. Optional; defaults to 40. Must be greater than
-# mcp_wait_timeout_minutes.
+# and Grok's per-server `tool_timeout_sec`. Optional; defaults to 40. Must be
+# greater than mcp_wait_timeout_minutes.
 mcp_tool_timeout_minutes = 40
 
 [notifications]
@@ -191,7 +192,7 @@ Supported agents:
 
 Agent Layer always projects one built-in MCP server, `agent-layer`, into every
 enabled Codex, Claude, Antigravity, VS Code, Copilot CLI, and Grok client. It serves
-the Agent Dispatch tools (see [Agent Dispatch](https://github.com/conn-castle/agent-layer/blob/main/docs/AGENT-DISPATCH.md)),
+the Agent Dispatch tools (see [Agent Dispatch](./agent-dispatch)),
 is derived from your configuration rather than declared in it, and appears in
 generated permission allowlists alongside your own servers. Its `agent-layer`
 ID is reserved and cannot be used by a `[[mcp.servers]]` entry.
@@ -429,6 +430,7 @@ The command surface is intentionally small. Most of the time you only need one r
 | `al wizard` | Interactive configuration plus profile mode (`--profile`) and backup cleanup (`--cleanup-backups`). |
 | `al sync` | Regenerate client configs without launching a client. |
 | `al <client>` | Sync and launch a client (agy/claude/codex/copilot/grok/vscode). |
+| `al dispatch options` | List dispatchable agents and their allowed overrides. |
 | `al dispatch start` | Start a headless conversation asynchronously and return its handle. |
 | `al dispatch wait <handle>` | Wait up to eight minutes; return `running` if work continues, otherwise return the terminal result. |
 | `al dispatch continue <handle>` | Start another invocation in a terminal conversation. |
@@ -436,7 +438,9 @@ The command surface is intentionally small. Most of the time you only need one r
 | `al skills add <repository> <selector>... [--yes]` | Import skills from a Git repository and project them. |
 | `al skills remove <repository> <selector> [--yes]` | Remove one configured import selector and recompute the desired set. |
 | `al skills status` | Report local imported-skill state. Local and network-free; `--all` expands it. |
+| `al skills diff <name>` | Compare two live skill sides (`base`, `local`, `upstream`, `destination`) as a Git unified diff. |
 | `al skills pull` | Fetch configured sources, reconcile them with local content, and project the results. |
+| `al skills resolve <name>` | Apply the staged Git index of a conflict workspace from a conflicted pull or push. |
 | `al skills reset <name> [--yes]` | Permanently discard one imported skill's local edits and accept its current configured upstream version. |
 | `al skills push [--yes]` | Publish local imported-skill changes to configured destinations. |
 | `al probe agy` | Run the Antigravity capability probe and print JSON. |
@@ -741,7 +745,13 @@ al vscode --no-sync -- --reuse-window
 
 ### Dispatch
 
-Agent Dispatch is a fully asynchronous, stateful interface.
+Agent Dispatch is a fully asynchronous, stateful interface with two surfaces over
+one backend: MCP tools for agents and `al dispatch` commands for humans and scripts.
+The MCP tools are served by the built-in `agent-layer` MCP server, which `al sync`
+projects into every enabled client. It exposes `dispatch_options`,
+`dispatch_start`, `dispatch_wait`, `dispatch_continue`, and `dispatch_cancel`.
+Valid dispatch targets are `codex`, `claude`, `antigravity`, and `grok`; VS Code
+and Copilot CLI can call the MCP tools but are not dispatch targets.
 
 ```bash
 al dispatch options
@@ -765,8 +775,8 @@ failed-invocation exit.
 
 The agent-facing interface contains read-only `options` plus `start`, `wait`,
 `continue`, and `cancel`. Parallel work uses independent conversation handles
-rather than a fanout resource. See `docs/AGENT-DISPATCH.md` in the repository
-for the complete contract.
+rather than a fanout resource. See [Agent Dispatch](./agent-dispatch) for the
+complete lifecycle, MCP interface, timeout behavior, and configuration.
 
 ### Skill import commands
 
@@ -776,7 +786,9 @@ for the complete contract.
 al skills add https://github.com/example/skills.git skills/reviewer
 al skills add https://github.com/example/skills.git "skills/*" --ref v1.4.0
 al skills status --all
+al skills diff reviewer
 al skills pull
+al skills resolve reviewer
 al skills reset reviewer
 al skills push
 al skills remove https://github.com/example/skills.git skills/reviewer
@@ -790,11 +802,11 @@ Keep imported skills and the lockfile tracked and commit them together so clones
 and CI retain the imported content and publication checkpoints. Agent Layer never
 stages or commits your repository.
 
-`add`, `pull`, `reset`, and `push` contact remote repositories. `remove`
-contacts one whenever the block keeps a selector so newly revealed membership
-can be resolved at the current source target. Removing a block's last positive
-selector is the only `remove` that stays local. `status`, `al sync`, and agent
-launch are always local.
+`add`, `pull`, `reset`, `push`, and `diff` (when a requested side is remote)
+contact remote repositories. `remove` contacts one whenever the block keeps a
+selector so newly revealed membership can be resolved at the current source
+target. Removing a block's last positive selector is the only `remove` that
+stays local. `status`, `resolve`, `al sync`, and agent launch are always local.
 
 **add** validates the selectors you name, creates or extends the one block with
 a matching policy, performs the initial pull for a new block, and projects the
@@ -812,16 +824,30 @@ so `remove` contacts the remote unless it is removing the block's last positive
 selector. A block left without a positive selector is removed.
 
 **status** is local and read-only. Its default output summarizes total, clean,
-modified, missing, invalid, and collided skills plus tracking and write policy
-counts. `--all` expands it to one entry per resolved skill and lists the
-configured exclusions.
+modified, missing, invalid, collided, and conflicted skills plus tracking and
+write policy counts. `--all` expands it to one entry per resolved skill, lists
+the configured exclusions, and includes the Git workspace path of an active
+matching conflict.
+
+**diff** prints an ordinary Git unified diff between two live sides of one
+imported skill. Supported sides are `base` (the locked source tree), `local`
+(the live imported tree), `upstream` (the current configured source target),
+and `destination` (the current configured push destination tree). Defaults are
+local to upstream. Fetch runs only for sides that require it. Identical trees
+produce no output. For a pinned import, `upstream` is the current ref tip even
+though ordinary pull does not follow that tip until the configured ref changes.
+The destination side requires a writable import whose configured branch exists;
+an absent skill path on that branch is an empty tree.
 
 **pull** is the only command that advances tracked imports. It merges the locked
 upstream tree, your current local tree, and the new upstream tree, so local
 edits survive an update. A change on one side applies cleanly; incompatible
 changes to the same path, delete/modify cases, and non-text files changed on
-both sides are reported as conflicts and fail only that skill. Pinned imports
-stay put unless you change the configured ref, which is reconciled as a
+both sides are reported as conflicts and fail only that skill. Every conflict
+leaves a Git workspace under `.agent-layer/tmp/skill-conflicts/<name>/` with
+`base`, `local`, and `upstream` branches. Finish the merge with ordinary git
+commands, `git add` the result, and run `al skills resolve <name>`. Pinned
+imports stay put unless you change the configured ref, which is reconciled as a
 retarget rather than a removal plus addition.
 
 Each skill uses its own lock entry as the upstream merge base. Members declared
@@ -839,13 +865,23 @@ commit, stash, copy, or backup. Resetting a pinned branch deliberately repins it
 at the branch's current commit; ordinary pull leaves that new pin fixed. Reset
 prompts before discarding edits; non-interactive callers must pass `--yes`.
 
+**resolve** applies the staged Git index of a conflict workspace. Unmerged
+entries and unstaged tracked changes are refused; untracked mergetool files are
+ignored. A pull resolution writes the staged tree and advances the recorded
+upstream lock. A push resolution writes the staged tree locally and records the
+reconciled destination head as the publication checkpoint without moving the
+source lock; rerun `al skills push` afterwards. Successful resolve removes the
+workspace and projects the imported skill.
+
 **push** publishes local changes to each block's configured destination. It
 never pulls first and never force-pushes. Changes for one destination
 repository and branch are committed and pushed together. For a tracked import,
 push first verifies the source ref is still at the locked commit and tells you
-to run `al skills pull` if it moved. Push prompts before publication;
-non-interactive callers must pass `--yes`. `add` and `remove` use the same
-confirmation pattern before modifying import configuration.
+to run `al skills pull` if it moved. A destination merge conflict leaves the
+same kind of Git workspace as pull, with `base`, `local`, and `destination`
+branches. Push prompts before publication; non-interactive callers must pass
+`--yes`. `add` and `remove` use the same confirmation pattern before modifying
+import configuration.
 
 The first push reconciles against the locked source tree. After publication,
 the lock entry separately records the exact destination commit and tree, which

--- a/site/docs/reference.mdx
+++ b/site/docs/reference.mdx
@@ -773,10 +773,10 @@ file named by `result_path`. Every successful command returns exactly one JSON
 object; `wait` also writes its terminal JSON result before a non-zero
 failed-invocation exit.
 
-The agent-facing interface contains read-only `options` plus `start`, `wait`,
-`continue`, and `cancel`. Parallel work uses independent conversation handles
-rather than a fanout resource. See [Agent Dispatch](./agent-dispatch) for the
-complete lifecycle, MCP interface, timeout behavior, and configuration.
+The agent-facing interface contains read-only `options` and `wait`, plus
+`start`, `continue`, and `cancel`. Parallel work uses independent conversation
+handles rather than a fanout resource. See [Agent Dispatch](./agent-dispatch)
+for the complete lifecycle, MCP interface, timeout behavior, and configuration.
 
 ### Skill import commands
 
@@ -846,9 +846,11 @@ changes to the same path, delete/modify cases, and non-text files changed on
 both sides are reported as conflicts and fail only that skill. Every conflict
 leaves a Git workspace under `.agent-layer/tmp/skill-conflicts/<name>/` with
 `base`, `local`, and `upstream` branches. Finish the merge with ordinary git
-commands, `git add` the result, and run `al skills resolve <name>`. Pinned
-imports stay put unless you change the configured ref, which is reconciled as a
-retarget rather than a removal plus addition.
+commands, `git add` the result, and run `al skills resolve <name>`. If that
+workspace is stale or unreadable, Agent Layer will not replace it; move or
+remove the directory, then retry pull or push. Pinned imports stay put unless
+you change the configured ref, which is reconciled as a retarget rather than a
+removal plus addition.
 
 Each skill uses its own lock entry as the upstream merge base. Members declared
 together may therefore remain at different commits after partial success.

--- a/site/docs/skills-approach.mdx
+++ b/site/docs/skills-approach.mdx
@@ -1,7 +1,7 @@
 ---
 title: Skills approach
 description: Agent Layer's skill ethos and bundled root skill model.
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 This page defines Agent Layer's root-skill and workflow architecture.

--- a/site/docs/skills.mdx
+++ b/site/docs/skills.mdx
@@ -191,9 +191,12 @@ half-replaced skill.
 A conflict leaves a Git workspace under `.agent-layer/tmp/skill-conflicts/<name>/`.
 Finish the merge with ordinary git commands, `git add` the result, and run
 `al skills resolve <name>`. Agent Layer applies the staged index after verifying
-that the recorded lock and configuration still match. `al skills diff <name>`
-prints an ordinary Git diff of live `base`, `local`, `upstream`, or
-`destination` trees.
+that the recorded lock and configuration still match. If that workspace is stale
+or unreadable — for example after `al skills reset`, or after the lock or
+configuration changed — later pull or push commands refuse to replace it. Move
+or remove `.agent-layer/tmp/skill-conflicts/<name>/`, then retry `al skills pull`
+or `al skills push`. `al skills diff <name>` prints an ordinary Git diff of live
+`base`, `local`, `upstream`, or `destination` trees.
 
 The generated `.agent-layer/.gitignore` ignores only
 `.agent-layer/skills-imported/.staging/`, the transaction scratch space. Keep

--- a/site/docs/skills.mdx
+++ b/site/docs/skills.mdx
@@ -1,7 +1,7 @@
 ---
 title: Skills
 description: Structured workflows that give agents repeatable, multi-phase processes for common development tasks.
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 Agent skills are structured Markdown workflows that guide AI coding agents through complex, multi-step tasks. Instead of describing what you want step by step, you invoke a skill and the agent follows a tested process with built-in quality gates.
@@ -133,7 +133,7 @@ tools and has no external binary requirement.
 
 | Skill | What it does |
 | --- | --- |
-| `dispatch-agent` | Uses the Agent Dispatch MCP tools only when the user names an external dispatch target or another skill explicitly requires dispatch; it has no external binary requirement. |
+| `dispatch-agent` | Uses the built-in [Agent Dispatch](./agent-dispatch) MCP tools only when the user names an external dispatch target or another skill explicitly requires dispatch; it has no external binary requirement. |
 | `find-docs` | Uses Context7 for current API and library documentation when local docs or CLI help are insufficient. |
 | `playwright` | Uses `playwright-cli` for browser automation, screenshots, user interface inspection, and Playwright test work. |
 | `tavily-web` | Uses Tavily CLI for web search, URL extraction, site mapping, and cited research. |
@@ -174,6 +174,7 @@ without losing your edits, and contribute changes back.
 ```bash
 al skills add https://github.com/example/skills.git skills/reviewer
 al skills status
+al skills diff reviewer
 al skills pull
 ```
 
@@ -186,6 +187,13 @@ valid, that one skill fails and its content is left untouched — the rest of th
 repository still imports. If a run is interrupted part way through, the next
 `al skills` or `al sync` command rolls it back, so you never end up with a
 half-replaced skill.
+
+A conflict leaves a Git workspace under `.agent-layer/tmp/skill-conflicts/<name>/`.
+Finish the merge with ordinary git commands, `git add` the result, and run
+`al skills resolve <name>`. Agent Layer applies the staged index after verifying
+that the recorded lock and configuration still match. `al skills diff <name>`
+prints an ordinary Git diff of live `base`, `local`, `upstream`, or
+`destination` trees.
 
 The generated `.agent-layer/.gitignore` ignores only
 `.agent-layer/skills-imported/.staging/`, the transaction scratch space. Keep
@@ -246,7 +254,8 @@ reconciles upstream changes, so a change made on the destination branch is
 preserved rather than overwritten. If the destination branch removed a skill
 entirely, that removal is preserved too: the push reports the skill as
 unchanged when your copy still matches what you imported, and reports a
-conflict when you had also edited it.
+conflict when you had also edited it. Finish a destination conflict in its Git
+workspace with `al skills resolve`, then rerun push.
 
 After a successful contribution-branch push, Agent Layer records that exact
 published tree as a separate destination checkpoint. Running `al skills push`

--- a/site/docs/troubleshooting.mdx
+++ b/site/docs/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 description: Fix common install, configuration, and MCP server issues.
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 Use this page when installs fail, configs do not validate, or MCP servers do not connect. Most issues are configuration or PATH-related, so start with a quick triage before diving deeper. The goal is to get you back to a predictable state without guessing.

--- a/site/docs/upgrade-checklist.mdx
+++ b/site/docs/upgrade-checklist.mdx
@@ -1,7 +1,7 @@
 ---
 title: Upgrade checklist
 description: One-page upgrade checklist for interactive teams and CI.
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 Use this page when you want a repeatable, low-risk upgrade runbook.

--- a/site/docs/upgrades.mdx
+++ b/site/docs/upgrades.mdx
@@ -1,7 +1,7 @@
 ---
 title: Upgrades
 description: Upgrade contract, compatibility guarantees, migration rules, and platform support.
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 This page is the canonical upgrade contract for Agent Layer.


### PR DESCRIPTION
## Summary

- Add `al skills diff <name>` command to compare live base, local, upstream, and destination trees as an ordinary Git diff.
- Add conflict resolution workspaces under `.agent-layer/tmp/skill-conflicts/<name>/` and `al skills resolve <name>` to complete pull/push merges with ordinary git tools.
- Add `read-pr-comments.sh` to the `ship-pr` skill template to inspect PR comments and review thread status.
- Add Agent Dispatch and skill sync documentation.

## Changes

- `cmd/al/skills.go`, `internal/skillimport/diff.go`: implement `al skills diff` with support for comparing base, local, upstream, and destination.
- `internal/skillimport/conflict.go`, `internal/gitrepo/workspace.go`: create Git conflict workspaces when pull/push encounters merge conflicts; implement `al skills resolve`.
- `internal/skillimport/push.go`: reuse prior publication checkpoint when recreating a deleted contribution branch.
- `internal/templates/skills/ship-pr/scripts/read-pr-comments.sh`: add readable markdown PR comment inspection tool with thread status.
- `site/docs/agent-dispatch.mdx`, `docs/AGENT-DISPATCH.md`, `site/docs/*`: add documentation for agent dispatch and updated skill sync workflow.

## Verification

- `make fmt-check` — passed
- `make test` — all 4402 tests passed
- `pre-commit run --all-files` — all hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `al skills diff` for comparing skill versions or sources.
  * Added `al skills resolve` for completing pull and push conflict resolution.
  * Added readable pull-request comment reporting.
  * Added Agent Dispatch documentation and CLI guidance.
* **Bug Fixes**
  * Improved documentation redirects when versioned content is removed.
  * Preserved publication checkpoints when contribution branches are recreated.
* **Documentation**
  * Expanded guidance for conflict workspaces, status reporting, remote comparisons, timeouts, and dispatch workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->