### PR TITLE
fix: make dev a fast formatting and lint loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ GO_CACHE ?= $(CACHE_ROOT)/go-build
 GO_MOD_CACHE ?= $(CACHE_ROOT)/go-mod
 GOLANGCI_LINT_CACHE ?= $(ROOT_DIR)/.cache/golangci-lint
 
-GO_FILES_FIND_CMD := find . -type f -name '*.go' -not -path './.tools/*' -not -path './.cache/*' -not -path './.claude/*' -not -path './.codex/*' -not -path './.gemini/*' -not -path './.agy/*' -not -path './.antigravitycli/*' -not -path './.agents/*' -not -path './.agent-layer/*' -not -path './tmp/*'
+# Prune excluded directory roots before descent; -not -path still traverses them.
+GO_FILES_FIND_CMD := find . \( -path './.git' -o -path './.tools' -o -path './.cache' -o -path './.claude' -o -path './.codex' -o -path './.gemini' -o -path './.agy' -o -path './.antigravitycli' -o -path './.agents' -o -path './.agent-layer' -o -path './tmp' \) -prune -o -type f -name '*.go'
 
 COVERAGE_THRESHOLD ?= 90.0
 
@@ -285,13 +286,9 @@ test-e2e-ci: ## Run e2e tests for CI (online downloads, upgrade scenarios requir
 ci: tidy-check fmt-check lint dead-code coverage test-deepswe-planner test-race test-release test-e2e-harness test-e2e-ci docs-cta-check ## Run CI checks locally
 
 .PHONY: dev
-dev: ## Fast local checks during development (format + lint + coverage + release tests)
+dev: ## Fast local formatting and lint loop
 	@$(MAKE) fmt
-	@$(MAKE) fmt-check
 	@$(MAKE) lint
-	@$(MAKE) coverage
-	@$(MAKE) test-deepswe-planner
-	@$(MAKE) test-release
 
 # Local dev targets — run al subcommands against this repo's own .agent-layer using source
 AL_RUN := GOCACHE="$(GO_CACHE)" GOMODCACHE="$(GO_MOD_CACHE)" go run ./cmd/al

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -30,7 +30,7 @@ This repo is built around determinism: the same inputs should produce the same c
 ## Daily workflow
 - Use the commands in `docs/agent-layer/COMMANDS.md` for format, lint, test, coverage, and release builds.
 - Prefer `make` targets (see `docs/agent-layer/COMMANDS.md`) instead of running `goimports` / `golangci-lint` directly; tools are installed repo-locally under `.tools/bin` so you do not need to edit your shell PATH. This avoids “works on my machine” drift and keeps local output aligned with CI.
-- Use `make dev` for a quick local pass (format + fmt-check + lint + coverage + release tests). Run `./scripts/setup.sh` or `make tools` first.
+- Use `make dev` for the fast local formatting and lint loop. Run `./scripts/setup.sh` or `make tools` first. Use `make test` or `make coverage` for the global test and coverage gates, and `make ci` as the complete local/pre-PR verification command (hosted CI runs the same target).
 - **Template sources live in `internal/templates/`**, not in `.agent-layer/`. The `.agent-layer/` directory is the *install output* created by `al init`/`al upgrade` in target repos. When adding or editing templates (instructions, memory files, skills, config), always edit the source in `internal/templates/`. If you change installer templates, run `al upgrade` in a target repo to apply the updated templates. When testing from this source repo's scratch target (`tmp/dev-repo`), use `go run ../../cmd/al upgrade` (or `go run ../../cmd/al init` for a fresh repo).
 - If template-managed file semantics change for release upgrades, regenerate the release manifest: `./scripts/generate-template-manifest.sh --tag vX.Y.Z`.
 - If you change upgrade behavior or upgrade-facing guidance, update the canonical upgrade contract page at `site/docs/upgrades.mdx` and keep release notes/docs links aligned.
@@ -143,16 +143,16 @@ Guarantees worth knowing before running it with `--apply`:
 
 ## Run checks locally
 ```bash
-# Quick pass (format + fmt-check + lint + coverage + release tests)
+# Fast formatting and lint loop
 make dev
 
-# Targeted checks (optional)
+# Targeted or global tests and coverage
 make test
-make lint
 make coverage
 ```
 Notes:
-- `make dev` includes coverage and `test-release`; use `make test` when you want a faster loop without the coverage gate and release checks.
+- `make dev` formats Go source and runs golangci-lint. It does not run tests, coverage, or the full CI suite.
+- Use `make test` for the global test suite and `make coverage` to enforce the coverage gate.
 - `make test` uses `gotestsum` for more readable output (installed via `make tools`).
 - `make lint` and `make test` fail fast if tools are missing; run `make tools` once per clone.
 
@@ -161,7 +161,7 @@ Notes:
 make ci
 make release-dist AL_VERSION=ci DIST_DIR=dist
 ```
-Note: `make ci` includes `make tidy-check`, which fails if `go.mod` or `go.sum` would change. While you are actively editing dependencies, use `make test`, `make lint`, and `make coverage` instead. `make ci` expects tools to be installed via `make tools`. The `make release-dist ...` command mirrors CI's dry-run release artifact build.
+Note: `make ci` is the complete local/pre-PR verification gate and the same target hosted CI runs. It includes `make tidy-check`, which fails if `go.mod` or `go.sum` would change. While you are actively editing dependencies, use `make test`, `make lint`, and `make coverage` instead. `make ci` expects tools to be installed via `make tools`. The `make release-dist ...` command mirrors CI's dry-run release artifact build.
 
 ## Managing bundled instructions
 

--- a/docs/agent-layer/COMMANDS.md
+++ b/docs/agent-layer/COMMANDS.md
@@ -193,16 +193,17 @@ make coverage
 ```
 Run from: repo root  
 Prerequisites: Go 1.26.0+
-Notes: Canonical local/CI parity command for coverage. `make dev` and `make ci` both route through this target, and GitHub Actions runs `make ci`.
+Notes: Canonical local/CI parity command for coverage. `make ci` routes through this target, and GitHub Actions runs `make ci`.
 
 ### Dev
 
-- Primary local test command (format + fmt-check + lint + coverage + release tests)
+- Fast local formatting and lint loop
 ```bash
 make dev
 ```
 Run from: repo root
 Prerequisites: Go 1.26.0+, `make tools` has been run
+Notes: Formats Go source and runs golangci-lint. Does not run tests, coverage, or the full CI suite. Use `make test` or `make coverage` for those gates, and `make ci` as the complete local/pre-PR verification command (GitHub Actions also runs `make ci`).
 
 - Run al subcommands against this repo's own .agent-layer using the source tree
 ```bash
@@ -238,13 +239,13 @@ Notes: Prints JSON describing a contained `grok` run under `.agent-layer/tmp/pro
 
 ### CI
 
-- Run CI checks locally
+- Run CI checks locally (complete pre-PR verification gate)
 ```bash
 make ci
 ```
 Run from: repo root
 Prerequisites: Go 1.26.0+, `make tools` has been run
-Notes: Includes `make tidy-check`, `make test-race` (race detector on concurrency-critical packages), `make test-release`, `make test-e2e-ci` (online e2e with required upgrade scenarios), and `make docs-cta-check`; requires network access for upgrade binary downloads. `tidy-check` permits an existing intended diff, reports a validation failure when `go mod tidy` changes the module files, and propagates dependency, toolchain, network, and filesystem errors.
+Notes: The complete local/pre-PR verification command; GitHub Actions runs the same target. Includes `make tidy-check`, `make fmt-check`, `make lint`, `make dead-code`, `make coverage`, `make test-deepswe-planner`, `make test-race` (race detector on concurrency-critical packages), `make test-release`, `make test-e2e-harness`, `make test-e2e-ci` (online e2e with required upgrade scenarios), and `make docs-cta-check`; requires network access for upgrade binary downloads. `tidy-check` permits an existing intended diff, reports a validation failure when `go mod tidy` changes the module files, and propagates dependency, toolchain, network, and filesystem errors.
 GitHub Actions also runs a separate website build job using `make website-build-check` against `conn-castle/agent-layer-web`.
 The release workflow runs this target on macOS before importing signing credentials.
 

--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -29,11 +29,6 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
 
 <!-- ENTRIES START -->
 
-- Issue 2026-08-21 make-dev-slow-execution-time: make dev execution time is excessively slow for local workflows
-    Priority: Medium. Area: developer experience / build tooling
-    Description: `make dev` runs full formatting, linting, global coverage enforcement, DeepSWE verification, and release test suites sequentially, taking several minutes per invocation and slowing local iteration.
-    Next step: Profile individual target durations in `make dev` and evaluate separating fast local iteration from full whole-repo verification.
-
 - Issue 2026-08-05 coverage-remainder-is-error-injection-only: Coverage above ~91.4% requires failure-injection tests
     Priority: Low. Area: test suite / coverage
     Description: After a behavior-focused pass raised total coverage from 90.02% to 91.42%, every remaining uncovered region is a block of 1–5 statements. They are overwhelmingly `if err != nil` wrappers around filesystem, git, and process calls, plus platform-unreachable branches (device/socket nodes in skilltree.describeNode, non-finite floats that `encoding/json` cannot decode, and defensive duplicate-selector checks that config validation already rejects). No untested feature-level behavior remains in a single block larger than 5 statements.

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -149,6 +149,7 @@ expected_version="v1.0.0"
 expected_version_no_v="${expected_version#v}"
 
 run_workflow_consistency_tests
+run_dev_loop_consistency_tests
 run_release_generation_test
 run_build_invocation_details
 run_artifact_verification

--- a/scripts/test-release/workflow_tests.sh
+++ b/scripts/test-release/workflow_tests.sh
@@ -177,12 +177,11 @@ run_dev_loop_consistency_tests() {
     fail "dev-loop: make ci prerequisites changed (got: $ci_prereqs)"
   fi
 
-  dev_recipe=$(printf '%s\n' "$make_db" | awk '
+  dev_recipe=$(awk '
     /^dev:/ { target = 1; next }
-    target && /^#[[:space:]]+commands to execute/ { recipe = 1; next }
-    recipe && /^\t/ { sub(/^\t/, ""); print; next }
-    recipe { exit }
-  ')
+    target && /^\t/ { sub(/^\t/, ""); print; next }
+    target { exit }
+  ' "$ROOT_DIR/Makefile")
   if [[ "$dev_recipe" == $'@$(MAKE) fmt\n@$(MAKE) lint' ]]; then
     pass "dev-loop: make dev runs formatting and lint only"
   else

--- a/scripts/test-release/workflow_tests.sh
+++ b/scripts/test-release/workflow_tests.sh
@@ -156,3 +156,57 @@ run_workflow_consistency_tests() {
     fail "workflow-consistency: CHANGELOG.md missing (required by release workflow for release notes)"
   fi
 }
+
+run_dev_loop_consistency_tests() {
+  section "Dev Loop Consistency Tests"
+
+  local make_db make_status ci_prereqs dev_recipe fmt_dry
+  if make_db=$(make -C "$ROOT_DIR" -qp --no-builtin-rules --no-builtin-variables 2>/dev/null); then
+    make_status=0
+  else
+    make_status=$?
+  fi
+  if (( make_status > 1 )); then
+    fail "dev-loop: could not inspect the make database (exit $make_status)"
+    return
+  fi
+  ci_prereqs=$(printf '%s\n' "$make_db" | awk '/^ci:/{print; exit}')
+  if [[ "$ci_prereqs" == "ci: tidy-check fmt-check lint dead-code coverage test-deepswe-planner test-race test-release test-e2e-harness test-e2e-ci docs-cta-check" ]]; then
+    pass "dev-loop: make ci retains the complete verification prerequisites"
+  else
+    fail "dev-loop: make ci prerequisites changed (got: $ci_prereqs)"
+  fi
+
+  dev_recipe=$(printf '%s\n' "$make_db" | awk '
+    /^dev:/ { target = 1; next }
+    target && /^#[[:space:]]+commands to execute/ { recipe = 1; next }
+    recipe && /^\t/ { sub(/^\t/, ""); print; next }
+    recipe { exit }
+  ')
+  if [[ "$dev_recipe" == $'@$(MAKE) fmt\n@$(MAKE) lint' ]]; then
+    pass "dev-loop: make dev runs formatting and lint only"
+  else
+    fail "dev-loop: make dev must run formatting and lint only (got: $dev_recipe)"
+  fi
+
+  if ! fmt_dry=$(make -C "$ROOT_DIR" -n --no-builtin-rules --no-builtin-variables fmt 2>&1); then
+    fail "dev-loop: could not inspect make fmt"
+    return
+  fi
+  if [[ "$fmt_dry" != *"-prune"* || "$fmt_dry" == *"-not -path"* ]]; then
+    fail "dev-loop: formatting discovery must prune excluded directory roots"
+  else
+    local root missing_root=""
+    for root in .git .tools .cache .claude .codex .gemini .agy .antigravitycli .agents .agent-layer tmp; do
+      if [[ "$fmt_dry" != *"-path './$root'"* ]]; then
+        missing_root="$root"
+        break
+      fi
+    done
+    if [[ -n "$missing_root" ]]; then
+      fail "dev-loop: formatting discovery does not prune ./$missing_root"
+    else
+      pass "dev-loop: formatting discovery prunes every excluded directory root"
+    fi
+  fi
+}

--- a/site/pages/contributing.mdx
+++ b/site/pages/contributing.mdx
@@ -31,7 +31,7 @@ make dev
 
 Run from: repo root
 
-If you want a faster loop, use `make test` while you iterate and `make dev` before you open a PR.
+`make dev` is the fast formatting and lint loop. Use `make test` or `make coverage` for the global test and coverage gates, and run `make ci` before you open a PR. Hosted CI also runs `make ci`.
 
 ## Template and sync changes
 


### PR DESCRIPTION
## Summary

- `make dev` is now a fast formatting-and-lint loop (~3s) instead of a multi-minute chain that also ran `fmt-check`, `coverage`, `test-deepswe-planner`, and `test-release`.
- `make ci` keeps every prerequisite and the 90.0% coverage threshold unchanged and is documented as the complete pre-PR verification gate.
- Go-file discovery prunes excluded directory roots before descending instead of walking them and discarding results.
- Resolves Issue 2026-08-21 `make-dev-slow-execution-time`.

## Changes

- `Makefile`: `dev` now runs `make fmt` then `make lint` only. `GO_FILES_FIND_CMD` switched from `-not -path` filters to a `\( ... \) -prune -o -type f -name '*.go'` expression, adding `./.git` to the pruned roots. Every call site already appends `-print0`, so the action binds to the non-pruned branch and pruned directories are not emitted.
- `scripts/test-release/workflow_tests.sh`: new `run_dev_loop_consistency_tests` asserts the exact `make dev` recipe, the complete `make ci` prerequisite list, and that formatting discovery prunes each excluded root (and uses no `-not -path`). Wired into `scripts/test-release.sh`.
- `docs/DEVELOPMENT.md`, `docs/agent-layer/COMMANDS.md`, `site/pages/contributing.mdx`: distinguish the fast `make dev` loop, `make test`/`make coverage` for the test and coverage gates, and `make ci` as the complete local/pre-PR gate that hosted CI also runs. `COMMANDS.md` now lists the full `make ci` prerequisite set.
- `docs/agent-layer/ISSUES.md`: removed the resolved issue entry.

## Verification

- `make dev` — passed, `3.3s` wall clock (was several minutes).
- `make test-release` — 102 total, 102 passed, 0 failed, including the 3 new `dev-loop:` checks.
- Go-file discovery parity: old and new `find` expressions both return 567 files.

## Notes

- No CI coverage or gates were weakened; the `dev-loop` regression checks fail if the `make ci` prerequisite list or the prune contract regresses.
- No CHANGELOG entry: this is internal developer tooling with no end-user-visible behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Developer Experience**
  * Simplified the development workflow so the fast local loop focuses on formatting and linting.
  * Preserved comprehensive testing, coverage, and CI verification as separate commands.
  * Improved file discovery performance by skipping excluded directories during traversal.

* **Documentation**
  * Clarified local development, testing, coverage, and pre-PR verification guidance.
  * Updated contribution and command references to identify the complete CI workflow.

* **Testing**
  * Added release checks to verify development and CI workflow consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->