### PR TITLE
fix: standardize review disposition replies

### DIFF
--- a/internal/templates/skills/ship-pr/SKILL.md
+++ b/internal/templates/skills/ship-pr/SKILL.md
@@ -70,11 +70,16 @@ Unless the user narrows the scope, include the entire current working tree.
    creation, stop and report that no feedback was received. If ready, continue
    to step 5. Otherwise, address the full actionable round before committing.
 
-4. Commit and push accepted fixes. Post each supported worker-proposed reply one
-   at a time: reply natively to inline comments; for conversation comments or
-   review summaries, post an issue comment linking the source. Rerun the comment
-   command and correct any missing or unsupported reply. Return to step 3 until
-   ready. If only checks or reviews are pending, wait for the watcher.
+4. Commit and push accepted fixes. Replace every worker proposal beginning
+   `Fixed.` with `Fixed in <full commit SHA>.`, naming the pushed commit that
+   contains that fix; preserve its explanation after the canonical prefix.
+   Post each supported worker-proposed reply one at a time: reply natively to
+   inline comments; for conversation comments or review summaries, post an
+   issue comment linking the source. Posted disposition replies must begin
+   exactly `Fixed in <full commit SHA>.`, `Deferred.`, or `Disagreed.`. Rerun
+   the comment command and correct any missing, noncanonical, or unsupported
+   reply. Return to step 3 until ready. If only checks or reviews are pending,
+   wait for the watcher.
 
 5. Request single-use merge authorization for the exact PR and head. Report any
    substantive findings, a concise comment disposition summary, and readiness

--- a/internal/templates/skills/ship-pr/references/address-pr-comments.md
+++ b/internal/templates/skills/ship-pr/references/address-pr-comments.md
@@ -38,10 +38,11 @@ issue creation unless authorized.
 Prepare one reply per eligible, unblocked comment, keyed by its stable ID or
 URL:
 
-- **Fixed.** Describe the fix. This is a proposal marker only; the shipper must
-  replace it with `Fixed in <full commit SHA>.` after committing the fix.
-- **Disagreed.** Give evidence for making no change.
-- **Deferred.** Name the tracking location and explain the boundary.
+- `Fixed.` Describe the fix. This is a proposal marker only; the shipper must
+  replace it with `Fixed in <full commit SHA>.` after pushing the fix.
+- `Disagreed.` Give evidence for not following the reviewer's recommendation,
+  including any alternative fix that addresses the underlying problem.
+- `Deferred.` Name the tracking location and explain the boundary.
 
 The first words are a machine-readable disposition protocol. Do not substitute
 `No change`, `Done`, `Resolved`, or another synonym. Never post the proposal

--- a/internal/templates/skills/ship-pr/references/address-pr-comments.md
+++ b/internal/templates/skills/ship-pr/references/address-pr-comments.md
@@ -38,9 +38,15 @@ issue creation unless authorized.
 Prepare one reply per eligible, unblocked comment, keyed by its stable ID or
 URL:
 
-- **Fixed.** Describe the fix.
-- **No change — `<reason>`.** Give evidence.
-- **Deferred — tracked in `<location>`.** Explain the boundary.
+- **Fixed.** Describe the fix. This is a proposal marker only; the shipper must
+  replace it with `Fixed in <full commit SHA>.` after committing the fix.
+- **Disagreed.** Give evidence for making no change.
+- **Deferred.** Name the tracking location and explain the boundary.
+
+The first words are a machine-readable disposition protocol. Do not substitute
+`No change`, `Done`, `Resolved`, or another synonym. Never post the proposal
+marker `Fixed.`; a posted fixed disposition must name the full commit that
+contains the accepted fix.
 
 Finish when every eligible comment has a supported disposition and no unblocked
 local work remains. Return dispositions, stable comment IDs or URLs, fixes and


### PR DESCRIPTION
## Summary
- define machine-readable Fixed, Deferred, and Disagreed reply prefixes
- require fixed replies to name the full pushed commit SHA
- reject ambiguous disposition synonyms during shipping

## Verification
- `go test ./internal/templates/... ./internal/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how proposed pull-request comment dispositions should be recorded.
  - Standardized disposition labels for fixed, disagreed, and deferred comments.
  - Fixed items now include the complete commit reference while preserving the explanation.
  - Disagreements require supporting evidence, and deferred items require tracking details.
  - Added guidance to correct missing, unsupported, or incorrectly formatted disposition replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->