### PR TITLE
Allow missing Agent Layer env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ Agent Layer treats a denial as a failure rather than passing that answer through
 
 ### Secrets: `.agent-layer/.env`
 
-API tokens and other secrets live in `.agent-layer/.env` (always gitignored).
+API tokens and other secrets live in `.agent-layer/.env` (always gitignored). The file is optional: when no secrets are needed, it can be absent.
 
 **Important:** Only environment variables that start with the `AL_` prefix are sourced from `.env` (others are ignored). This convention avoids conflicts with your shell environment and ensures Agent Layer's variables don't override existing environment variables when VS Code terminals inherit the process environment.
 

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -46,6 +46,22 @@ func TestLoadEnvMissing(t *testing.T) {
 	}
 }
 
+func TestLoadEnvUnreadable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatalf("mkdir env path: %v", err)
+	}
+
+	_, err := LoadEnv(path)
+	if err == nil {
+		t.Fatal("expected error for unreadable env file")
+	}
+	if !strings.Contains(err.Error(), "failed to read env file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadEnvInvalidLine(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".env")

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -37,12 +37,12 @@ AL_QUOTED='value with spaces'
 }
 
 func TestLoadEnvMissing(t *testing.T) {
-	_, err := LoadEnv(filepath.Join(t.TempDir(), ".env"))
-	if err == nil {
-		t.Fatalf("expected missing env error")
+	env, err := LoadEnv(filepath.Join(t.TempDir(), ".env"))
+	if err != nil {
+		t.Fatalf("LoadEnv error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "missing env file") {
-		t.Fatalf("unexpected error: %v", err)
+	if len(env) != 0 {
+		t.Fatalf("expected empty env, got %#v", env)
 	}
 }
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -42,10 +42,14 @@ func LoadTemplateConfig() (*Config, error) {
 	return ParseConfig(data, "template config.toml")
 }
 
-// LoadEnv reads .agent-layer/.env into a key-value map.
+// LoadEnv reads .agent-layer/.env into a key-value map. A missing file is
+// equivalent to an empty environment; malformed or unreadable files fail.
 func LoadEnv(path string) (map[string]string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]string{}, nil
+		}
 		return nil, fmt.Errorf(messages.ConfigMissingEnvFileFmt, path, err)
 	}
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -50,7 +50,7 @@ func LoadEnv(path string) (map[string]string, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return map[string]string{}, nil
 		}
-		return nil, fmt.Errorf(messages.ConfigMissingEnvFileFmt, path, err)
+		return nil, fmt.Errorf(messages.ConfigFailedReadEnvFileFmt, path, err)
 	}
 
 	env, err := envfile.Parse(string(data))

--- a/internal/config/load_fs.go
+++ b/internal/config/load_fs.go
@@ -115,11 +115,16 @@ func LoadConfigFS(fsys fs.FS, root string, path string) (*Config, error) {
 	return ParseConfig(data, path)
 }
 
-// LoadEnvFS reads .agent-layer/.env from fsys into a key-value map.
+// LoadEnvFS reads .agent-layer/.env from fsys into a key-value map. A missing
+// file is equivalent to an empty environment; malformed or unreadable files
+// fail.
 // root is used for path resolution when path is absolute; path is used for error messages.
 func LoadEnvFS(fsys fs.FS, root string, path string) (map[string]string, error) {
 	data, err := readFileFS(fsys, root, path)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return map[string]string{}, nil
+		}
 		return nil, fmt.Errorf(messages.ConfigMissingEnvFileFmt, path, err)
 	}
 

--- a/internal/config/load_fs.go
+++ b/internal/config/load_fs.go
@@ -125,7 +125,7 @@ func LoadEnvFS(fsys fs.FS, root string, path string) (map[string]string, error) 
 		if errors.Is(err, fs.ErrNotExist) {
 			return map[string]string{}, nil
 		}
-		return nil, fmt.Errorf(messages.ConfigMissingEnvFileFmt, path, err)
+		return nil, fmt.Errorf(messages.ConfigFailedReadEnvFileFmt, path, err)
 	}
 
 	env, err := envfile.Parse(string(data))

--- a/internal/config/load_fs_test.go
+++ b/internal/config/load_fs_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	pathpkg "path"
@@ -142,6 +143,27 @@ func TestLoadEnvFS_Missing(t *testing.T) {
 	}
 	if len(env) != 0 {
 		t.Fatalf("expected empty env, got %#v", env)
+	}
+}
+
+func TestLoadEnvFS_Unreadable(t *testing.T) {
+	fsys := errorFS{
+		FS: fstest.MapFS{
+			".agent-layer/.env": {Data: []byte("AL_OK=1\n")},
+		},
+		errPath: ".agent-layer/.env",
+		err:     fs.ErrPermission,
+	}
+
+	_, err := LoadEnvFS(fsys, "root", ".agent-layer/.env")
+	if err == nil {
+		t.Fatal("expected error when env file cannot be read")
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("unreadable env file was treated as missing: %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to read env file") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/config/load_fs_test.go
+++ b/internal/config/load_fs_test.go
@@ -135,6 +135,16 @@ func TestLoadEnvFS_Invalid(t *testing.T) {
 	}
 }
 
+func TestLoadEnvFS_Missing(t *testing.T) {
+	env, err := LoadEnvFS(fstest.MapFS{}, "root", ".agent-layer/.env")
+	if err != nil {
+		t.Fatalf("LoadEnvFS error: %v", err)
+	}
+	if len(env) != 0 {
+		t.Fatalf("expected empty env, got %#v", env)
+	}
+}
+
 func TestLoadInstructionsFS_NoMarkdown(t *testing.T) {
 	fsys := fstest.MapFS{
 		".agent-layer/instructions":            {Mode: fs.ModeDir},

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -147,19 +147,23 @@ description: test command
 ---
 
 Do it.`
-	if err := os.WriteFile(filepath.Join(paths.SkillsDir, "hello.md"), []byte(cmdContent), 0o600); err != nil {
+	helloDir := filepath.Join(paths.SkillsDir, "hello")
+	if err := os.MkdirAll(helloDir, 0o700); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(helloDir, "SKILL.md"), []byte(cmdContent), 0o600); err != nil {
 		t.Fatalf("write skill: %v", err)
 	}
 	if err := os.WriteFile(paths.CommandsAllow, []byte("git status"), 0o600); err != nil {
 		t.Fatalf("write commands allow: %v", err)
 	}
 
-	_, err := LoadProjectConfig(root)
-	if err == nil {
-		t.Fatalf("expected missing env error")
+	project, err := LoadProjectConfig(root)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "missing env file") {
-		t.Fatalf("unexpected error: %v", err)
+	if len(project.Env) != 1 || project.Env[BuiltinRepoRootEnvVar] != root {
+		t.Fatalf("expected only built-in env, got %#v", project.Env)
 	}
 }
 

--- a/internal/messages/config.go
+++ b/internal/messages/config.go
@@ -10,7 +10,7 @@ const (
 	// ConfigMissingFileFmt formats missing config file errors.
 	ConfigMissingFileFmt        = "missing config file %s: %w"
 	ConfigFailedReadTemplateFmt = "failed to read template config.toml: %w"
-	ConfigMissingEnvFileFmt     = "missing env file %s: %w"
+	ConfigFailedReadEnvFileFmt  = "failed to read env file %s: %w"
 	ConfigInvalidEnvFileFmt     = "invalid env file %s: %w"
 	ConfigInvalidConfigFmt      = "invalid config %s: %w"
 	ConfigFSRequired            = "config filesystem is required"


### PR DESCRIPTION
## Summary

- Allow repositories with committed Agent Layer configuration to run when `.agent-layer/.env` is absent.
- Keep malformed and unreadable environment files as explicit errors.

## Changes

- Treat a missing `.agent-layer/.env` as an empty environment in both disk and `fs.FS` config loaders.
- Add regression coverage for missing environment files and full project loading without one.
- Document that the secrets file is optional when no secrets are needed.

## Verification

- `make test` — passed.
- Pre-commit hooks — passed, including formatting, lint, module tidiness, and `go test ./...`.
