### PR TITLE
test: skip permission fixtures when privileges bypass mode bits

### DIFF
--- a/docs/agent-layer/ISSUES.md
+++ b/docs/agent-layer/ISSUES.md
@@ -35,12 +35,6 @@ Deferred defects, maintainability refactors, technical debt, risks, and engineer
     Open question: whether a higher coverage threshold is worth adding fault-injection seams (an injectable filesystem or forced-error hooks) to the packages that currently call `os` directly.
     Notes: `internal/agentdispatch` (~430 missed) and `internal/benchmark` (~300 missed) hold most of the remainder; both are dominated by provider/Docker orchestration failure paths.
 
-- Issue 2026-08-04 permission-based-test-fixtures-assume-non-root: chmod-driven failure fixtures silently pass under root
-    Priority: Low. Area: test suite
-    Description: Pre-existing tests in internal/install and internal/clients drive production error paths by removing a directory's write bit. A process with CAP_DAC_OVERRIDE — root in many containers — writes anyway, so the operation under test succeeds and the assertion fails for an environment reason. CI runs on ubuntu-latest as a non-root user, so nothing currently fails.
-    Next step: If root execution is ever supported, add one shared writability probe helper and apply it to every chmod-based fixture rather than to individual tests.
-    Notes: The skill-import fixtures raised in PR #170 were removed or replaced with deterministic injected failures; this issue now covers only the older remaining fixtures.
-
 - Issue 2026-07-28 dispatch-mcp-start-transport-window: An MCP dispatch_start disconnect can orphan a handle
     Priority: Medium. Area: Agent Dispatch MCP interface
     Description: `dispatch_start` is an RPC acknowledgement rather than a direct write to the caller's terminal. If the transport disconnects after the backend starts but before the client observes the response, the dispatch keeps running durably while the caller never learns its handle. This slice deliberately added no idempotency state and no listing API.

--- a/internal/clients/runner_test.go
+++ b/internal/clients/runner_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/conn-castle/agent-layer/internal/config"
 	"github.com/conn-castle/agent-layer/internal/run"
+	"github.com/conn-castle/agent-layer/internal/testutil"
 	"github.com/conn-castle/agent-layer/internal/update"
 	"github.com/conn-castle/agent-layer/internal/updatewarn"
 )
@@ -135,6 +136,7 @@ func TestRunSyncError(t *testing.T) {
 	t.Cleanup(func() {
 		_ = os.Chmod(root, 0o700) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
 	})
+	testutil.SkipIfWritable(t, root)
 
 	err := Run(context.Background(), root, "antigravity", func(cfg *config.Config) *bool {
 		return cfg.Agents.Antigravity.Enabled

--- a/internal/install/install_gitignore_test.go
+++ b/internal/install/install_gitignore_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/conn-castle/agent-layer/internal/gitenv"
 	"github.com/conn-castle/agent-layer/internal/templates"
+	"github.com/conn-castle/agent-layer/internal/testutil"
 )
 
 func TestRenderGitignoreBlock_UsesSyncGuidance(t *testing.T) {
@@ -431,6 +432,8 @@ func TestWriteGitignoreBlock_WriteError(t *testing.T) {
 	if err := os.Mkdir(dir, 0o500); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, dir)
 	path := filepath.Join(dir, "gitignore.block")
 
 	err := writeGitignoreBlock(RealSystem{}, path, "gitignore.block", 0o644, nil, nil)
@@ -478,6 +481,7 @@ func TestEnsureGitignore_WriteNewError(t *testing.T) {
 		t.Fatalf("chmod: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(root, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, root)
 
 	err := EnsureGitignore(RealSystem{}, path, "block")
 	if err == nil {
@@ -498,6 +502,7 @@ func TestEnsureGitignore_WriteUpdateError(t *testing.T) {
 		t.Fatalf("chmod: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(root, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, root)
 
 	err := EnsureGitignore(RealSystem{}, path, "new block")
 	if err == nil {
@@ -551,6 +556,7 @@ func TestWriteGitignoreBlock_OverwriteWriteError(t *testing.T) {
 		t.Fatalf("chmod: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(root, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, root)
 
 	prompt := func(path string) (bool, error) {
 		return true, nil

--- a/internal/install/install_run_test.go
+++ b/internal/install/install_run_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/conn-castle/agent-layer/internal/templates"
+	"github.com/conn-castle/agent-layer/internal/testutil"
 )
 
 func TestRunCreatesStructure(t *testing.T) {
@@ -704,6 +705,7 @@ func TestWriteVersionFile_WriteError(t *testing.T) {
 		t.Fatalf("chmod: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(filepath.Dir(path), 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, filepath.Dir(path))
 
 	inst := &installer{root: root, pinVersion: "1.0.0", sys: RealSystem{}}
 	err := inst.writeVersionFile()

--- a/internal/install/install_templates_test.go
+++ b/internal/install/install_templates_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/conn-castle/agent-layer/internal/templates"
+	"github.com/conn-castle/agent-layer/internal/testutil"
 )
 
 func TestWriteTemplateIfMissingExisting(t *testing.T) {
@@ -240,6 +241,7 @@ func TestWriteTemplateFile_StatError(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, dir)
 
 	path := filepath.Join(dir, "config.toml")
 	err := writeTemplateFile(RealSystem{}, path, "config.toml", 0o644, nil)
@@ -297,6 +299,7 @@ func TestWriteTemplateFiles_WriteError(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(alDir, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, alDir)
 
 	inst := &installer{root: root, sys: RealSystem{}}
 	err := inst.templates().writeTemplateFiles()
@@ -323,6 +326,7 @@ func TestWriteTemplateDirs_WriteError(t *testing.T) {
 		t.Fatalf("chmod: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(instrDir, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, instrDir)
 
 	inst := &installer{root: root, sys: RealSystem{}}
 	err := inst.templates().writeTemplateDirs()
@@ -346,6 +350,7 @@ func TestWriteTemplateFile_WriteAfterOverwriteError(t *testing.T) {
 		t.Fatalf("chmod: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(root, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, root)
 
 	prompt := func(p string) (bool, error) {
 		return true, nil // Agree to overwrite
@@ -493,6 +498,7 @@ func TestWriteTemplateDirCached_Error(t *testing.T) {
 		t.Fatalf("chmod: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(instrDir, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, instrDir)
 
 	inst := &installer{
 		root:                root,
@@ -683,6 +689,7 @@ func TestAppendTemplateDirDiffs_StatError_Permissions(t *testing.T) {
 		t.Fatalf("chmod: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(instrDir, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, instrDir)
 
 	inst := &installer{root: root, sys: RealSystem{}}
 	dir := templateDir{
@@ -809,6 +816,7 @@ func TestTemplateFileMatches_ReadError(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(blockPath, 0o600) })
+	testutil.SkipIfWritable(t, blockPath)
 
 	info, _ := os.Stat(blockPath)
 	inst := &installer{root: root, sys: RealSystem{}}

--- a/internal/install/install_templates_test.go
+++ b/internal/install/install_templates_test.go
@@ -689,7 +689,7 @@ func TestAppendTemplateDirDiffs_StatError_Permissions(t *testing.T) {
 		t.Fatalf("chmod: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(instrDir, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
-	testutil.SkipIfWritable(t, instrDir)
+	testutil.SkipIfReadable(t, basePath)
 
 	inst := &installer{root: root, sys: RealSystem{}}
 	dir := templateDir{
@@ -816,7 +816,7 @@ func TestTemplateFileMatches_ReadError(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(blockPath, 0o600) })
-	testutil.SkipIfWritable(t, blockPath)
+	testutil.SkipIfReadable(t, blockPath)
 
 	info, _ := os.Stat(blockPath)
 	inst := &installer{root: root, sys: RealSystem{}}

--- a/internal/install/install_unknowns_test.go
+++ b/internal/install/install_unknowns_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/conn-castle/agent-layer/internal/messages"
+	"github.com/conn-castle/agent-layer/internal/testutil"
 )
 
 func TestScanUnknownRoot_StatError(t *testing.T) {
@@ -146,6 +147,7 @@ func TestHandleUnknowns_DeleteError(t *testing.T) {
 		t.Fatalf("chmod: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(protectedDir, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, protectedDir)
 
 	inst := &installer{
 		root:      root,
@@ -293,6 +295,7 @@ func TestHandleUnknowns_IndividualDeleteError(t *testing.T) {
 		t.Fatalf("chmod: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(protectedDir, 0o755) }) // #nosec G302 -- test toggles dir/file mode bits to drive a production error path; the executable/traversal bit is intentional.
+	testutil.SkipIfWritable(t, protectedDir)
 
 	inst := &installer{
 		root:      root,

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -52,7 +52,7 @@ func ForbidExec(t *testing.T, target *func(string, []string, []string) error) {
 }
 
 // testContext captures the testing hooks needed by the exec seam helpers
-// and the writability probe.
+// and permission probes.
 type testContext interface {
 	Cleanup(func())
 	Fatal(...any)
@@ -172,6 +172,32 @@ func skipIfWritable(t testContext, path string) {
 		return
 	}
 	t.Fatalf("writability probe %s: %v", path, probeErr)
+}
+
+// SkipIfReadable probes path with a real read attempt after a fixture has
+// restricted its mode bits. A successful probe is closed and the test is
+// skipped so elevated privileges cannot bypass a permission-dependent read or
+// traversal error. Permission denied lets the caller proceed. Any other probe
+// error fails with the protected path and the underlying error.
+func SkipIfReadable(t *testing.T, path string) {
+	t.Helper()
+	skipIfReadable(t, path)
+}
+
+func skipIfReadable(t testContext, path string) {
+	t.Helper()
+	file, probeErr := os.Open(path) // #nosec G304 -- path is a test-controlled fixture.
+	if probeErr == nil {
+		if closeErr := file.Close(); closeErr != nil {
+			t.Fatalf("readability probe %s: cleanup: %v", path, closeErr)
+		}
+		t.Skipf("process can read %s despite restrictive mode bits; skipping permission-dependent fixture", path)
+		return
+	}
+	if errors.Is(probeErr, os.ErrPermission) {
+		return
+	}
+	t.Fatalf("readability probe %s: %v", path, probeErr)
 }
 
 // WithWorkingDir runs fn with dir as the current working directory and restores the previous directory.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -51,12 +51,14 @@ func ForbidExec(t *testing.T, target *func(string, []string, []string) error) {
 	forbidExec(t, target)
 }
 
-// testContext captures the testing hooks needed by the exec seam helpers.
+// testContext captures the testing hooks needed by the exec seam helpers
+// and the writability probe.
 type testContext interface {
 	Cleanup(func())
 	Fatal(...any)
 	Fatalf(string, ...any)
 	Helper()
+	Skipf(string, ...any)
 }
 
 // captureExec installs the capture seam for both production test contexts and
@@ -124,6 +126,52 @@ func WriteStubExpectArg(t *testing.T, dir string, name string, expectedArg strin
 // v is the boolean value to take the address of.
 func BoolPtr(v bool) *bool {
 	return &v
+}
+
+// SkipIfWritable probes path with a real write or create attempt after a
+// fixture has restricted its mode bits. A successful probe is cleaned up and
+// the test is skipped so elevated privileges cannot make a permission-dependent
+// assertion pass or fail for an environment reason. Permission denied lets the
+// caller proceed. Any other probe error fails with the protected path and the
+// underlying error.
+func SkipIfWritable(t *testing.T, path string) {
+	t.Helper()
+	skipIfWritable(t, path)
+}
+
+func skipIfWritable(t testContext, path string) {
+	t.Helper()
+	info, probeErr := os.Stat(path)
+	if probeErr == nil {
+		if info.IsDir() {
+			var file *os.File
+			file, probeErr = os.CreateTemp(path, ".al-writability-probe-*")
+			if probeErr == nil {
+				name := file.Name()
+				closeErr := file.Close()
+				removeErr := os.Remove(name)
+				if closeErr != nil || removeErr != nil {
+					t.Fatalf("writability probe %s: cleanup %s: close: %v remove: %v", path, name, closeErr, removeErr)
+				}
+				t.Skipf("process can write %s despite restrictive mode bits; skipping permission-dependent fixture", path)
+				return
+			}
+		} else {
+			var file *os.File
+			file, probeErr = os.OpenFile(path, os.O_WRONLY, 0) // #nosec G304 -- path is a test-controlled fixture.
+			if probeErr == nil {
+				if closeErr := file.Close(); closeErr != nil {
+					t.Fatalf("writability probe %s: cleanup: %v", path, closeErr)
+				}
+				t.Skipf("process can write %s despite restrictive mode bits; skipping permission-dependent fixture", path)
+				return
+			}
+		}
+	}
+	if errors.Is(probeErr, os.ErrPermission) {
+		return
+	}
+	t.Fatalf("writability probe %s: %v", path, probeErr)
 }
 
 // WithWorkingDir runs fn with dir as the current working directory and restores the previous directory.

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -346,6 +346,59 @@ func TestSkipIfWritableAllowsProtectedDirectory(t *testing.T) {
 	SkipIfWritable(t, dir)
 }
 
+func TestSkipIfReadableSkipsReadablePath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "readable")
+	if err := os.WriteFile(path, []byte("content"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	context := &fakeTestContext{}
+	skipIfReadable(context, path)
+	if context.skipped == "" {
+		t.Fatal("expected skip for readable path")
+	}
+	if !strings.Contains(context.skipped, path) {
+		t.Fatalf("expected skip to name %q, got %q", path, context.skipped)
+	}
+}
+
+func TestSkipIfReadableFailsUnexpectedProbeError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	_, openErr := os.Open(missing) // #nosec G304 -- path is constructed from test-controlled inputs.
+	if openErr == nil {
+		t.Fatal("expected missing path to fail open")
+	}
+	context := &fakeTestContext{}
+	failure := requireTestFailure(t, func() {
+		skipIfReadable(context, missing)
+	})
+	if !strings.Contains(failure.message, missing) {
+		t.Fatalf("expected failure to name %q, got %q", missing, failure.message)
+	}
+	if !strings.Contains(failure.message, "readability probe") {
+		t.Fatalf("expected failure to identify the probe, got %q", failure.message)
+	}
+	if !strings.Contains(failure.message, openErr.Error()) {
+		t.Fatalf("expected failure to include the underlying error %q, got %q", openErr, failure.message)
+	}
+	if context.skipped != "" {
+		t.Fatalf("unexpected skip for probe error: %q", context.skipped)
+	}
+}
+
+func TestSkipIfReadableAllowsProtectedTraversal(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "protected")
+	if err := os.WriteFile(path, []byte("content"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Chmod(dir, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) }) // #nosec G302 -- restore owner access for TempDir cleanup.
+
+	SkipIfReadable(t, path)
+}
+
 func namesOf(entries []os.DirEntry) []string {
 	names := make([]string, len(entries))
 	for i, entry := range entries {

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -18,6 +18,7 @@ type testFailure struct {
 
 type fakeTestContext struct {
 	cleanups []func()
+	skipped  string
 }
 
 func (f *fakeTestContext) Cleanup(cleanup func()) {
@@ -33,6 +34,10 @@ func (f *fakeTestContext) Fatalf(format string, args ...any) {
 }
 
 func (f *fakeTestContext) Helper() {}
+
+func (f *fakeTestContext) Skipf(format string, args ...any) {
+	f.skipped = fmt.Sprintf(format, args...)
+}
 
 func (f *fakeTestContext) runCleanups() {
 	for i := len(f.cleanups) - 1; i >= 0; i-- {
@@ -262,6 +267,91 @@ func TestWriteStubExpectArgHonorsRequiredArg(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected non-zero exit without required arg")
 	}
+}
+
+func TestSkipIfWritableSkipsWritablePathAfterCleanup(t *testing.T) {
+	t.Run("directory", func(t *testing.T) {
+		dir := t.TempDir()
+		context := &fakeTestContext{}
+		skipIfWritable(context, dir)
+		if context.skipped == "" {
+			t.Fatal("expected skip for writable directory")
+		}
+		if !strings.Contains(context.skipped, dir) {
+			t.Fatalf("expected skip to name %q, got %q", dir, context.skipped)
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("readdir: %v", err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("expected probe file cleanup, found %v", namesOf(entries))
+		}
+	})
+	t.Run("file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "protected")
+		if err := os.WriteFile(path, []byte("keep"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		context := &fakeTestContext{}
+		skipIfWritable(context, path)
+		if context.skipped == "" {
+			t.Fatal("expected skip for writable file")
+		}
+		if !strings.Contains(context.skipped, path) {
+			t.Fatalf("expected skip to name %q, got %q", path, context.skipped)
+		}
+		data, err := os.ReadFile(path) // #nosec G304 -- path is constructed from test-controlled inputs.
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if string(data) != "keep" {
+			t.Fatalf("probe mutated file contents: %q", data)
+		}
+	})
+}
+
+func TestSkipIfWritableFailsUnexpectedProbeError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	_, statErr := os.Stat(missing)
+	if statErr == nil {
+		t.Fatal("expected missing path to fail stat")
+	}
+	context := &fakeTestContext{}
+	failure := requireTestFailure(t, func() {
+		skipIfWritable(context, missing)
+	})
+	if !strings.Contains(failure.message, missing) {
+		t.Fatalf("expected failure to name %q, got %q", missing, failure.message)
+	}
+	if !strings.Contains(failure.message, "writability probe") {
+		t.Fatalf("expected failure to identify the probe, got %q", failure.message)
+	}
+	if !strings.Contains(failure.message, statErr.Error()) {
+		t.Fatalf("expected failure to include the underlying error %q, got %q", statErr, failure.message)
+	}
+	if context.skipped != "" {
+		t.Fatalf("unexpected skip for probe error: %q", context.skipped)
+	}
+}
+
+func TestSkipIfWritableAllowsProtectedDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil { // #nosec G302 -- restrictive mode exercises the exported permission probe.
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) }) // #nosec G302 -- restore owner access for TempDir cleanup.
+
+	SkipIfWritable(t, dir)
+}
+
+func namesOf(entries []os.DirEntry) []string {
+	names := make([]string, len(entries))
+	for i, entry := range entries {
+		names[i] = entry.Name()
+	}
+	return names
 }
 
 func TestBoolPtr(t *testing.T) {


### PR DESCRIPTION
## Summary

- Permission-driven test fixtures in `internal/install` and `internal/clients` restrict mode bits to force a production error path. A process that bypasses those bits (`CAP_DAC_OVERRIDE` for writes, `CAP_DAC_READ_SEARCH` for reads and traversal — root in many containers) completes the operation anyway, so the assertion fails for an environment reason rather than a code defect.
- Adds shared real-I/O probes so those fixtures skip under elevated privileges instead of failing misleadingly.
- Resolves `Issue 2026-08-04 permission-based-test-fixtures-assume-non-root`.

## Changes

- `internal/testutil`: new `SkipIfWritable(t, path)`. After a fixture restricts mode bits, it attempts a real create (directories) or write-open (files). A successful probe is cleaned up and the test is skipped; `os.ErrPermission` lets the caller proceed; any other probe error fails with the protected path and the underlying error. No UID or root heuristics.
- `internal/testutil`: new `SkipIfReadable(t, path)` with the same contract, using a real open. Read- and traversal-dependent fixtures need this because `CAP_DAC_READ_SEARCH` without `CAP_DAC_OVERRIDE` bypasses reads while the write probe still returns `EACCES`.
- `internal/testutil`: `testContext` gains `Skipf` so both helpers are covered through the existing fake-context seam.
- Applies the helpers to all 15 affected fixtures: `internal/clients/runner_test.go` (1), `install_gitignore_test.go` (4), `install_run_test.go` (1), `install_templates_test.go` (7), `install_unknowns_test.go` (2). Fixtures that previously created a restrictive directory without restoring its mode now register cleanup before probing.
- `docs/agent-layer/ISSUES.md`: removes the resolved issue entry.

## Verification

- `go test ./internal/testutil/... ./internal/install/... ./internal/clients/...` — pass
- `make fmt-check` — pass
- `make lint` — 0 issues
- `make coverage` — 90.00% against a 90.00% threshold, PASS
- pre-commit hooks (gofmt/goimports, tidy check, golangci-lint, `go test ./...`) — passed on each commit

## Notes

- Probe selection follows the operation each fixture depends on. `TestTemplateFileMatches_ReadError` probes its mode-`000` file for readability. `TestAppendTemplateDirDiffs_StatError_Permissions` probes the existing child file inside its mode-`000` directory, which gates on exactly the traversal permission the production `sys.Stat` needs.
- Deliberately unprobed: `TestAppendTemplateFileDiffs_StatError` (its EISDIR read failure is root-independent) and `TestScanUnknownRoot_WalkDirError` (no permission-dependent assertion). Rollback, mode-restoration, and symlink-safety chmod uses are unchanged.
- Coverage now sits exactly on the 90.00% gate with no margin. The new helper branches are covered to 90–100% (the unreachable close-error paths are the remainder), but any unrelated change that adds uncovered code will tip the gate red.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission-dependent test reliability across different filesystem and privilege environments.
  * Tests now skip when requested read-only or restricted permissions are not enforced, preventing false failures.

* **Tests**
  * Added coverage for filesystem permission checks, cleanup behavior, preserved file contents, and unexpected errors.

* **Documentation**
  * Removed an outdated issue entry regarding permission-based test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->