### PR TITLE
fix: canonicalize codex trust repo root through symlinks

### DIFF
--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -39,12 +39,6 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
     Description: `make dev` runs full formatting, linting, global coverage enforcement, DeepSWE verification, and release test suites sequentially, taking several minutes per invocation and slowing local iteration.
     Next step: Profile individual target durations in `make dev` and evaluate separating fast local iteration from full whole-repo verification.
 
-- Issue 2026-08-18 codex-trust-symlink-path: Codex trust uses a lexical rather than canonical repository path
-    Priority: Low. Area: providers / codex / trust
-    Description: Codex trust seeding uses `filepath.Abs` without resolving symlinks, so a repository opened through a symlink may not match the client-observed canonical path.
-    Next step: Reproduce at the installed Codex boundary and canonicalize the trust key with regression coverage if confirmed.
-    Notes: Found while fixing the equivalent Grok integration defect; outside the Grok change scope.
-
 - Issue 2026-08-05 coverage-remainder-is-error-injection-only: Coverage above ~91.4% requires failure-injection tests
     Priority: Low. Area: test suite / coverage
     Description: After a behavior-focused pass raised total coverage from 90.02% to 91.42%, every remaining uncovered region is a block of 1–5 statements. They are overwhelmingly `if err != nil` wrappers around filesystem, git, and process calls, plus platform-unreachable branches (device/socket nodes in skilltree.describeNode, non-finite floats that `encoding/json` cannot decode, and defensive duplicate-selector checks that config validation already rejects). No untested feature-level behavior remains in a single block larger than 5 statements.

--- a/internal/sync/codex.go
+++ b/internal/sync/codex.go
@@ -305,7 +305,11 @@ func codexTrustedProjectRoot(root string) (string, error) {
 		bad, _ := utf8.DecodeRuneInString(absRoot[idx:])
 		return "", fmt.Errorf(messages.SyncCodexTrustRootControlCharFmt, absRoot, bad)
 	}
-	return absRoot, nil
+	canonicalRoot, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		return "", fmt.Errorf(messages.SyncCodexTrustRootResolveFailedFmt, absRoot, err)
+	}
+	return canonicalRoot, nil
 }
 
 func appendCodexTrustedProject(builder *strings.Builder, repoRoot string, agentSpecific map[string]any) error {

--- a/internal/sync/codex.go
+++ b/internal/sync/codex.go
@@ -288,6 +288,20 @@ func codexTrustedProjectRoot(root string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf(messages.SyncCodexTrustRootResolveFailedFmt, root, err)
 	}
+	if err := validateCodexTrustedProjectRoot(absRoot); err != nil {
+		return "", err
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		return "", fmt.Errorf(messages.SyncCodexTrustRootResolveFailedFmt, absRoot, err)
+	}
+	if err := validateCodexTrustedProjectRoot(canonicalRoot); err != nil {
+		return "", err
+	}
+	return canonicalRoot, nil
+}
+
+func validateCodexTrustedProjectRoot(root string) error {
 	// fmt %q (used to encode the `[projects.<root>]` TOML key) emits Go escapes
 	// for control characters (e.g. \x00, \a, \v, \x1b, \x85) and for invalid
 	// UTF-8 bytes (e.g. \xff) that are NOT valid TOML basic-string escapes. A
@@ -298,18 +312,14 @@ func codexTrustedProjectRoot(root string) (string, error) {
 	// Check invalid UTF-8 first: on Unix, paths are arbitrary byte sequences, and
 	// strings.IndexFunc decodes invalid bytes as utf8.RuneError (which is not a
 	// control rune), so the control-char scan alone would miss them.
-	if !utf8.ValidString(absRoot) {
-		return "", fmt.Errorf(messages.SyncCodexTrustRootInvalidUTF8Fmt, absRoot)
+	if !utf8.ValidString(root) {
+		return fmt.Errorf(messages.SyncCodexTrustRootInvalidUTF8Fmt, root)
 	}
-	if idx := strings.IndexFunc(absRoot, unicode.IsControl); idx >= 0 {
-		bad, _ := utf8.DecodeRuneInString(absRoot[idx:])
-		return "", fmt.Errorf(messages.SyncCodexTrustRootControlCharFmt, absRoot, bad)
+	if idx := strings.IndexFunc(root, unicode.IsControl); idx >= 0 {
+		bad, _ := utf8.DecodeRuneInString(root[idx:])
+		return fmt.Errorf(messages.SyncCodexTrustRootControlCharFmt, root, bad)
 	}
-	canonicalRoot, err := filepath.EvalSymlinks(absRoot)
-	if err != nil {
-		return "", fmt.Errorf(messages.SyncCodexTrustRootResolveFailedFmt, absRoot, err)
-	}
-	return canonicalRoot, nil
+	return nil
 }
 
 func appendCodexTrustedProject(builder *strings.Builder, repoRoot string, agentSpecific map[string]any) error {

--- a/internal/sync/codex_config_merge_test.go
+++ b/internal/sync/codex_config_merge_test.go
@@ -17,9 +17,9 @@ import (
 func TestWriteCodexConfig_MergesSharedStateAndIsIdempotent(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	absRoot, err := filepath.Abs(root)
+	absRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
-		t.Fatalf("abs root: %v", err)
+		t.Fatalf("canonical root: %v", err)
 	}
 	writeExistingCodexConfig(t, root, "# user note\n"+codexHeader+`
 model = "old-model"
@@ -178,9 +178,9 @@ func TestWriteCodexConfig_InlineTableProjectsSeedConflictFailsWithActionableErro
 func TestWriteCodexConfig_InlineTableProjectsWithTrustedRootSucceeds(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	absRoot, err := filepath.Abs(root)
+	absRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
-		t.Fatalf("abs root: %v", err)
+		t.Fatalf("canonical root: %v", err)
 	}
 	// The trusted root is already present in the inline table, so no header is
 	// appended and the config is left valid (no false shape conflict).
@@ -1136,9 +1136,9 @@ func TestWriteCodexConfig_PreservesExistingQuotedProjectTrust(t *testing.T) {
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		t.Fatalf("mkdir root: %v", err)
 	}
-	absRoot, err := filepath.Abs(root)
+	absRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
-		t.Fatalf("abs root: %v", err)
+		t.Fatalf("canonical root: %v", err)
 	}
 	writeExistingCodexConfig(t, root, codexPartialHeader+`
 [projects.`+tomlpatch.FormatKey(absRoot)+`]

--- a/internal/sync/codex_coverage_test.go
+++ b/internal/sync/codex_coverage_test.go
@@ -178,6 +178,39 @@ func TestCodexTrustedProjectRoot_RejectsEmptyRoot(t *testing.T) {
 	}
 }
 
+func TestCodexTrustedProjectRoot_RejectsMissingRoot(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join(t.TempDir(), "missing")
+	if _, err := codexTrustedProjectRoot(root); err == nil || !strings.Contains(err.Error(), "failed to resolve repo root") {
+		t.Fatalf("missing repo root error = %v", err)
+	}
+}
+
+func TestCodexTrustedProjectRoot_ResolvesSymlinks(t *testing.T) {
+	t.Parallel()
+	parent := t.TempDir()
+	realRoot := filepath.Join(parent, "real")
+	if err := os.Mkdir(realRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	linkedRoot := filepath.Join(parent, "linked")
+	if err := os.Symlink(realRoot, linkedRoot); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	got, err := codexTrustedProjectRoot(linkedRoot)
+	if err != nil {
+		t.Fatalf("codexTrustedProjectRoot: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(realRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("trusted root = %q, want canonical path %q", got, want)
+	}
+}
+
 // TestCodexTrustedProjectRoot_RejectsControlChars asserts the fail-loud guard:
 // a repo root containing a control character that fmt %q would escape into an
 // invalid TOML basic-string escape (e.g. \x00, \a, \v, \x1b) must abort with an
@@ -216,6 +249,9 @@ func TestCodexTrustedProjectRoot_RejectsInvalidUTF8(t *testing.T) {
 func TestCodexTrustedProjectRoot_AcceptsPrintablePath(t *testing.T) {
 	t.Parallel()
 	root := filepath.Join(t.TempDir(), `repo"quote`)
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	resolved, err := codexTrustedProjectRoot(root)
 	if err != nil {
 		t.Fatalf("unexpected error for printable path: %v", err)

--- a/internal/sync/codex_coverage_test.go
+++ b/internal/sync/codex_coverage_test.go
@@ -1,8 +1,10 @@
 package sync
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -211,6 +213,58 @@ func TestCodexTrustedProjectRoot_ResolvesSymlinks(t *testing.T) {
 	}
 }
 
+func TestCodexTrustedProjectRoot_RejectsUnsafeSymlinkTarget(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name        string
+		targetName  string
+		wantMessage string
+	}{
+		{name: "control character", targetName: "real\a", wantMessage: "contains a control character"},
+		{name: "invalid UTF-8", targetName: "real\xff", wantMessage: "contains invalid UTF-8 bytes"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			parent := t.TempDir()
+			realRoot := filepath.Join(parent, test.targetName)
+			if err := os.Mkdir(realRoot, 0o700); err != nil {
+				t.Skipf("cannot create unsafe symlink target: %v", err)
+			}
+			linkedRoot := filepath.Join(parent, "linked")
+			if err := os.Symlink(realRoot, linkedRoot); err != nil {
+				t.Skipf("symlinks unavailable: %v", err)
+			}
+
+			if _, err := codexTrustedProjectRoot(linkedRoot); err == nil || !strings.Contains(err.Error(), test.wantMessage) {
+				t.Fatalf("unsafe symlink target error = %v, want message containing %q", err, test.wantMessage)
+			}
+		})
+	}
+}
+
+func TestCodexTrustedProjectRoot_CanonicalizesDarwinPrivateTmp(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-specific /tmp canonicalization")
+	}
+	root, err := os.MkdirTemp("/tmp", "agent-layer-codex-trust-")
+	if err != nil {
+		t.Skipf("cannot create repository root beneath /tmp: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(root); err != nil {
+			t.Errorf("remove temporary repository root: %v", err)
+		}
+	})
+
+	got, err := codexTrustedProjectRoot(root)
+	if err != nil {
+		t.Fatalf("codexTrustedProjectRoot: %v", err)
+	}
+	want := filepath.Join("/private", root)
+	if got != want {
+		t.Fatalf("trusted root = %q, want macOS canonical path %q", got, want)
+	}
+}
+
 // TestCodexTrustedProjectRoot_RejectsControlChars asserts the fail-loud guard:
 // a repo root containing a control character that fmt %q would escape into an
 // invalid TOML basic-string escape (e.g. \x00, \a, \v, \x1b) must abort with an
@@ -221,10 +275,12 @@ func TestCodexTrustedProjectRoot_RejectsControlChars(t *testing.T) {
 	t.Parallel()
 	base := t.TempDir()
 	for _, ctrl := range []rune{0x00, '\a', '\v', 0x1b, 0x85} {
-		root := filepath.Join(base, "repo"+string(ctrl)+"x")
-		if _, err := codexTrustedProjectRoot(root); err == nil {
-			t.Fatalf("expected error for repo root containing control char U+%04X", ctrl)
-		}
+		t.Run(fmt.Sprintf("U+%04X", ctrl), func(t *testing.T) {
+			root := filepath.Join(base, "repo"+string(ctrl)+"x")
+			if _, err := codexTrustedProjectRoot(root); err == nil || !strings.Contains(err.Error(), "contains a control character") {
+				t.Fatalf("control-character path error = %v", err)
+			}
+		})
 	}
 }
 
@@ -237,8 +293,8 @@ func TestCodexTrustedProjectRoot_RejectsControlChars(t *testing.T) {
 func TestCodexTrustedProjectRoot_RejectsInvalidUTF8(t *testing.T) {
 	t.Parallel()
 	root := filepath.Join(t.TempDir(), "repo\xffx")
-	if _, err := codexTrustedProjectRoot(root); err == nil {
-		t.Fatalf("expected error for repo root containing invalid UTF-8 bytes")
+	if _, err := codexTrustedProjectRoot(root); err == nil || !strings.Contains(err.Error(), "contains invalid UTF-8 bytes") {
+		t.Fatalf("invalid-UTF-8 path error = %v", err)
 	}
 }
 

--- a/internal/sync/codex_test.go
+++ b/internal/sync/codex_test.go
@@ -194,9 +194,12 @@ func TestBuildCodexConfigHeaderPrecedesModelSettings(t *testing.T) {
 
 func TestBuildCodexConfigAgentSpecificDifferentProjectDoesNotSuppressTrust(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "repo")
-	absRoot, err := filepath.Abs(root)
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	absRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
-		t.Fatalf("abs root: %v", err)
+		t.Fatalf("canonical root: %v", err)
 	}
 	otherRoot := absRoot + "-other"
 	project := &config.ProjectConfig{
@@ -249,9 +252,12 @@ func TestBuildCodexConfigAgentSpecificDifferentProjectDoesNotSuppressTrust(t *te
 
 func TestBuildCodexConfigAgentSpecificSameProjectSuppressesManagedTrust(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "repo")
-	absRoot, err := filepath.Abs(root)
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	absRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
-		t.Fatalf("abs root: %v", err)
+		t.Fatalf("canonical root: %v", err)
 	}
 	project := &config.ProjectConfig{
 		Config: config.Config{

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -335,6 +335,11 @@ func assertFileEquals(t *testing.T, expectedPath string, actualPath string, repo
 		t.Fatalf("read actual %s: %v", actualPath, err)
 	}
 	expectedContent := strings.ReplaceAll(string(expected), "__REPO_ROOT__", repoRoot)
+	canonicalRepoRoot, err := filepath.EvalSymlinks(repoRoot)
+	if err != nil {
+		t.Fatalf("canonicalize repo root: %v", err)
+	}
+	expectedContent = strings.ReplaceAll(expectedContent, "__CANONICAL_REPO_ROOT__", canonicalRepoRoot)
 	if expectedContent != string(actual) {
 		t.Fatalf("mismatch for %s", actualPath)
 	}

--- a/internal/sync/testdata/fixture-repo/expected/.codex/config.toml
+++ b/internal/sync/testdata/fixture-repo/expected/.codex/config.toml
@@ -12,7 +12,7 @@ direct_only_tool_namespaces = ['mcp__agent_layer']
 [tui]
 status_line = ['model-with-reasoning', 'context-used', 'weekly-limit', 'thread-id', 'git-branch', 'branch-changes', 'pull-request-number', 'current-dir']
 
-[projects."__REPO_ROOT__"]
+[projects."__CANONICAL_REPO_ROOT__"]
 trust_level = "trusted"
 
 [mcp_servers."agent-layer"]


### PR DESCRIPTION
## Summary

- Codex trust seeding used a lexical absolute path, so a repository opened through a symlink produced a trust key that never matched the workspace the installed Codex CLI actually sees (it identifies a workspace by its physical path).
- `codexTrustedProjectRoot` now canonicalizes the validated absolute path with `filepath.EvalSymlinks`, so the managed `[projects."..."]` key matches the client-observed path.
- Resolves Issue `2026-08-18 codex-trust-symlink-path`.

## Changes

- `internal/sync/codex.go`: resolve symlinks after absolute-path validation; fail explicitly via `SyncCodexTrustRootResolveFailedFmt` when resolution is impossible (for example a missing repo root) rather than emitting a stale trust key.
- `internal/sync/codex.go`: the UTF-8 and control-character guard is extracted into `validateCodexTrustedProjectRoot` and applied to **both** the lexical absolute path and the canonical path. A printable symlink can point at a physical path containing unsafe bytes, which `fmt %q` would escape into an invalid TOML basic-string escape and reject the entire generated config. The lexical check is retained so paths `EvalSymlinks` would fail on with an opaque syscall error (e.g. an embedded NUL) still produce the actionable message.
- `internal/sync/testdata/fixture-repo/expected/.codex/config.toml`: golden trust key placeholder changed from `__REPO_ROOT__` to `__CANONICAL_REPO_ROOT__`, with `assertFileEquals` expanding it from the canonicalized repo root.
- Regression coverage: symlinked repository roots resolve to the canonical path, unsafe symlink targets (control character and invalid UTF-8) are rejected, missing roots fail loudly, macOS `/tmp` canonicalizes to `/private/tmp`, and the config-merge tests assert canonical trust keys.
- `docs/agent-layer/ISSUES.md`: removed the now-resolved issue entry.

## Verification

- `go build ./...` — passed
- `go test ./internal/sync` — passed
- `go test ./...` (via pre-commit) — passed
- `golangci-lint`, `gofmt + goimports`, `go mod tidy` (via pre-commit) — passed
- `make dev` — 4,411 tests, 90.00% coverage, all release checks passed
- `git diff --check` — clean

## Notes

- Because canonicalization requires the path to exist, the trust helper now fails on a missing repo root instead of silently emitting an unresolvable key. This is the intended fail-loud behavior and is covered by a new test.
- The invalid-UTF-8 symlink-target regression skips on filesystems that reject such path bytes (e.g. macOS APFS) and runs on Linux CI.
- Mirrors the equivalent fix already applied to the Grok trust integration.