### PR TITLE
fix: require structured provider terminal results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+- Agent Dispatch now uses structured provider output internally for every supported agent, including Antigravity display-name models, while returning only the extracted plain-text answer to callers.
+
+### Fixed
+- Antigravity exact-slug dispatches now allocate their structured event capture before provider execution instead of failing before launch.
+
 ## v0.17.6 - 2026-08-27
 
 ### Changed

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -62,10 +62,10 @@ For a release that changes Agent Dispatch, attach a short evidence record under
 exact `claude --version`, `codex --version`, `agy --version`, and
 `grok --version` values, plus a fresh `start`/`wait` probe and a
 `continue`/`wait` probe for every declared supported provider. A changed or
-missing Antigravity UUID line must also be
-shown to retain diagnostics and fail safe as `not resumable`; do not replace it
-with global/provider-private state lookup. This is release evidence, not a new
-public probe command.
+missing Antigravity structured terminal result must fail without publishing
+plain provider output. The result must carry a conversation ID, final answer,
+and usage evidence; any diagnostic-log UUID that is present must match the
+structured result. This is release evidence, not a new public probe command.
 
 ## GitHub release (automatic)
 1. Tag push triggers the release workflow.

--- a/internal/agentdispatch/dispatch.go
+++ b/internal/agentdispatch/dispatch.go
@@ -167,24 +167,16 @@ func executeDispatch(request dispatchExecution) error {
 				}
 				id = logID
 			}
-			if id == "" {
-				result.NotResumable = true
-				request.Run.Record.NotResumable = true
-				if _, err := fmt.Fprintf(request.Stderr, "[%s] antigravity · not resumable · agy %s · diagnostics: %s\n", session.Name, request.Version, command.LogPath); err != nil {
-					return finishDispatchFailure(request, wrapExitError(ExitTargetFailure, "write Antigravity capability warning", err))
-				}
-			} else {
-				if request.Mode == dispatchModeResume && id != session.ProviderSessionID {
-					return finishDispatchFailure(request, exitError(ExitTargetFailure, "Antigravity resume returned a different provider conversation ID"))
-				}
-				if err := persist(id); err != nil {
-					return finishDispatchFailure(request, err)
-				}
-				if err := os.Remove(command.LogPath); err != nil {
-					return finishDispatchFailure(request, wrapExitError(ExitConfig, "remove successful Antigravity dispatch log", err))
-				}
-				request.Run.Record.ProviderLogPath = ""
+			if request.Mode == dispatchModeResume && id != session.ProviderSessionID {
+				return finishDispatchFailure(request, exitError(ExitTargetFailure, "Antigravity resume returned a different provider conversation ID"))
 			}
+			if err := persist(id); err != nil {
+				return finishDispatchFailure(request, err)
+			}
+			if err := os.Remove(command.LogPath); err != nil {
+				return finishDispatchFailure(request, wrapExitError(ExitConfig, "remove successful Antigravity dispatch log", err))
+			}
+			request.Run.Record.ProviderLogPath = ""
 		}
 		return completeDispatchSuccess(request, result, session)
 	}
@@ -201,11 +193,7 @@ func completeDispatchSuccess(request dispatchExecution, result executionResult, 
 	}
 	now := time.Now().UTC()
 	request.Run.Record.State = dispatchStateCompleted
-	if result.NotResumable {
-		request.Run.Record.RecoveryState = recoveryNotResumable
-	} else {
-		request.Run.Record.RecoveryState = recoveryResumeRequired
-	}
+	request.Run.Record.RecoveryState = recoveryResumeRequired
 	request.Run.Record.CompletedAt = &now
 	request.Run.Record.TerminalExitCode = 0
 	request.Run.Record.ProviderSessionID = session.ProviderSessionID

--- a/internal/agentdispatch/dispatch_test.go
+++ b/internal/agentdispatch/dispatch_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/conn-castle/agent-layer/internal/templates"
 )
 
+const antigravityStructuredOK = `printf '{"event":"result","result":{"status":"SUCCESS","conversation_id":"22222222-2222-4222-8222-222222222222","response":"agy ok","usage":{"input_tokens":1,"output_tokens":2,"thinking_tokens":1,"cache_read_tokens":0}}}\n'`
+
 func TestRunUsesSuppliedRepositoryRootWithoutCreatingWorktree(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{})
 	git := func(args ...string) string {
@@ -300,7 +302,7 @@ func TestRunAntigravityUsesConfiguredModel(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{AntigravityModel: "Gemini 3.1 Pro (High)"})
 	binDir := t.TempDir()
 	logPath := filepath.Join(t.TempDir(), "agy.log")
-	writeDispatchStub(t, binDir, "agy", `printf 'agy ok'`)
+	writeDispatchStub(t, binDir, "agy", antigravityStructuredOK)
 	env := []string{
 		"PATH=" + testPath(binDir),
 		"AL_TEST_LOG=" + logPath,
@@ -323,14 +325,16 @@ func TestRunAntigravityUsesConfiguredModel(t *testing.T) {
 	}
 	assertFileContains(t, logPath, "ARG_3=--model")
 	assertFileContains(t, logPath, "ARG_4=Gemini 3.1 Pro (High)")
-	assertFileContains(t, logPath, "ARG_5=--print-timeout")
+	assertFileContains(t, logPath, "ARG_5=--output-format")
+	assertFileContains(t, logPath, "ARG_6=stream-json")
+	assertFileContains(t, logPath, "ARG_7=--print-timeout")
 }
 
 func TestRunAntigravityUsesModelOverride(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{AntigravityModel: "Gemini 3.1 Pro (High)"})
 	binDir := t.TempDir()
 	logPath := filepath.Join(t.TempDir(), "agy.log")
-	writeDispatchStub(t, binDir, "agy", `printf 'agy ok'`)
+	writeDispatchStub(t, binDir, "agy", antigravityStructuredOK)
 	env := []string{
 		"PATH=" + testPath(binDir),
 		"AL_TEST_LOG=" + logPath,
@@ -355,6 +359,61 @@ func TestRunAntigravityUsesModelOverride(t *testing.T) {
 	assertFileContains(t, logPath, "ARG_3=--model")
 	assertFileContains(t, logPath, "ARG_4=Gemini 3.5 Flash (High)")
 	assertFileDoesNotContain(t, logPath, "Gemini 3.1 Pro (High)")
+}
+
+func TestRunAntigravityExactSlugCapturesStructuredEvents(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "agy.log")
+	writeDispatchStub(t, binDir, "agy", `printf '{"event":"result","result":{"status":"SUCCESS","conversation_id":"22222222-2222-4222-8222-222222222222","response":"agy structured ok","usage":{"input_tokens":1,"output_tokens":2,"thinking_tokens":1,"cache_read_tokens":0}}}\n'`)
+	var stdout bytes.Buffer
+	err := executeFreshDispatch(dispatchExecRequest{
+		Root:            root,
+		Agent:           AgentAntigravity,
+		Model:           "gemini-3.5-flash-low",
+		ReasoningEffort: "low",
+		Prompt:          "Review",
+		Env:             []string{"PATH=" + testPath(binDir), "AL_TEST_LOG=" + logPath},
+		Stdout:          &stdout,
+		Stderr:          &bytes.Buffer{},
+		LookPath:        mockLookPath(binDir),
+	})
+	if err != nil {
+		t.Fatalf("exact-slug dispatch error: %v", err)
+	}
+	if stdout.String() != "agy structured ok" {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	assertFileContains(t, logPath, "ARG_5=--output-format")
+	assertFileContains(t, logPath, "ARG_6=stream-json")
+}
+
+func TestRunAntigravityRejectsMismatchedStreamAndDiagnosticIDs(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "agy.log")
+	writeDispatchStub(t, binDir, "agy", antigravityStructuredOK)
+	var stdout bytes.Buffer
+	err := executeFreshDispatch(dispatchExecRequest{
+		Root:   root,
+		Agent:  AgentAntigravity,
+		Prompt: "Review",
+		Env: []string{
+			"PATH=" + testPath(binDir),
+			"AL_TEST_LOG=" + logPath,
+			"AL_TEST_AGY_LOG_ID=33333333-3333-4333-8333-333333333333",
+		},
+		Stdout:   &stdout,
+		Stderr:   &bytes.Buffer{},
+		LookPath: mockLookPath(binDir),
+	})
+	requireDispatchExitCode(t, err, ExitTargetFailure)
+	if stdout.Len() != 0 {
+		t.Fatalf("mismatched Antigravity answer leaked to caller: %q", stdout.String())
+	}
+	if !strings.Contains(err.Error(), "different provider conversation IDs") {
+		t.Fatalf("mismatch error = %q", err)
+	}
 }
 
 func TestClaudeSkillPromptAndCommandConstruction(t *testing.T) {
@@ -479,7 +538,7 @@ func TestAntigravityCommandConstruction(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := filepath.Join(t.TempDir(), "agy.log")
 	promptPath := filepath.Join(t.TempDir(), "agy.prompt")
-	writeDispatchStub(t, binDir, "agy", `printf 'agy ok'`)
+	writeDispatchStub(t, binDir, "agy", antigravityStructuredOK)
 	env := []string{
 		"PATH=" + testPath(binDir),
 		"AL_TEST_LOG=" + logPath,
@@ -502,9 +561,11 @@ func TestAntigravityCommandConstruction(t *testing.T) {
 		t.Fatalf("stdout = %q", stdout.String())
 	}
 	assertFileContains(t, logPath, "ARG_0=--gemini_dir="+filepath.Join(root, ".agy"))
-	assertFileContains(t, logPath, "ARG_3=--print-timeout")
-	assertFileContains(t, logPath, "ARG_4="+AntigravityPrintTimeout)
-	assertFileContains(t, logPath, "ARG_5=--print")
+	assertFileContains(t, logPath, "ARG_3=--output-format")
+	assertFileContains(t, logPath, "ARG_4=stream-json")
+	assertFileContains(t, logPath, "ARG_5=--print-timeout")
+	assertFileContains(t, logPath, "ARG_6="+AntigravityPrintTimeout)
+	assertFileContains(t, logPath, "ARG_7=--print")
 	assertFileContains(t, logPath, "AGY_CLI_DISABLE_AUTO_UPDATE=1")
 }
 
@@ -718,7 +779,7 @@ if [ %q = "agy" ]; then
   previous=""
   for arg in "$@"; do
     if [ "$previous" = "log" ]; then
-      printf 'Created conversation 22222222-2222-4222-8222-222222222222\n' > "$arg"
+      printf 'Created conversation %%s\n' "${AL_TEST_AGY_LOG_ID:-22222222-2222-4222-8222-222222222222}" > "$arg"
       previous=""
       continue
     fi

--- a/internal/agentdispatch/dispatch_test.go
+++ b/internal/agentdispatch/dispatch_test.go
@@ -384,6 +384,8 @@ func TestRunAntigravityExactSlugCapturesStructuredEvents(t *testing.T) {
 	if stdout.String() != "agy structured ok" {
 		t.Fatalf("stdout = %q", stdout.String())
 	}
+	assertFileContains(t, logPath, "ARG_3=--model")
+	assertFileContains(t, logPath, "ARG_4=gemini-3.5-flash-low")
 	assertFileContains(t, logPath, "ARG_5=--output-format")
 	assertFileContains(t, logPath, "ARG_6=stream-json")
 }

--- a/internal/agentdispatch/failure_contract_test.go
+++ b/internal/agentdispatch/failure_contract_test.go
@@ -70,7 +70,7 @@ func TestRunnerFailsLoudlyForProviderAndCaptureFailures(t *testing.T) {
 	}
 
 	preStart := newRun(t)
-	_, err := executeProvider(providerCommand{Path: filepath.Join(root, "missing-provider"), Provider: AgentCodex, Structured: true, SessionID: runtimeSessionID}, nil, preStart, root, nil, func(string) error { return nil })
+	_, err := executeProvider(providerCommand{Path: filepath.Join(root, "missing-provider"), Provider: AgentCodex, SessionID: runtimeSessionID}, nil, preStart, root, nil, func(string) error { return nil })
 	var start *preStartFailure
 	if !errors.As(err, &start) {
 		t.Fatalf("start error = %T: %v", err, err)
@@ -80,12 +80,11 @@ func TestRunnerFailsLoudlyForProviderAndCaptureFailures(t *testing.T) {
 	terminationTestDeadline := 3 * providerTerminationGrace
 	failedStarted := time.Now()
 	_, err = executeProvider(providerCommand{
-		Path:       "/bin/sh",
-		Args:       []string{"-c", `trap '' TERM; printf '{"type":"turn.failed","message":"provider refused"}\n'; while :; do sleep 1; done`},
-		Env:        os.Environ(),
-		Provider:   AgentCodex,
-		SessionID:  runtimeSessionID,
-		Structured: true,
+		Path:      "/bin/sh",
+		Args:      []string{"-c", `trap '' TERM; printf '{"type":"turn.failed","message":"provider refused"}\n'; while :; do sleep 1; done`},
+		Env:       os.Environ(),
+		Provider:  AgentCodex,
+		SessionID: runtimeSessionID,
 	}, nil, failedRun, root, nil, func(string) error { return nil })
 	requireDispatchExitCode(t, err, ExitTargetFailure)
 	if elapsed := time.Since(failedStarted); elapsed > terminationTestDeadline {
@@ -95,7 +94,7 @@ func TestRunnerFailsLoudlyForProviderAndCaptureFailures(t *testing.T) {
 	publicationRun := newRun(t)
 	publicationStarted := time.Now()
 	_, err = executeProvider(providerCommand{
-		Path: "/bin/sh", Env: os.Environ(), Provider: AgentAntigravity, Plain: true,
+		Path: "/bin/sh", Env: os.Environ(), Provider: AgentCodex, SessionID: runtimeSessionID,
 	}, nil, publicationRun, root, func(string, ...string) *exec.Cmd {
 		current, loadErr := loadRunRecord(root, publicationRun.Record.ID)
 		if loadErr != nil {
@@ -116,7 +115,7 @@ func TestRunnerFailsLoudlyForProviderAndCaptureFailures(t *testing.T) {
 	if err := os.WriteFile(timeoutLog, []byte("Error: timeout waiting for response\n"), 0o600); err != nil {
 		t.Fatalf("write timeout log: %v", err)
 	}
-	_, err = executeProvider(providerCommand{Path: "/bin/sh", Args: []string{"-c", `printf answer`}, Env: os.Environ(), Provider: AgentAntigravity, Plain: true, LogPath: timeoutLog}, nil, timeoutRun, root, nil, func(string) error { return nil })
+	_, err = executeProvider(providerCommand{Path: "/bin/sh", Args: []string{"-c", `printf '{"event":"result","result":{"status":"SUCCESS","conversation_id":"conversation","response":"answer","usage":{"input_tokens":1}}}\n'`}, Env: os.Environ(), Provider: AgentAntigravity, LogPath: timeoutLog}, nil, timeoutRun, root, nil, func(string) error { return nil })
 	requireDispatchExitCode(t, err, ExitTargetFailure)
 	if timedOut, readErr := antigravityTimeoutReported(timeoutRun.Record.StderrPath, filepath.Join(root, "missing-log")); readErr == nil || timedOut {
 		t.Fatalf("missing Antigravity diagnostics = timedOut %t, error %v", timedOut, readErr)

--- a/internal/agentdispatch/provider.go
+++ b/internal/agentdispatch/provider.go
@@ -114,12 +114,10 @@ type providerCommand struct {
 	Args          []string
 	Env           []string
 	WorkDir       string
-	Plain         bool
 	SessionID     string
 	LogPath       string
 	Provider      string
 	RunMode       string
-	Structured    bool
 	Model         string
 	Effort        string
 	ClaudeLineage bool
@@ -302,7 +300,6 @@ func buildProviderCommand(
 		command.Env = clients.UnsetEnv(command.Env, claudePrintBackgroundWaitCeilingEnv)
 		command.Env = clients.SetEnv(command.Env, claudePrintBackgroundWaitCeilingEnv, claudePrintBackgroundWaitCeilingValue)
 		command.SessionID = sessionID
-		command.Structured = true
 		command.ClaudeLineage = lineage
 	case AgentCodex:
 		args := []string{"exec"}
@@ -350,7 +347,6 @@ func buildProviderCommand(
 		command.Args = args
 		command.Env = codex.ConfigureEnvironment(project.Root, env, project.Config.Agents.Codex, diagnostics)
 		command.SessionID = sessionID
-		command.Structured = true
 	case AgentAntigravity:
 		if len(prompt) > AntigravityPromptMaxBytes {
 			return providerCommand{}, exitError(ExitUsage, fmt.Sprintf("antigravity prompt is %d bytes; `al dispatch` caps it at %d bytes because agy --print has no stdin/file path. Use --agent claude or --agent codex for larger prompts.", len(prompt), AntigravityPromptMaxBytes))
@@ -379,9 +375,6 @@ func buildProviderCommand(
 		if mode == dispatchModeResume {
 			args = append(args, "--conversation", sessionID)
 		}
-		// Thinking-tier slugs, not session TargetPinned, select stream-json.
-		// TargetPinned is set on every durable resume, including ordinary
-		// display-name conversations that must keep historical plain output.
 		if derivedEffort, ok := antigravitySlugEffort(resolvedModel); ok {
 			configured := strings.TrimSpace(effort)
 			if configured != "" && configured != derivedEffort {
@@ -390,13 +383,10 @@ func buildProviderCommand(
 			// The exact benchmark model slug selects its thinking tier. Passing a
 			// second effort flag risks contradictory client behavior.
 			command.Effort = derivedEffort
-			args = append(args, "--output-format", "stream-json")
-			command.Plain = false
-			command.Structured = true
 		} else {
 			command.Effort = strings.TrimSpace(effort)
-			command.Plain = true
 		}
+		args = append(args, "--output-format", "stream-json")
 		args = append(args, "--print-timeout", AntigravityPrintTimeout, "--print", string(prompt))
 		command.Args = args
 		command.Env = antigravity.ConfigureEnvironment(env)
@@ -458,7 +448,6 @@ func buildProviderCommand(
 		}
 		command.Env = grok.ConfigureEnvironment(project.Root, env, project.Config.Agents.Grok, diagnostics)
 		command.SessionID = sessionID
-		command.Structured = true
 	default:
 		return providerCommand{}, exitError(ExitUsage, fmt.Sprintf("unsupported dispatch provider %q", target.Name))
 	}

--- a/internal/agentdispatch/provider_runner_test.go
+++ b/internal/agentdispatch/provider_runner_test.go
@@ -673,6 +673,36 @@ func TestRunnerBuffersOnlyCompletedAnswer(t *testing.T) {
 	}
 }
 
+func TestRunnerDerivesMissingEventsPath(t *testing.T) {
+	root := t.TempDir()
+	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
+	if err != nil {
+		t.Fatalf("new run: %v", err)
+	}
+	run.Record.EventsPath = ""
+	if err := writeRunRecord(run.Dir, &run.Record); err != nil {
+		t.Fatalf("write legacy run record: %v", err)
+	}
+
+	result, err := executeProvider(providerCommand{
+		Path:      "/bin/sh",
+		Args:      []string{"-c", `printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"answer"}\n{"type":"turn.completed"}\n'`},
+		Env:       os.Environ(),
+		Provider:  AgentCodex,
+		SessionID: runtimeSessionID,
+	}, []byte("prompt"), run, root, nil, func(string) error { return nil })
+	if err != nil || !result.Complete {
+		t.Fatalf("legacy run result=%#v err=%v", result, err)
+	}
+	wantPath := filepath.Join(run.Dir, "provider.events")
+	if run.Record.EventsPath != wantPath {
+		t.Fatalf("events path = %q, want %q", run.Record.EventsPath, wantPath)
+	}
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("stat derived events capture: %v", err)
+	}
+}
+
 func TestClaudeRunnerReadsLineageAndLatestResultThroughEOF(t *testing.T) {
 	root := t.TempDir()
 	run, err := newDispatchRun(root, AgentClaude, "2.1.212", dispatchModeFresh)

--- a/internal/agentdispatch/provider_runner_test.go
+++ b/internal/agentdispatch/provider_runner_test.go
@@ -42,7 +42,7 @@ func TestProviderCommandsUseExactProviderContracts(t *testing.T) {
 		t.Fatalf("build Claude command: %v", err)
 	}
 	claudeArgs := strings.Join(claudeCommand.Args, " ")
-	if !claudeCommand.Structured || !strings.Contains(claudeArgs, "--session-id "+runtimeSessionID) || !strings.Contains(claudeArgs, "--model override") || !strings.Contains(claudeArgs, "--effort high") {
+	if !strings.Contains(claudeArgs, "--session-id "+runtimeSessionID) || !strings.Contains(claudeArgs, "--model override") || !strings.Contains(claudeArgs, "--effort high") {
 		t.Fatalf("Claude command = %#v", claudeCommand)
 	}
 
@@ -84,7 +84,7 @@ func TestProviderCommandsUseExactProviderContracts(t *testing.T) {
 		t.Fatalf("build slug Antigravity command: %v", err)
 	}
 	antigravityArgs := strings.Join(antigravityCommand.Args, " ")
-	if !antigravityCommand.Structured || antigravityCommand.Plain || antigravityCommand.Effort != "low" || !strings.Contains(antigravityArgs, "--model gemini-3.5-flash-low") || !strings.Contains(antigravityArgs, "--output-format stream-json") || strings.Contains(antigravityArgs, "--effort") {
+	if antigravityCommand.Effort != "low" || !strings.Contains(antigravityArgs, "--model gemini-3.5-flash-low") || !strings.Contains(antigravityArgs, "--output-format stream-json") || strings.Contains(antigravityArgs, "--effort") {
 		t.Fatalf("slug Antigravity command = %#v", antigravityCommand)
 	}
 	conflictRun, err := newDispatchRun(root, AgentAntigravity, supportedProviderVersions[AgentAntigravity], dispatchModeFresh)
@@ -96,17 +96,17 @@ func TestProviderCommandsUseExactProviderContracts(t *testing.T) {
 	} else {
 		requireDispatchExitCode(t, err, ExitConfig)
 	}
-	plainRun, err := newDispatchRun(root, AgentAntigravity, supportedProviderVersions[AgentAntigravity], dispatchModeResume)
+	displayRun, err := newDispatchRun(root, AgentAntigravity, supportedProviderVersions[AgentAntigravity], dispatchModeResume)
 	if err != nil {
-		t.Fatalf("new Antigravity resume run: %v", err)
+		t.Fatalf("new display-name Antigravity resume run: %v", err)
 	}
-	plainCommand, err := buildProviderCommand(antigravityTarget, project, nil, []byte("prompt"), "Gemini 3.5 Flash (High)", "", true, dispatchModeResume, runtimeSessionID, plainRun, io.Discard)
+	displayCommand, err := buildProviderCommand(antigravityTarget, project, nil, []byte("prompt"), "Gemini 3.5 Flash (High)", "", true, dispatchModeResume, runtimeSessionID, displayRun, io.Discard)
 	if err != nil {
 		t.Fatalf("build durable display-name Antigravity command: %v", err)
 	}
-	plainArgs := strings.Join(plainCommand.Args, " ")
-	if !plainCommand.Plain || plainCommand.Structured || strings.Contains(plainArgs, "--output-format") {
-		t.Fatalf("durable display-name Antigravity command = %#v", plainCommand)
+	displayArgs := strings.Join(displayCommand.Args, " ")
+	if !strings.Contains(displayArgs, "--output-format stream-json") {
+		t.Fatalf("durable display-name Antigravity command = %#v", displayCommand)
 	}
 
 	grokTarget, ok := lookupTarget(AgentGrok)
@@ -118,7 +118,7 @@ func TestProviderCommandsUseExactProviderContracts(t *testing.T) {
 		t.Fatalf("build Grok command: %v", err)
 	}
 	grokArgs := strings.Join(grokCommand.Args, " ")
-	if !grokCommand.Structured || !slices.Contains(grokCommand.Args, "--no-auto-update") || !strings.Contains(grokArgs, "--session-id "+runtimeSessionID) || !strings.Contains(grokArgs, "--model grok-4.6") || !strings.Contains(grokArgs, "--reasoning-effort high") || !strings.Contains(grokArgs, "--output-format streaming-json") || !strings.Contains(grokArgs, "--permission-mode bypassPermissions --always-approve") {
+	if !slices.Contains(grokCommand.Args, "--no-auto-update") || !strings.Contains(grokArgs, "--session-id "+runtimeSessionID) || !strings.Contains(grokArgs, "--model grok-4.6") || !strings.Contains(grokArgs, "--reasoning-effort high") || !strings.Contains(grokArgs, "--output-format streaming-json") || !strings.Contains(grokArgs, "--permission-mode bypassPermissions --always-approve") {
 		t.Fatalf("Grok command = %#v", grokCommand)
 	}
 	if home, ok := clients.GetEnv(grokCommand.Env, clientgrok.EnvHome); !ok || home != clientgrok.HomeDir(root) {
@@ -593,17 +593,6 @@ func TestSelectiveJSONReaderTruncatesRetainedAnswerAndConsumesRecord(t *testing.
 	}
 }
 
-func TestAnswerPrefixBufferTruncatesWithoutShortWrite(t *testing.T) {
-	buffer := answerPrefixBuffer{limit: 8}
-	written, err := buffer.Write([]byte("abcdefghijk"))
-	if err != nil || written != len("abcdefghijk") {
-		t.Fatalf("answer prefix write = %d, %v", written, err)
-	}
-	if got := buffer.String(); got != "abcdefgh"+truncatedAnswerNotice {
-		t.Fatalf("truncated plain answer = %q", got)
-	}
-}
-
 func TestRetainedAnswerTruncationDropsIncompleteUTF8Rune(t *testing.T) {
 	parser := newSelectiveJSONReader()
 	parser.retainedStringBytes = 1
@@ -615,14 +604,6 @@ func TestRetainedAnswerTruncationDropsIncompleteUTF8Rune(t *testing.T) {
 	events := reduceCodexEvent(value.Fields)
 	if len(events) != 1 || events[0].Answer != truncatedAnswerNotice {
 		t.Fatalf("UTF-8 structured truncation events = %#v", events)
-	}
-
-	buffer := answerPrefixBuffer{limit: 1}
-	if _, err := buffer.Write([]byte("éx")); err != nil {
-		t.Fatalf("write UTF-8 plain answer: %v", err)
-	}
-	if got := buffer.String(); got != truncatedAnswerNotice {
-		t.Fatalf("UTF-8 plain truncation = %q", got)
 	}
 }
 
@@ -652,12 +633,11 @@ func TestRunnerBuffersOnlyCompletedAnswer(t *testing.T) {
 	}
 	var persisted string
 	result, err := executeProvider(providerCommand{
-		Path:       "/bin/sh",
-		Args:       []string{"-c", `printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"answer"}\n{"type":"turn.completed"}\n'`},
-		Env:        os.Environ(),
-		Provider:   AgentCodex,
-		SessionID:  runtimeSessionID,
-		Structured: true,
+		Path:      "/bin/sh",
+		Args:      []string{"-c", `printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"answer"}\n{"type":"turn.completed"}\n'`},
+		Env:       os.Environ(),
+		Provider:  AgentCodex,
+		SessionID: runtimeSessionID,
 	}, []byte("prompt"), successfulRun, root, nil, func(id string) error {
 		persisted = id
 		return nil
@@ -677,12 +657,11 @@ func TestRunnerBuffersOnlyCompletedAnswer(t *testing.T) {
 		t.Fatalf("new incomplete run: %v", err)
 	}
 	_, err = executeProvider(providerCommand{
-		Path:       "/bin/sh",
-		Args:       []string{"-c", `printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"partial"}\n'`},
-		Env:        os.Environ(),
-		Provider:   AgentCodex,
-		SessionID:  runtimeSessionID,
-		Structured: true,
+		Path:      "/bin/sh",
+		Args:      []string{"-c", `printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"partial"}\n'`},
+		Env:       os.Environ(),
+		Provider:  AgentCodex,
+		SessionID: runtimeSessionID,
 	}, []byte("prompt"), incompleteRun, root, nil, func(string) error { return nil })
 	requireDispatchExitCode(t, err, ExitTargetFailure)
 	if _, readErr := os.Stat(incompleteRun.Record.AnswerPath); !os.IsNotExist(readErr) {
@@ -710,7 +689,6 @@ func TestClaudeRunnerReadsLineageAndLatestResultThroughEOF(t *testing.T) {
 		Env:           os.Environ(),
 		Provider:      AgentClaude,
 		SessionID:     runtimeSessionID,
-		Structured:    true,
 		ClaudeLineage: true,
 	}, []byte("prompt"), run, root, nil, func(string) error { return nil })
 	if err != nil {
@@ -932,12 +910,11 @@ func TestGrokRunnerReadsStreamingJSONThroughEOF(t *testing.T) {
 		`{"type":"text","data":"Grok output"}` + "\n" +
 		`{"type":"end","sessionId":"` + runtimeSessionID + `","stopReason":"end_turn"}` + "\n"
 	result, err := executeProvider(providerCommand{
-		Path:       "/bin/sh",
-		Args:       []string{"-c", `printf '%s' "$1"`, "sh", fixtureContent},
-		Env:        os.Environ(),
-		Provider:   AgentGrok,
-		SessionID:  runtimeSessionID,
-		Structured: true,
+		Path:      "/bin/sh",
+		Args:      []string{"-c", `printf '%s' "$1"`, "sh", fixtureContent},
+		Env:       os.Environ(),
+		Provider:  AgentGrok,
+		SessionID: runtimeSessionID,
 	}, []byte("prompt"), run, root, nil, func(string) error { return nil })
 	if err != nil {
 		t.Fatal(err)
@@ -1018,12 +995,11 @@ func TestGrokRunnerFailsProviderObservedPermissionDenial(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = executeProvider(providerCommand{
-		Path:       "/bin/sh",
-		Args:       []string{"-c", `printf '%s' "$1"`, "sh", string(streamData)},
-		Env:        os.Environ(),
-		Provider:   AgentGrok,
-		SessionID:  runtimeSessionID,
-		Structured: true,
+		Path:      "/bin/sh",
+		Args:      []string{"-c", `printf '%s' "$1"`, "sh", string(streamData)},
+		Env:       os.Environ(),
+		Provider:  AgentGrok,
+		SessionID: runtimeSessionID,
 	}, []byte("prompt"), run, root, nil, func(string) error { return nil })
 	if err == nil || !strings.Contains(err.Error(), "Denied by permission policy") {
 		t.Fatalf("denied provider run error = %v", err)

--- a/internal/agentdispatch/runner.go
+++ b/internal/agentdispatch/runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -91,6 +92,9 @@ func executeProvider(
 		return executionResult{}, wrapExitError(ExitConfig, "create dispatch stderr capture", err)
 	}
 	defer func() { _ = providerStderr.Close() }()
+	if run.Record.EventsPath == "" {
+		run.Record.EventsPath = filepath.Join(run.Dir, "provider.events")
+	}
 	events, err := newCaptureWriter(run.Record.EventsPath)
 	if err != nil {
 		return executionResult{}, wrapExitError(ExitConfig, "create dispatch event capture", err)

--- a/internal/agentdispatch/runner.go
+++ b/internal/agentdispatch/runner.go
@@ -16,42 +16,6 @@ type captureWriter struct {
 	mu   sync.Mutex
 }
 
-// answerPrefixBuffer retains a bounded answer prefix while reporting complete
-// writes so the provider's full stdout continues streaming to raw evidence.
-type answerPrefixBuffer struct {
-	buffer    bytes.Buffer
-	limit     int
-	truncated bool
-}
-
-func (w *answerPrefixBuffer) Write(data []byte) (int, error) {
-	received := len(data)
-	limit := w.limit
-	if limit <= 0 {
-		limit = maxRetainedAnswerBytes
-	}
-	remaining := limit - w.buffer.Len()
-	if remaining > 0 {
-		_, _ = w.buffer.Write(data[:min(remaining, received)])
-	}
-	if received > remaining {
-		w.truncated = true
-	}
-	return received, nil
-}
-
-func (w *answerPrefixBuffer) String() string {
-	retained := w.buffer.Bytes()
-	if w.truncated {
-		retained = retained[:validUTF8PrefixLength(retained)]
-	}
-	answer := string(retained)
-	if w.truncated {
-		answer += truncatedAnswerNotice
-	}
-	return answer
-}
-
 func newCaptureWriter(path string) (*captureWriter, error) {
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) // #nosec G304 -- path is in an isolated dispatch run directory.
 	if err != nil {
@@ -81,11 +45,10 @@ func (w *captureWriter) Close() error {
 }
 
 type executionResult struct {
-	SessionID    string
-	Complete     bool
-	AnswerSeen   bool
-	NotResumable bool
-	Answer       string
+	SessionID  string
+	Complete   bool
+	AnswerSeen bool
+	Answer     string
 }
 
 // unprovenProviderTerminationError marks a provider failure whose process
@@ -128,14 +91,11 @@ func executeProvider(
 		return executionResult{}, wrapExitError(ExitConfig, "create dispatch stderr capture", err)
 	}
 	defer func() { _ = providerStderr.Close() }()
-	var events *captureWriter
-	if command.Structured {
-		events, err = newCaptureWriter(run.Record.EventsPath)
-		if err != nil {
-			return executionResult{}, wrapExitError(ExitConfig, "create dispatch event capture", err)
-		}
-		defer func() { _ = events.Close() }()
+	events, err := newCaptureWriter(run.Record.EventsPath)
+	if err != nil {
+		return executionResult{}, wrapExitError(ExitConfig, "create dispatch event capture", err)
 	}
+	defer func() { _ = events.Close() }()
 	var lineage *captureWriter
 	if command.ClaudeLineage {
 		if run.Record.LineagePath == "" {
@@ -154,11 +114,7 @@ func executeProvider(
 		cmd.Dir = root
 	}
 	cmd.Env = command.Env
-	if command.Plain {
-		cmd.Stdin = nil
-	} else {
-		cmd.Stdin = bytes.NewReader(prompt)
-	}
+	cmd.Stdin = bytes.NewReader(prompt)
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return executionResult{}, wrapExitError(ExitTargetFailure, "open dispatch provider stdout", err)
@@ -283,24 +239,6 @@ func executeProvider(
 	streamErr := make(chan error, 1)
 	stderrErr := make(chan error, 1)
 	go func() {
-		if command.Plain {
-			var candidate answerPrefixBuffer
-			_, err := io.Copy(io.MultiWriter(providerStdout, &candidate), stdoutPipe)
-			if err == nil {
-				resultMu.Lock()
-				pendingAnswer = candidate.String()
-				result.AnswerSeen = candidate.buffer.Len() > 0
-				now := time.Now().UTC()
-				run.Record.LastOutputAt = &now
-				run.Record.LastActivityAt = &now
-				resultMu.Unlock()
-			}
-			if err != nil {
-				setFailure(fmt.Errorf("capture provider stdout: %w", err))
-			}
-			streamErr <- err
-			return
-		}
 		err := readStructuredEventsWithLineage(stdoutPipe, providerStdout, command.Provider, command.SessionID, command.ClaudeLineage, func(event providerEvent) error {
 			encoded, marshalErr := json.Marshal(event)
 			if marshalErr != nil {
@@ -382,11 +320,8 @@ func executeProvider(
 			return executionResult{}, exitError(ExitTargetFailure, "antigravity reported terminal failure: Error: timeout waiting for response")
 		}
 	}
-	if command.Structured && (!result.Complete || !result.AnswerSeen || result.SessionID == "") {
+	if !result.Complete || !result.AnswerSeen || result.SessionID == "" {
 		return executionResult{}, exitError(ExitTargetFailure, fmt.Sprintf("%s dispatch completed without required terminal result, session ID, and final answer", command.Provider))
-	}
-	if command.Plain && !result.AnswerSeen {
-		return executionResult{}, exitError(ExitTargetFailure, "antigravity dispatch completed without a final answer")
 	}
 	resultMu.Lock()
 	terminalAnswer := pendingAnswer

--- a/internal/agentdispatch/runtime_test.go
+++ b/internal/agentdispatch/runtime_test.go
@@ -73,12 +73,11 @@ func TestRunnerRequiresProviderTerminalEvidence(t *testing.T) {
 		t.Fatalf("new run: %v", err)
 	}
 	_, err = executeProvider(providerCommand{
-		Path:       "/bin/sh",
-		Args:       []string{"-c", `printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"partial"}\n'`},
-		Env:        os.Environ(),
-		Provider:   AgentCodex,
-		SessionID:  runtimeSessionID,
-		Structured: true,
+		Path:      "/bin/sh",
+		Args:      []string{"-c", `printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n{"type":"agent_message","message":"partial"}\n'`},
+		Env:       os.Environ(),
+		Provider:  AgentCodex,
+		SessionID: runtimeSessionID,
 	}, []byte("prompt"), run, root, nil, func(string) error { return nil })
 	requireDispatchExitCode(t, err, ExitTargetFailure)
 

--- a/internal/agentdispatch/state.go
+++ b/internal/agentdispatch/state.go
@@ -182,9 +182,7 @@ func newDispatchRun(root string, agent string, version string, mode string) (*di
 		AnswerPath:            filepath.Join(dir, "result.md"),
 		StdoutPath:            filepath.Join(dir, "provider.stdout"),
 		StderrPath:            filepath.Join(dir, "provider.stderr"),
-	}
-	if providerProducesStructuredEvents(agent) {
-		record.EventsPath = filepath.Join(dir, "provider.events")
+		EventsPath:            filepath.Join(dir, "provider.events"),
 	}
 	if claudeLineage {
 		record.LineagePath = filepath.Join(dir, "provider.lineage")
@@ -193,10 +191,6 @@ func newDispatchRun(root string, agent string, version string, mode string) (*di
 		return nil, err
 	}
 	return &dispatchRun{Record: record, Dir: dir}, nil
-}
-
-func providerProducesStructuredEvents(agent string) bool {
-	return agent == AgentClaude || agent == AgentCodex || agent == AgentGrok
 }
 
 func newUUID() (string, error) {

--- a/internal/agentdispatch/state_operations_test.go
+++ b/internal/agentdispatch/state_operations_test.go
@@ -107,7 +107,7 @@ func TestGrokSessionRoundTripsThroughStateStore(t *testing.T) {
 	}
 }
 
-func TestNewDispatchRunAdvertisesOnlyApplicableEventArtifact(t *testing.T) {
+func TestNewDispatchRunAdvertisesEventsAndOnlyApplicableLineage(t *testing.T) {
 	root := t.TempDir()
 	structured, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
 	if err != nil {
@@ -134,19 +134,19 @@ func TestNewDispatchRunAdvertisesOnlyApplicableEventArtifact(t *testing.T) {
 		t.Fatalf("old Claude advertised lineage path %q", oldClaude.Record.LineagePath)
 	}
 
-	plain, err := newDispatchRun(root, AgentAntigravity, supportedProviderVersions[AgentAntigravity], dispatchModeFresh)
+	antigravity, err := newDispatchRun(root, AgentAntigravity, supportedProviderVersions[AgentAntigravity], dispatchModeFresh)
 	if err != nil {
-		t.Fatalf("new plain run: %v", err)
+		t.Fatalf("new Antigravity run: %v", err)
 	}
-	if plain.Record.EventsPath != "" {
-		t.Fatalf("plain provider advertised events path %q", plain.Record.EventsPath)
+	if antigravity.Record.EventsPath != filepath.Join(antigravity.Dir, "provider.events") {
+		t.Fatalf("Antigravity events path = %q", antigravity.Record.EventsPath)
 	}
-	data, err := os.ReadFile(filepath.Join(plain.Dir, dispatchRunFile)) // #nosec G304 -- test-owned run path.
+	data, err := os.ReadFile(filepath.Join(antigravity.Dir, dispatchRunFile)) // #nosec G304 -- test-owned run path.
 	if err != nil {
-		t.Fatalf("read plain run record: %v", err)
+		t.Fatalf("read Antigravity run record: %v", err)
 	}
-	if strings.Contains(string(data), `"events_path"`) {
-		t.Fatalf("plain run record advertised an events artifact: %s", data)
+	if !strings.Contains(string(data), `"events_path"`) {
+		t.Fatalf("Antigravity run record omitted its events artifact: %s", data)
 	}
 }
 

--- a/internal/agentdispatch/v013_test.go
+++ b/internal/agentdispatch/v013_test.go
@@ -206,7 +206,7 @@ func identityName(t *testing.T, stderr string) string {
 	return trimmed[1:end]
 }
 
-func TestAntigravitySuccessfulAnswerWithoutIDIsNotResumable(t *testing.T) {
+func TestAntigravityPlainOutputIsRejected(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{})
 	binDir := t.TempDir()
 	path := filepath.Join(binDir, "agy")
@@ -221,34 +221,22 @@ printf 'answer without a provider id'
 		t.Fatalf("write agy stub: %v", err)
 	}
 	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	if err := executeFreshDispatch(dispatchExecRequest{
+	err := executeFreshDispatch(dispatchExecRequest{
 		Root:     root,
 		Agent:    AgentAntigravity,
 		Prompt:   "fresh",
 		Env:      []string{"PATH=" + testPath(binDir)},
 		Stdout:   &stdout,
-		Stderr:   &stderr,
+		Stderr:   &bytes.Buffer{},
 		LookPath: mockLookPath(binDir),
-	}); err != nil {
-		t.Fatalf("dispatch Antigravity: %v", err)
-	}
-	if stdout.String() != "answer without a provider id" {
-		t.Fatalf("stdout = %q", stdout.String())
-	}
-	if !strings.Contains(stderr.String(), "not resumable · agy 1.1.21 · diagnostics:") {
-		t.Fatalf("missing not-resumable warning: %q", stderr.String())
-	}
-	sessions, err := listSessions(root)
-	if err != nil {
-		t.Fatalf("list sessions: %v", err)
-	}
-	if len(sessions) != 1 || sessions[0].State != "pending" || sessions[0].ActiveRunID != "" {
-		t.Fatalf("non-resumable history mapping = %#v", sessions)
+	})
+	requireDispatchExitCode(t, err, ExitTargetFailure)
+	if stdout.Len() != 0 {
+		t.Fatalf("plain provider output leaked to caller: %q", stdout.String())
 	}
 }
 
-func TestAntigravityResumeWithoutParsedIDRetainsDurableMapping(t *testing.T) {
+func TestAntigravityResumePlainOutputFailsAndRetainsDurableMapping(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{})
 	run, err := newDispatchRun(root, AgentAntigravity, supportedProviderVersions[AgentAntigravity], dispatchModeFresh)
 	if err != nil {
@@ -290,8 +278,8 @@ printf 'resumed answer without a provider id'
 		Prompt:   "resume",
 		Env:      []string{"PATH=" + testPath(binDir)},
 		LookPath: mockLookPath(binDir),
-	}, session.Name); err != nil {
-		t.Fatalf("continue Antigravity dispatch: %v", err)
+	}, session.Name); err == nil {
+		t.Fatal("continue Antigravity dispatch accepted plain provider output")
 	}
 	retained, err := loadSession(root, session.Name)
 	if err != nil {
@@ -305,8 +293,59 @@ printf 'resumed answer without a provider id'
 		Prompt:   "resume again",
 		Env:      []string{"PATH=" + testPath(binDir)},
 		LookPath: mockLookPath(binDir),
-	}, session.Name); err != nil {
-		t.Fatalf("second continue Antigravity dispatch: %v", err)
+	}, session.Name); err == nil {
+		t.Fatal("second continue Antigravity dispatch accepted plain provider output")
+	}
+}
+
+func TestAntigravityStructuredResumeReturnsPlainAnswerAndRetainsDurableMapping(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "agy.log")
+	writeDispatchStub(t, binDir, "agy", antigravityStructuredOK)
+	env := []string{"PATH=" + testPath(binDir), "AL_TEST_LOG=" + logPath}
+
+	var freshErr bytes.Buffer
+	if err := executeFreshDispatch(dispatchExecRequest{
+		Root:     root,
+		Agent:    AgentAntigravity,
+		Prompt:   "fresh",
+		Env:      env,
+		Stderr:   &freshErr,
+		LookPath: mockLookPath(binDir),
+	}); err != nil {
+		t.Fatalf("fresh Antigravity dispatch: %v", err)
+	}
+	name := identityName(t, freshErr.String())
+	if err := os.WriteFile(logPath, nil, 0o600); err != nil {
+		t.Fatalf("reset provider log: %v", err)
+	}
+
+	var resumeOut bytes.Buffer
+	if err := executeContinueDispatch(dispatchExecRequest{
+		Root:     root,
+		Prompt:   "resume",
+		Env:      env,
+		Stdout:   &resumeOut,
+		Stderr:   &bytes.Buffer{},
+		LookPath: mockLookPath(binDir),
+	}, name); err != nil {
+		t.Fatalf("continue Antigravity dispatch: %v", err)
+	}
+	if resumeOut.String() != "agy ok" {
+		t.Fatalf("resume stdout = %q", resumeOut.String())
+	}
+	assertFileContains(t, logPath, "ARG_3=--conversation")
+	assertFileContains(t, logPath, "ARG_4=22222222-2222-4222-8222-222222222222")
+	assertFileContains(t, logPath, "ARG_5=--output-format")
+	assertFileContains(t, logPath, "ARG_6=stream-json")
+
+	retained, err := loadSession(root, name)
+	if err != nil {
+		t.Fatalf("load resumed session: %v", err)
+	}
+	if retained.ProviderSessionID != "22222222-2222-4222-8222-222222222222" || retained.State != "durable" {
+		t.Fatalf("retained session = %#v", retained)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Require structured terminal results for every supported Agent Dispatch provider.
- Prevent Antigravity plain output or mismatched conversation IDs from being published as successful answers.

## Changes

- Capture provider events for all providers and always pass Antigravity stream-json output through the structured parser.
- Persist and validate structured session IDs, final answers, and completion evidence before publication.
- Update Antigravity regression coverage and release documentation for the structured-result contract.

## Verification

- `make ci` — passed: 4,571 Go tests, 16 planner tests, release checks, harness checks, 842 e2e assertions, and 90.06% total coverage.
- Commit hooks — passed formatting, module-tidy, lint, and full Go test checks.

## Notes

- Plain Antigravity output now fails closed because it cannot provide the required durable conversation and usage evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent Dispatch now uses structured provider output across supported agents.
  * Antigravity supports display-name models while returning clean, plain-text answers.
  * Structured event artifacts and conversation IDs are consistently captured for dispatches.

* **Bug Fixes**
  * Improved validation prevents incomplete or mismatched provider results from exposing output.
  * Antigravity plain-text responses are rejected consistently, including resumed dispatches.
  * Resume behavior now preserves durable session mappings and validates structured results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->