### PR TITLE
fix: gate releases on benchmark readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,23 @@ permissions:
   contents: write
 
 jobs:
+  catalog-readiness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.release_tag || github.ref_name }}
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Certify pinned benchmark catalog
+        run: go run ./cmd/al benchmark readiness --task-concurrency 1 --remove-task-images
+
   build-release:
+    needs: catalog-readiness
     runs-on: macos-latest
     env:
       RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,24 @@ jobs:
   catalog-readiness:
     runs-on: ubuntu-latest
     timeout-minutes: 360
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
     steps:
+      - name: Validate stable release tag format
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Unsupported release tag ${RELEASE_TAG}. Release publishing supports stable tags only (vX.Y.Z)."
+            exit 1
+          fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.release_tag || github.ref_name }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Certify pinned benchmark catalog
         run: go run ./cmd/al benchmark readiness --task-concurrency 1 --remove-task-images
 
@@ -36,15 +45,22 @@ jobs:
     env:
       RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
     steps:
+      - name: Validate stable release tag format
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Unsupported release tag ${RELEASE_TAG}. Release publishing supports stable tags only (vX.Y.Z)."
+            exit 1
+          fi
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ inputs.release_tag || github.ref_name }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         id: setup-go
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - name: Install system dependencies
         run: |
           set -euo pipefail
@@ -56,13 +72,6 @@ jobs:
           fi
           if ! command -v uvx >/dev/null 2>&1; then
             echo "::error::uvx is required by the pinned benchmark adapter contract but was not found after installing uv."
-            exit 1
-          fi
-      - name: Validate stable release tag format
-        run: |
-          set -euo pipefail
-          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Unsupported release tag ${RELEASE_TAG}. Release publishing supports stable tags only (vX.Y.Z)."
             exit 1
           fi
       - name: Validate upgrade contract docs

--- a/cmd/al/benchmark.go
+++ b/cmd/al/benchmark.go
@@ -98,6 +98,7 @@ func newBenchmarkRunCmd() *cobra.Command {
 
 func newBenchmarkReadinessCmd() *cobra.Command {
 	var taskConcurrency int
+	var removeTaskImages bool
 	command := &cobra.Command{
 		Use:   benchmarkReadinessName,
 		Short: "Preflight every task in the pinned DeepSWE catalog",
@@ -107,7 +108,9 @@ func newBenchmarkReadinessCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			outcome, err := checkReadiness(context.Background(), bench.ReadinessAuditOptions{RepoRoot: root, TaskConcurrency: taskConcurrency})
+			outcome, err := checkReadiness(context.Background(), bench.ReadinessAuditOptions{
+				RepoRoot: root, TaskConcurrency: taskConcurrency, RemoveTaskImages: removeTaskImages,
+			})
 			if err != nil {
 				return err
 			}
@@ -132,5 +135,6 @@ func newBenchmarkReadinessCmd() *cobra.Command {
 		},
 	}
 	command.Flags().IntVar(&taskConcurrency, "task-concurrency", 1, "parallel task readiness checks, from 1 to 8")
+	command.Flags().BoolVar(&removeTaskImages, "remove-task-images", false, "remove exact task images after certification to bound Docker disk usage; requires task concurrency 1")
 	return command
 }

--- a/cmd/al/benchmark_test.go
+++ b/cmd/al/benchmark_test.go
@@ -49,14 +49,14 @@ func TestBenchmarkRunDryRunDoesNotInvokeProviderInference(t *testing.T) {
 func TestBenchmarkReadinessRunsWithoutProviderCalls(t *testing.T) {
 	original := checkReadiness
 	checkReadiness = func(_ context.Context, options bench.ReadinessAuditOptions) (bench.ReadinessAuditOutcome, error) {
-		if options.TaskConcurrency != 4 {
+		if options.TaskConcurrency != 1 || !options.RemoveTaskImages {
 			t.Fatalf("options = %#v", options)
 		}
 		return bench.ReadinessAuditOutcome{DeepSWECommit: strings.Repeat("d", 40), Required: 2, Certified: 2}, nil
 	}
 	t.Cleanup(func() { checkReadiness = original })
 	root := newRootCmd()
-	root.SetArgs([]string{"benchmark", "readiness", "--task-concurrency", "4"})
+	root.SetArgs([]string{"benchmark", "readiness", "--task-concurrency", "1", "--remove-task-images"})
 	var output bytes.Buffer
 	root.SetOut(&output)
 	root.SetErr(&output)

--- a/internal/benchmark/catalog.go
+++ b/internal/benchmark/catalog.go
@@ -206,6 +206,14 @@ func modelNameForPublished(identifier string) string {
 	return identifier
 }
 
+func supportedPublishedModelIdentifiers() []string {
+	identifiers := make([]string, 0, len(supportedModels))
+	for _, model := range supportedModels {
+		identifiers = append(identifiers, model.PublishedIdentifier)
+	}
+	return identifiers
+}
+
 func validTaskName(task string) bool {
 	if task == "" || len(task) > 160 {
 		return false

--- a/internal/benchmark/execution.go
+++ b/internal/benchmark/execution.go
@@ -49,6 +49,7 @@ const (
 	platformDarwin                 = "darwin"
 	platformLinux                  = "linux"
 	dockerFormatFlag               = "--format"
+	dockerForceFlag                = "--force"
 	dockerImageResource            = "image"
 	dockerNetworkResource          = "network"
 	dockerVolumeResource           = "volume"
@@ -551,9 +552,9 @@ func cleanupPierDockerResources(stage string, request ExecutionRequest) error {
 		removeBase []string
 		validName  *regexp.Regexp
 	}{
-		{name: "container", list: []string{"ps", "--all", dockerFormatFlag, dockerComposeOwnershipIDFormat}, removeBase: []string{"rm", "--force"}, validName: dockerResourceIDPattern},
+		{name: "container", list: []string{"ps", "--all", dockerFormatFlag, dockerComposeOwnershipIDFormat}, removeBase: []string{"rm", dockerForceFlag}, validName: dockerResourceIDPattern},
 		{name: dockerNetworkResource, list: []string{dockerNetworkResource, "ls", dockerFormatFlag, dockerComposeOwnershipIDFormat}, removeBase: []string{dockerNetworkResource, "rm"}, validName: dockerResourceIDPattern},
-		{name: dockerVolumeResource, list: []string{dockerVolumeResource, "ls", dockerFormatFlag, dockerComposeOwnershipNameFormat}, removeBase: []string{dockerVolumeResource, "rm", "--force"}, validName: dockerVolumeNamePattern},
+		{name: dockerVolumeResource, list: []string{dockerVolumeResource, "ls", dockerFormatFlag, dockerComposeOwnershipNameFormat}, removeBase: []string{dockerVolumeResource, "rm", dockerForceFlag}, validName: dockerVolumeNamePattern},
 	} {
 		output, listErr := runBenchmarkDockerCommand(ctx, resource.list...)
 		if listErr != nil {

--- a/internal/benchmark/readiness/e016041a6ccf8da29906afc9a3f5a8df940a1f78/testem-bail-on-test-failure/agent.Dockerfile
+++ b/internal/benchmark/readiness/e016041a6ccf8da29906afc9a3f5a8df940a1f78/testem-bail-on-test-failure/agent.Dockerfile
@@ -1,5 +1,11 @@
 FROM public.ecr.aws/d3j8x8q7/swe-bench-202605@sha256:dfcfc6397b39c9b0ecdc08e1baf4588991f430c86c6e71eb2ca8fe646633cd71
 
-RUN apt-get update \
+RUN rm -f /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list.d/nodesource.list \
+ && printf '%s\n' \
+      'deb https://snapshot.debian.org/archive/debian/20260722T043754Z/ bookworm main' \
+      'deb https://snapshot.debian.org/archive/debian-security/20260722T043754Z/ bookworm-security main' \
+      > /etc/apt/sources.list \
+ && echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until \
+ && apt-get update \
  && apt-get install -y --no-install-recommends firefox-esr=140.13.0esr-1~deb12u1 \
  && rm -rf /var/lib/apt/lists/*

--- a/internal/benchmark/readiness_audit.go
+++ b/internal/benchmark/readiness_audit.go
@@ -132,13 +132,14 @@ func CheckAllTaskReadiness(ctx context.Context, options ReadinessAuditOptions) (
 }
 
 func checkTaskReadinessWithBoundedDisk(ctx context.Context, repoRoot, checkout string, tasks []benchmarkPlanTask, checksums []string, results []ReadinessAuditTask) (ReadinessAuditOutcome, error) {
-	var previous *loadedTaskReadiness
+	var previous loadedTaskReadiness
+	hasPrevious := false
 	cleanupPrevious := func() error {
-		if previous == nil {
+		if !hasPrevious {
 			return nil
 		}
-		err := removeTaskReadinessImages(ctx, *previous)
-		previous = nil
+		err := removeTaskReadinessImages(ctx, previous)
+		hasPrevious = false
 		return err
 	}
 	defer func() { _ = cleanupPrevious() }()
@@ -153,7 +154,8 @@ func checkTaskReadinessWithBoundedDisk(ctx context.Context, repoRoot, checkout s
 		if err := cleanupPrevious(); err != nil {
 			return summarizeReadinessAudit(results), fmt.Errorf("reclaim benchmark readiness Docker images: %w", err)
 		}
-		previous = &readiness
+		previous = readiness
+		hasPrevious = true
 		if auditErr == nil {
 			results[index].Status = readinessStatusCertified
 			continue

--- a/internal/benchmark/readiness_audit.go
+++ b/internal/benchmark/readiness_audit.go
@@ -147,6 +147,9 @@ func checkTaskReadinessWithBoundedDisk(ctx context.Context, repoRoot, checkout s
 	for index, task := range tasks {
 		readiness, err := loadTaskReadiness(checkout, task.ID)
 		if err != nil {
+			if cleanupErr := cleanupPrevious(); cleanupErr != nil {
+				err = errors.Join(err, fmt.Errorf("reclaim benchmark readiness Docker images: %w", cleanupErr))
+			}
 			return summarizeReadinessAudit(results), err
 		}
 		results[index] = ReadinessAuditTask{Task: task.ID, Status: readinessStatusFailed}

--- a/internal/benchmark/readiness_audit.go
+++ b/internal/benchmark/readiness_audit.go
@@ -26,8 +26,9 @@ const (
 // ReadinessAuditOptions configures the non-paid audit of every task in the
 // pinned DeepSWE checkout.
 type ReadinessAuditOptions struct {
-	RepoRoot        string
-	TaskConcurrency int
+	RepoRoot         string
+	TaskConcurrency  int
+	RemoveTaskImages bool
 }
 
 // ReadinessAuditTask records the preflight result for one DeepSWE task.
@@ -58,6 +59,9 @@ func CheckAllTaskReadiness(ctx context.Context, options ReadinessAuditOptions) (
 	if options.TaskConcurrency < 1 || options.TaskConcurrency > 8 {
 		return ReadinessAuditOutcome{}, errors.New("DeepSWE readiness audit task concurrency must be from 1 to 8")
 	}
+	if options.RemoveTaskImages && options.TaskConcurrency != 1 {
+		return ReadinessAuditOutcome{}, errors.New("DeepSWE readiness audit image removal requires task concurrency 1")
+	}
 	checkout, err := ensurePinnedBenchmarkCheckout(ctx, options.RepoRoot)
 	if err != nil {
 		return ReadinessAuditOutcome{}, err
@@ -81,6 +85,9 @@ func CheckAllTaskReadiness(ctx context.Context, options ReadinessAuditOptions) (
 	}
 	if outcome := summarizeReadinessAudit(results); outcome.Failed > 0 {
 		return outcome, nil
+	}
+	if options.RemoveTaskImages {
+		return checkTaskReadinessWithBoundedDisk(ctx, options.RepoRoot, checkout, tasks, checksums, results)
 	}
 
 	jobs := make(chan int)
@@ -122,6 +129,66 @@ func CheckAllTaskReadiness(ctx context.Context, options ReadinessAuditOptions) (
 	workers.Wait()
 
 	return summarizeReadinessAudit(results), nil
+}
+
+func checkTaskReadinessWithBoundedDisk(ctx context.Context, repoRoot, checkout string, tasks []benchmarkPlanTask, checksums []string, results []ReadinessAuditTask) (ReadinessAuditOutcome, error) {
+	var previous *loadedTaskReadiness
+	cleanupPrevious := func() error {
+		if previous == nil {
+			return nil
+		}
+		err := removeTaskReadinessImages(ctx, *previous)
+		previous = nil
+		return err
+	}
+	defer func() { _ = cleanupPrevious() }()
+
+	for index, task := range tasks {
+		readiness, err := loadTaskReadiness(checkout, task.ID)
+		if err != nil {
+			return summarizeReadinessAudit(results), err
+		}
+		results[index] = ReadinessAuditTask{Task: task.ID, Status: readinessStatusFailed}
+		auditErr := auditTaskReadiness(ctx, repoRoot, checkout, task.ID, checksums[index])
+		if err := cleanupPrevious(); err != nil {
+			return summarizeReadinessAudit(results), fmt.Errorf("reclaim benchmark readiness Docker images: %w", err)
+		}
+		previous = &readiness
+		if auditErr == nil {
+			results[index].Status = readinessStatusCertified
+			continue
+		}
+		results[index].Error = auditErr.Error()
+		if !isReadinessInfrastructureFailure(auditErr) {
+			continue
+		}
+		results[index].Status = readinessStatusBlocked
+		for blocked := index + 1; blocked < len(tasks); blocked++ {
+			results[blocked] = ReadinessAuditTask{
+				Task:   tasks[blocked].ID,
+				Status: readinessStatusBlocked,
+				Error:  "audit canceled after a shared infrastructure failure",
+			}
+		}
+		break
+	}
+	if err := cleanupPrevious(); err != nil {
+		return summarizeReadinessAudit(results), fmt.Errorf("reclaim benchmark readiness Docker images: %w", err)
+	}
+	return summarizeReadinessAudit(results), nil
+}
+
+func removeTaskReadinessImages(ctx context.Context, readiness loadedTaskReadiness) error {
+	images := []string{readiness.pinnedImage}
+	if len(readiness.overlay) > 0 {
+		images = append([]string{readiness.agentImage}, images...)
+	}
+	arguments := append([]string{dockerImageResource, "rm", dockerForceFlag}, images...)
+	output, err := runTaskReadinessCommand(ctx, arguments...)
+	if err != nil && !strings.Contains(strings.ToLower(string(output)), "no such image") {
+		return fmt.Errorf("remove exact task images: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
 }
 
 func summarizeReadinessAudit(results []ReadinessAuditTask) ReadinessAuditOutcome {

--- a/internal/benchmark/readiness_audit_catalog_test.go
+++ b/internal/benchmark/readiness_audit_catalog_test.go
@@ -63,6 +63,47 @@ func auditContractsFixture(tasks ...string) fs.FS {
 	return contracts
 }
 
+func TestVersionPinnedAptOverlaysUseImmutableSnapshots(t *testing.T) {
+	root := "readiness/" + DeepSWECommit
+	var pinnedOverlays int
+	err := fs.WalkDir(readinessContracts, root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || entry.Name() != "agent.Dockerfile" {
+			return nil
+		}
+		data, err := fs.ReadFile(readinessContracts, path)
+		if err != nil {
+			return err
+		}
+		contents := string(data)
+		for _, line := range strings.Split(contents, "\n") {
+			if !strings.Contains(line, "apt-get install") || !strings.Contains(line, "=") {
+				continue
+			}
+			pinnedOverlays++
+			for _, required := range []string{
+				"snapshot.debian.org/archive/debian/",
+				"Acquire::Check-Valid-Until",
+				"rm -f /etc/apt/sources.list.d/",
+			} {
+				if !strings.Contains(contents, required) {
+					t.Errorf("version-pinned apt overlay %s does not contain %q", path, required)
+				}
+			}
+			break
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pinnedOverlays == 0 {
+		t.Fatal("pinned catalog contains no version-pinned apt overlay to audit")
+	}
+}
+
 // installAuditCheckout points the audit at a fixture checkout instead of
 // cloning the pinned DeepSWE repository.
 func installAuditCheckout(t *testing.T, checkout string) {
@@ -219,6 +260,7 @@ func TestReadinessAuditRejectsUnusableOptions(t *testing.T) {
 		{"no repository", ReadinessAuditOptions{TaskConcurrency: 1}, "requires a repository root"},
 		{"no workers", ReadinessAuditOptions{RepoRoot: "repo"}, "task concurrency must be from 1 to 8"},
 		{"too many workers", ReadinessAuditOptions{RepoRoot: "repo", TaskConcurrency: 9}, "task concurrency must be from 1 to 8"},
+		{"image removal with parallel workers", ReadinessAuditOptions{RepoRoot: "repo", TaskConcurrency: 2, RemoveTaskImages: true}, "image removal requires task concurrency 1"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if _, err := CheckAllTaskReadiness(context.Background(), test.options); err == nil ||

--- a/internal/benchmark/readiness_audit_test.go
+++ b/internal/benchmark/readiness_audit_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestReadinessAuditRemovesOnlyAfterTheSuccessorImageIsReady(t *testing.T) {
 	repository, checkout := t.TempDir(), t.TempDir()
-	writeAuditCatalogFixture(t, checkout, "first-task", "second-task")
+	writeAuditCatalogFixture(t, checkout, "first-task", "second-task", "third-task")
 	installAuditCheckout(t, checkout)
 	var events []string
-	installReadinessTestBoundaries(t, auditContractsFixture("first-task", "second-task"),
+	installReadinessTestBoundaries(t, auditContractsFixture("first-task", "second-task", "third-task"),
 		func(_ context.Context, arguments ...string) ([]byte, error) {
 			switch {
 			case len(arguments) > 2 && arguments[0] == commandRun:
@@ -33,14 +33,16 @@ func TestReadinessAuditRemovesOnlyAfterTheSuccessorImageIsReady(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if outcome.Certified != 2 || outcome.Failed != 0 || outcome.Blocked != 0 {
+	if outcome.Certified != 3 || outcome.Failed != 0 || outcome.Blocked != 0 {
 		t.Fatalf("audit outcome = %#v", outcome)
 	}
 	want := strings.Join([]string{
 		"run:" + auditTaskImage("first-task") + "@" + testReadinessDigest,
 		"run:" + auditTaskImage("second-task") + "@" + testReadinessDigest,
 		"remove:" + auditTaskImage("first-task") + "@" + testReadinessDigest,
+		"run:" + auditTaskImage("third-task") + "@" + testReadinessDigest,
 		"remove:" + auditTaskImage("second-task") + "@" + testReadinessDigest,
+		"remove:" + auditTaskImage("third-task") + "@" + testReadinessDigest,
 	}, "|")
 	if got := strings.Join(events, "|"); got != want {
 		t.Fatalf("bounded-disk Docker events = %q, want %q", got, want)

--- a/internal/benchmark/readiness_audit_test.go
+++ b/internal/benchmark/readiness_audit_test.go
@@ -1,11 +1,62 @@
 package benchmark
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestReadinessAuditRemovesOnlyAfterTheSuccessorImageIsReady(t *testing.T) {
+	repository, checkout := t.TempDir(), t.TempDir()
+	writeAuditCatalogFixture(t, checkout, "first-task", "second-task")
+	installAuditCheckout(t, checkout)
+	var events []string
+	installReadinessTestBoundaries(t, auditContractsFixture("first-task", "second-task"),
+		func(_ context.Context, arguments ...string) ([]byte, error) {
+			switch {
+			case len(arguments) > 2 && arguments[0] == commandRun:
+				events = append(events, "run:"+arguments[len(arguments)-2])
+			case len(arguments) > 3 && arguments[0] == "image" && arguments[1] == "rm":
+				events = append(events, "remove:"+arguments[3])
+			default:
+				t.Fatalf("unexpected Docker readiness command: %#v", arguments)
+			}
+			return nil, nil
+		})
+
+	outcome, err := CheckAllTaskReadiness(context.Background(), ReadinessAuditOptions{
+		RepoRoot: repository, TaskConcurrency: 1, RemoveTaskImages: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Certified != 2 || outcome.Failed != 0 || outcome.Blocked != 0 {
+		t.Fatalf("audit outcome = %#v", outcome)
+	}
+	want := strings.Join([]string{
+		"run:" + auditTaskImage("first-task") + "@" + testReadinessDigest,
+		"run:" + auditTaskImage("second-task") + "@" + testReadinessDigest,
+		"remove:" + auditTaskImage("first-task") + "@" + testReadinessDigest,
+		"remove:" + auditTaskImage("second-task") + "@" + testReadinessDigest,
+	}, "|")
+	if got := strings.Join(events, "|"); got != want {
+		t.Fatalf("bounded-disk Docker events = %q, want %q", got, want)
+	}
+}
+
+func TestReadinessAuditImageRemovalFailsLoudly(t *testing.T) {
+	installReadinessTestBoundaries(t, auditContractsFixture(),
+		func(context.Context, ...string) ([]byte, error) {
+			return []byte("permission denied"), errors.New("exit status 1")
+		})
+	err := removeTaskReadinessImages(context.Background(), loadedTaskReadiness{pinnedImage: "registry.example/task@sha256:" + strings.Repeat("1", 64)})
+	if err == nil || !strings.Contains(err.Error(), "remove exact task images") || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("image removal error = %v", err)
+	}
+}
 
 func TestListPinnedBenchmarkTasksAllowsCatalogMetadata(t *testing.T) {
 	root := t.TempDir()

--- a/internal/benchmark/readiness_audit_test.go
+++ b/internal/benchmark/readiness_audit_test.go
@@ -49,6 +49,39 @@ func TestReadinessAuditRemovesOnlyAfterTheSuccessorImageIsReady(t *testing.T) {
 	}
 }
 
+func TestReadinessAuditCombinesCleanupFailureWhenLaterLoadFails(t *testing.T) {
+	checkout := t.TempDir()
+	writeAuditCatalogFixture(t, checkout, "first-task", "second-task")
+	installReadinessTestBoundaries(t, auditContractsFixture("first-task"),
+		func(_ context.Context, arguments ...string) ([]byte, error) {
+			if len(arguments) > 3 && arguments[0] == "image" && arguments[1] == "rm" {
+				return []byte("permission denied"), errors.New("exit status 1")
+			}
+			return nil, nil
+		})
+
+	outcome, err := checkTaskReadinessWithBoundedDisk(
+		context.Background(),
+		t.TempDir(),
+		checkout,
+		[]benchmarkPlanTask{{ID: "first-task"}, {ID: "second-task"}},
+		[]string{strings.Repeat("1", 64), strings.Repeat("2", 64)},
+		[]ReadinessAuditTask{
+			{Task: "first-task", Status: readinessStatusValidated},
+			{Task: "second-task", Status: readinessStatusValidated},
+		},
+	)
+	if err == nil ||
+		!strings.Contains(err.Error(), "no mandatory environment readiness contract") ||
+		!strings.Contains(err.Error(), "reclaim benchmark readiness Docker images") ||
+		!strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("combined load and cleanup error = %v", err)
+	}
+	if outcome.Certified != 1 || outcome.Validated != 1 || outcome.Failed != 0 {
+		t.Fatalf("audit outcome = %#v", outcome)
+	}
+}
+
 func TestReadinessAuditImageRemovalFailsLoudly(t *testing.T) {
 	installReadinessTestBoundaries(t, auditContractsFixture(),
 		func(context.Context, ...string) ([]byte, error) {

--- a/internal/benchmark/study_execution.go
+++ b/internal/benchmark/study_execution.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -214,8 +215,22 @@ func validateMatrixSelection(selection matrixSelection) error {
 		return fmt.Errorf("benchmark selection schema v1 does not support manual exclusions")
 	}
 	model, effort, err := ParseModelSelection(modelNameForPublished(selection.Selector.Model) + ":" + selection.Selector.Reasoning)
-	if err != nil || model.PublishedIdentifier != selection.Selector.Model || effort != selection.Selector.Reasoning {
-		return fmt.Errorf("benchmark selection has an invalid selector configuration")
+	if err != nil {
+		return fmt.Errorf(
+			"benchmark selection selector model %q with reasoning %q is invalid (supported models: %s): %w",
+			selection.Selector.Model,
+			selection.Selector.Reasoning,
+			strings.Join(supportedPublishedModelIdentifiers(), ", "),
+			err,
+		)
+	}
+	if model.PublishedIdentifier != selection.Selector.Model || effort != selection.Selector.Reasoning {
+		return fmt.Errorf(
+			"benchmark selection selector model %q with reasoning %q must use exact canonical spelling (supported models: %s)",
+			selection.Selector.Model,
+			selection.Selector.Reasoning,
+			strings.Join(supportedPublishedModelIdentifiers(), ", "),
+		)
 	}
 	seen, excluded := map[string]bool{}, map[string]bool{}
 	for _, task := range selection.ManualExclusions {

--- a/internal/benchmark/study_execution_test.go
+++ b/internal/benchmark/study_execution_test.go
@@ -60,6 +60,18 @@ func TestStudySelectionRejectsManualExclusionsInSchemaV1(t *testing.T) {
 	}
 }
 
+func TestStudySelectionNamesInvalidSelectorAndSupportedModels(t *testing.T) {
+	selection := matrixSelectionFixture()
+	selection.Selector.Model = "grok-4-5"
+	err := validateMatrixSelection(selection)
+	if err == nil ||
+		!strings.Contains(err.Error(), `model "grok-4-5" with reasoning "low"`) ||
+		!strings.Contains(err.Error(), "grok-4.5") ||
+		!strings.Contains(err.Error(), "supported models:") {
+		t.Fatalf("invalid selector error = %v", err)
+	}
+}
+
 func TestStudySelectionBoundaryRejectsMalformedDocumentsAndTaskScopes(t *testing.T) {
 	selectionData, err := json.Marshal(matrixSelectionFixture())
 	if err != nil {

--- a/scripts/test-deepswe-planner.js
+++ b/scripts/test-deepswe-planner.js
@@ -572,6 +572,38 @@ test("copied selection matches the benchmark CLI schema", () => {
   );
 });
 
+test("copied selection translates provider model identities for the benchmark CLI", () => {
+  const { snapshot, buildBenchmarkSelection } = loadApplication();
+  const selection = {
+    estimatedSpend: 1,
+    rows: [{
+      id: "selected-task",
+      selected: true,
+      normalizedWeight: 1,
+      calibration: { intercept: 0.1, slope: 0.8 },
+      cell: { meanCost: 1 },
+    }],
+  };
+
+  const grok = snapshot.configurations.find(
+    (configuration) => configuration.model === "grok-4-5",
+  );
+  assert.ok(grok, "fixture snapshot must contain Grok 4.5");
+  assert.equal(
+    buildBenchmarkSelection(selection, grok.id, 1, 1).selector.model,
+    "grok-4.5",
+  );
+
+  const gemini = snapshot.configurations.find(
+    (configuration) => configuration.model === "gemini-3-5-flash",
+  );
+  assert.ok(gemini, "fixture snapshot must contain Gemini 3.5 Flash");
+  assert.equal(
+    buildBenchmarkSelection(selection, gemini.id, 1, 1).selector.model,
+    `gemini-3.5-flash-${gemini.reasoning}`,
+  );
+});
+
 test("benchmark selection identity matches the Go canonical identity", () => {
   const selection = {
     schema: "deepswe-benchmark-selection",

--- a/scripts/test-release/workflow_tests.sh
+++ b/scripts/test-release/workflow_tests.sh
@@ -1,5 +1,21 @@
 # Helper functions for CI/release workflow consistency tests in scripts/test-release.sh.
 
+# Print the YAML block for one GitHub Actions job, from its header through the
+# line before the next top-level job key.
+workflow_job_block() {
+  local file="$1"
+  local job="$2"
+  awk -v job="$job" '
+    $0 == "  " job ":" { grabbing = 1 }
+    grabbing {
+      if ($0 != "  " job ":" && /^  [^[:space:]]/) {
+        exit
+      }
+      print
+    }
+  ' "$file"
+}
+
 run_workflow_consistency_tests() {
   section "Workflow Consistency Tests"
 
@@ -22,12 +38,38 @@ run_workflow_consistency_tests() {
     fail "workflow-consistency: build-release must run on macos-latest for Developer ID signing"
   fi
 
-  if grep -q '^  catalog-readiness:' "$release_workflow" && \
-     grep -q '^    needs: catalog-readiness' "$release_workflow" && \
-     grep -q 'go run ./cmd/al benchmark readiness --task-concurrency 1 --remove-task-images' "$release_workflow"; then
+  local catalog_job build_job
+  catalog_job=$(workflow_job_block "$release_workflow" "catalog-readiness")
+  build_job=$(workflow_job_block "$release_workflow" "build-release")
+
+  if [[ -n "$catalog_job" && -n "$build_job" ]] && \
+     grep -q 'go run ./cmd/al benchmark readiness --task-concurrency 1 --remove-task-images' <<<"$catalog_job" && \
+     grep -q '^    needs: catalog-readiness$' <<<"$build_job"; then
     pass "workflow-consistency: pinned benchmark catalog readiness gates release builds"
   else
     fail "workflow-consistency: release builds must depend on the bounded-disk pinned catalog readiness audit"
+  fi
+
+  local catalog_validate_line catalog_checkout_line catalog_setup_line
+  local build_validate_line build_checkout_line build_setup_line
+  catalog_validate_line=$(grep -n 'name: Validate stable release tag format' <<<"$catalog_job" | head -n1 | cut -d: -f1 || true)
+  catalog_checkout_line=$(grep -n 'uses: actions/checkout@' <<<"$catalog_job" | head -n1 | cut -d: -f1 || true)
+  catalog_setup_line=$(grep -n 'uses: actions/setup-go@' <<<"$catalog_job" | head -n1 | cut -d: -f1 || true)
+  build_validate_line=$(grep -n 'name: Validate stable release tag format' <<<"$build_job" | head -n1 | cut -d: -f1 || true)
+  build_checkout_line=$(grep -n 'uses: actions/checkout@' <<<"$build_job" | head -n1 | cut -d: -f1 || true)
+  build_setup_line=$(grep -n 'uses: actions/setup-go@' <<<"$build_job" | head -n1 | cut -d: -f1 || true)
+
+  if [[ -n "$catalog_validate_line" && -n "$catalog_checkout_line" && -n "$catalog_setup_line" && \
+        -n "$build_validate_line" && -n "$build_checkout_line" && -n "$build_setup_line" && \
+        "$catalog_validate_line" -lt "$catalog_checkout_line" && "$catalog_checkout_line" -lt "$catalog_setup_line" && \
+        "$build_validate_line" -lt "$build_checkout_line" && "$build_checkout_line" -lt "$build_setup_line" ]] && \
+     grep -q 'ref: refs/tags/${{ env.RELEASE_TAG }}' <<<"$catalog_job" && \
+     grep -q 'ref: refs/tags/${{ env.RELEASE_TAG }}' <<<"$build_job" && \
+     awk '/uses: actions\/setup-go@/{found=1} found && /cache: false/{found=0; ok=1} found && /cache: true/{exit 1} END{exit !ok}' <<<"$catalog_job" && \
+     awk '/uses: actions\/setup-go@/{found=1} found && /cache: false/{found=0; ok=1} found && /cache: true/{exit 1} END{exit !ok}' <<<"$build_job"; then
+    pass "workflow-consistency: catalog-readiness and build-release validate the release tag before Go setup and do not cache unvalidated modules"
+  else
+    fail "workflow-consistency: catalog-readiness and build-release must validate the release tag before checkout and disable setup-go caching"
   fi
 
   if grep -q 'command -v rg' "$release_workflow" && grep -q 'brew install ripgrep' "$release_workflow"; then
@@ -40,8 +82,8 @@ run_workflow_consistency_tests() {
   # publish step, otherwise prerelease tags can publish artifacts before
   # failing downstream jobs.
   local stable_tag_check_line publish_release_line
-  stable_tag_check_line=$(grep -n 'name: Validate stable release tag format' "$release_workflow" | head -n1 | cut -d: -f1 || true)
-  publish_release_line=$(grep -n 'name: Publish release' "$release_workflow" | head -n1 | cut -d: -f1 || true)
+  stable_tag_check_line=$(grep -n 'name: Validate stable release tag format' <<<"$build_job" | head -n1 | cut -d: -f1 || true)
+  publish_release_line=$(grep -n 'name: Publish release' <<<"$build_job" | head -n1 | cut -d: -f1 || true)
 
   if [[ -z "$stable_tag_check_line" ]]; then
     fail "workflow-consistency: missing stable release tag validation step"

--- a/scripts/test-release/workflow_tests.sh
+++ b/scripts/test-release/workflow_tests.sh
@@ -22,6 +22,14 @@ run_workflow_consistency_tests() {
     fail "workflow-consistency: build-release must run on macos-latest for Developer ID signing"
   fi
 
+  if grep -q '^  catalog-readiness:' "$release_workflow" && \
+     grep -q '^    needs: catalog-readiness' "$release_workflow" && \
+     grep -q 'go run ./cmd/al benchmark readiness --task-concurrency 1 --remove-task-images' "$release_workflow"; then
+    pass "workflow-consistency: pinned benchmark catalog readiness gates release builds"
+  else
+    fail "workflow-consistency: release builds must depend on the bounded-disk pinned catalog readiness audit"
+  fi
+
   if grep -q 'command -v rg' "$release_workflow" && grep -q 'brew install ripgrep' "$release_workflow"; then
     pass "workflow-consistency: release workflow installs ripgrep via Homebrew when needed"
   else

--- a/site/static/deepswe-planner/app/index.html
+++ b/site/static/deepswe-planner/app/index.html
@@ -1689,6 +1689,25 @@ function configurationLabel(configurationId) {
 }
 
 /**
+ * Translate DeepSWE's published model identity to the exact model identity
+ * accepted by the benchmark CLI. Provider CLIs use dotted version numbers,
+ * and Antigravity encodes reasoning in its Gemini model slug.
+ * @param {object} configuration published DeepSWE configuration
+ * @returns {string} benchmark CLI model identity
+ */
+function benchmarkModelForConfiguration(configuration) {
+  if (configuration.model === "grok-4-5") return "grok-4.5";
+  if (configuration.model === "grok-4-6") return "grok-4.6";
+  if (
+    configuration.model === "gemini-3-5-flash" &&
+    ["low", "medium", "high"].includes(configuration.reasoning)
+  ) {
+    return `gemini-3.5-flash-${configuration.reasoning}`;
+  }
+  return configuration.model;
+}
+
+/**
  * Build the benchmark CLI's canonical selection document.
  * @param {object} selection selected rows and expected spend
  * @param {string} configurationId primary published configuration
@@ -1726,7 +1745,7 @@ function buildBenchmarkSelection(
       sha256: SNAPSHOT.source.sha256,
     },
     selector: {
-      model: configuration.model,
+      model: benchmarkModelForConfiguration(configuration),
       reasoning: configuration.reasoning,
       budgetUsd: budget,
       iterationsPerTask: iterations,


### PR DESCRIPTION
## Summary

- Gate release builds on certification of the pinned DeepSWE benchmark catalog.
- Bound readiness-audit Docker disk usage while preserving explicit failures.
- Keep planner and benchmark CLI model identities compatible and improve selector errors.

## Changes

- Add the release workflow readiness job and bounded-disk readiness option.
- Remove exact task images after successor certification and cover cleanup/error paths.
- Pin the catalog's versioned apt overlay to immutable Debian snapshots.
- Translate published Grok/Gemini model identities to canonical benchmark CLI identities.
- Add regression tests for the audit, model validation, planner handoff, and workflow gate.

## Verification

- `make ci` — passed: 4,559 Go tests (1 expected platform skip), 90.02% coverage, planner 16/16, release 103/103, and E2E 842/842.
- `git diff --check` — passed.
- Pre-commit hooks — passed: formatting, tidy check, lint, and Go tests.

## Notes

- The readiness job runs serially with exact task-image cleanup to keep the release runner's Docker disk bounded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release validation to confirm benchmark catalog readiness before builds proceed.
  * Added an option to remove certified task images during readiness checks, helping manage disk usage.
  * Improved benchmark model selection for Grok and reasoning-enabled Gemini configurations.
  * Enhanced validation messages for unsupported model selectors.

* **Bug Fixes**
  * Improved cleanup error reporting and handling of already-removed images.
  * Pinned readiness environments to stable package snapshots for more consistent results.

* **Tests**
  * Added coverage for release workflow checks, image cleanup behavior, model selection, and environment reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->