### PR TITLE
fix: show upgrade keep-list candidates before prompt

### DIFF
--- a/cmd/al/upgrade.go
+++ b/cmd/al/upgrade.go
@@ -307,7 +307,8 @@ func buildUpgradePrompter(cmd *cobra.Command, policy upgradeApplyPolicy, reviewS
 			if len(paths) != 1 {
 				noun = "paths"
 			}
-			if _, err := fmt.Fprintf(cmd.OutOrStdout(), messages.UpgradeKeepListCandidatesFmt, len(paths), noun); err != nil {
+			header := fmt.Sprintf(messages.UpgradeKeepListCandidatesFmt, len(paths), noun)
+			if err := printFilePaths(cmd.OutOrStdout(), header, paths); err != nil {
 				return nil, err
 			}
 			add, err := promptYesNo(stdinReader, cmd.OutOrStdout(), messages.UpgradeAddToKeepListPrompt, true)

--- a/cmd/al/upgrade_prompter_test.go
+++ b/cmd/al/upgrade_prompter_test.go
@@ -127,8 +127,21 @@ func TestBuildUpgradePrompter_SelectUnknownsToKeepInteractive(t *testing.T) {
 	if !reflect.DeepEqual(ui.options, paths) || ui.title != messages.UpgradeKeepListSelectTitle {
 		t.Fatalf("UI received title %q and options %v", ui.title, ui.options)
 	}
-	if !strings.Contains(out.String(), "Found 2 unknown paths eligible") {
-		t.Fatalf("output did not describe keep-list candidates: %q", out.String())
+	printed := out.String()
+	if !strings.Contains(printed, "Found 2 unknown paths eligible") {
+		t.Fatalf("output did not describe keep-list candidates: %q", printed)
+	}
+	// The candidate paths must be listed before the yes/no question so the
+	// user can decide with the actual list in view.
+	promptIndex := strings.Index(printed, messages.UpgradeAddToKeepListPrompt)
+	if promptIndex < 0 {
+		t.Fatalf("keep-list question missing from output: %q", printed)
+	}
+	for _, path := range paths {
+		pathIndex := strings.Index(printed, path)
+		if pathIndex < 0 || pathIndex > promptIndex {
+			t.Fatalf("path %q was not listed before the keep-list question: %q", path, printed)
+		}
 	}
 }
 

--- a/internal/messages/cli.go
+++ b/internal/messages/cli.go
@@ -71,7 +71,7 @@ const (
 	UpgradeViewDiffPrompt                           = "View the full diff?"
 	UpgradeDeleteUnknownAllPrompt                   = "Delete all unknown files found during upgrade scan (excludes .agent-layer/tmp/, which is prompted separately)?"
 	UpgradeAddToKeepListPrompt                      = "Would you like to add anything to the upgrade keep list?"
-	UpgradeKeepListCandidatesFmt                    = "Found %d unknown %s eligible for the upgrade keep list.\n"
+	UpgradeKeepListCandidatesFmt                    = "Found %d unknown %s eligible for the upgrade keep list:"
 	UpgradeKeepListSelectTitle                      = "Select intentional local paths to keep during future upgrades"
 	UpgradeDeleteUnknownPromptFmt                   = "Delete %s?"
 	UpgradeDeleteUnknownTmpAllPromptFmt             = "Delete all %d file(s) under .agent-layer/tmp/?"


### PR DESCRIPTION
## Summary

- Show unknown upgrade paths before asking whether to add them to the keep list.
- Keep the confirmation decision informed by the actual candidate paths.

## Changes

- Route keep-list candidate output through the shared file-list renderer.
- Add a regression assertion that every candidate appears before the yes/no prompt.

## Verification

- `make ci` — passed; 4,515 tests passed, 1 skipped for an unsupported invalid-UTF-8 symlink case.
- Commit hooks — passed formatting, module tidy, lint, and test checks.
