### PR TITLE
fix: preflight retained benchmark streams

### DIFF
--- a/internal/benchmark/assets/pier_agent_layer.py
+++ b/internal/benchmark/assets/pier_agent_layer.py
@@ -942,11 +942,11 @@ class _AgentLayerStreamAgent(_AgentLayerTreatment, BaseInstalledAgent):
             raise RuntimeError(f"unsupported retained stream validator provider {provider!r}")
         remote_path = f"/tmp/agent-layer-{provider}-stream-validator-preflight.jsonl"
         encoded = base64.b64encode(payload.encode("utf-8")).decode("ascii")
-        await self.exec_as_agent(
-            environment,
-            command=f"printf '%s' '{encoded}' | base64 -d > {remote_path}",
-        )
         try:
+            await self.exec_as_agent(
+                environment,
+                command=f"printf '%s' '{encoded}' | base64 -d > {remote_path}",
+            )
             await self._validate_retained_stream(environment, remote_path, provider, session_id)
         finally:
             await self.exec_as_agent(environment, command=f"rm -f {remote_path}")

--- a/internal/benchmark/assets/pier_agent_layer.py
+++ b/internal/benchmark/assets/pier_agent_layer.py
@@ -915,7 +915,7 @@ class _AgentLayerStreamAgent(_AgentLayerTreatment, BaseInstalledAgent):
         source = inspect.getsource(_bounded_json_lines) + inspect.getsource(parser)
         invocation = "parse_antigravity_stream(payload)" if provider == "antigravity" else f"parse_grok_stream(payload, {session_id!r})"
         script = (
-            "import json\n"
+            f"import json\nSTREAM_BYTE_CAP = {STREAM_BYTE_CAP}\n"
             + source
             + f"\npayload = open({remote_path!r}, encoding='utf-8').read()\n{invocation}\n"
         )
@@ -924,6 +924,32 @@ class _AgentLayerStreamAgent(_AgentLayerTreatment, BaseInstalledAgent):
             environment,
             command=f"printf '%s' '{encoded}' | base64 -d | python3",
         )
+
+    async def _preflight_retained_stream_validator(self, environment, provider: str) -> None:
+        """Execute the exact post-inference validator before a paid provider call."""
+        session_id = "11111111-1111-4111-8111-111111111111"
+        if provider == "antigravity":
+            payload = (
+                '{"event":"result","result":{"status":"SUCCESS",'
+                '"conversation_id":"preflight","usage":{"input_tokens":1,"output_tokens":1}}}\n'
+            )
+        elif provider == "grok":
+            payload = (
+                '{"type":"usage","usage":{"input_tokens":1,"output_tokens":1}}\n'
+                f'{{"type":"end","sessionId":"{session_id}","stopReason":"end_turn"}}\n'
+            )
+        else:
+            raise RuntimeError(f"unsupported retained stream validator provider {provider!r}")
+        remote_path = f"/tmp/agent-layer-{provider}-stream-validator-preflight.jsonl"
+        encoded = base64.b64encode(payload.encode("utf-8")).decode("ascii")
+        await self.exec_as_agent(
+            environment,
+            command=f"printf '%s' '{encoded}' | base64 -d > {remote_path}",
+        )
+        try:
+            await self._validate_retained_stream(environment, remote_path, provider, session_id)
+        finally:
+            await self.exec_as_agent(environment, command=f"rm -f {remote_path}")
 
 
 class AgentLayerAntigravity(_AgentLayerStreamAgent):
@@ -979,6 +1005,7 @@ with open(path, "w", encoding="utf-8") as stream:
                         f"{{ echo 'Antigravity benchmark model is unavailable' >&2; cat {models_path} >&2; exit 1; }}"
                     ),
                 )
+                await self._preflight_retained_stream_validator(environment, "antigravity")
                 return
             env = self.build_process_env({"AGY_CLI_DISABLE_AUTO_UPDATE": "1"})
             stream_path = str(EnvironmentPaths.agent_dir / self.OUTPUT_NAME)
@@ -1053,6 +1080,7 @@ class AgentLayerGrok(_AgentLayerStreamAgent):
                     ),
                     env=env,
                 )
+                await self._preflight_retained_stream_validator(environment, "grok")
                 return
             stream_path = str(EnvironmentPaths.agent_dir / self.OUTPUT_NAME)
             diagnostics_path = str(EnvironmentPaths.agent_dir / "grok.stderr")

--- a/internal/benchmark/post_inference_replay_test.go
+++ b/internal/benchmark/post_inference_replay_test.go
@@ -1,0 +1,207 @@
+package benchmark
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const replayGrokCellCostUSD = 0.18418582
+
+type postInferenceReplayExecutor struct {
+	rejectCalls bool
+	mu          sync.Mutex
+	calls       int
+}
+
+func (executor *postInferenceReplayExecutor) Execute(_ context.Context, request ExecutionRequest) (AttemptResult, error) {
+	executor.mu.Lock()
+	executor.calls++
+	executor.mu.Unlock()
+	if executor.rejectCalls {
+		return AttemptResult{}, errors.New("cached replay reached the provider boundary")
+	}
+	result, found, err := recoverCompletedPierExecution(request)
+	if err != nil {
+		return AttemptResult{}, err
+	}
+	if !found {
+		return AttemptResult{}, errors.New("retained fixture inference was not recoverable without a provider call")
+	}
+	return result, nil
+}
+
+func writeRetainedGrokExecution(t *testing.T, request ExecutionRequest) {
+	t.Helper()
+	stage := writePierStage(t, request.TaskChecksum, .8, replayGrokCellCostUSD)
+	rewriteReplayProvider(t, stage, adapterGrok)
+	streamPath := filepath.Join(stage, "jobs", "one", "agent", "grok.jsonl")
+	if err := os.MkdirAll(filepath.Dir(streamPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stream := `{"type":"usage","usage":{"input_tokens":100,"output_tokens":20,"cache_read_input_tokens":10,"cache_creation_input_tokens":0,"reasoning_tokens":5}}` + "\n" +
+		`{"type":"end","sessionId":"` + request.EventID + `","stopReason":"end_turn","total_cost_usd":` + strconv.FormatFloat(replayGrokCellCostUSD, 'f', -1, 64) + `}` + "\n"
+	if err := os.WriteFile(streamPath, []byte(stream), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := promoteSanitizedPierArtifacts(request, stage); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePierExecutionReceipt(request, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (executor *postInferenceReplayExecutor) callCount() int {
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	return executor.calls
+}
+
+func rewriteReplayProvider(t *testing.T, stage, provider string) {
+	t.Helper()
+	path := filepath.Join(stage, "jobs", "one", "result.json")
+	data, err := os.ReadFile(path) // #nosec G304 -- fixed path beneath a test-owned stage.
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	result["agent_info"] = map[string]any{"model_info": map[string]any{"provider": provider}}
+	if err := writeJSON(path, result); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSuccessfulGrokInferenceReplayCompletesAndCachesThePostRunPipeline(t *testing.T) {
+	root := t.TempDir()
+	writeBareStudy(t, root, modelGrok45, "minimal")
+	stubStudyInfrastructure(t, root)
+
+	originalAuthentication := validateBenchmarkAuthentication
+	originalRuntimePreflight := preflightTreatmentRuntime
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{adapterGrok: {
+			Provider: adapterGrok, Check: authCheckJSONFilePresence,
+			AuthenticationMethod: authMethodJSONFile, VerifiedAt: time.Now().UTC(),
+		}}, nil
+	}
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error { return nil }
+	t.Cleanup(func() {
+		validateBenchmarkAuthentication = originalAuthentication
+		preflightTreatmentRuntime = originalRuntimePreflight
+	})
+
+	dry, err := RunStudy(context.Background(), StudyOptions{
+		RepoRoot: root, StudyPath: filepath.Join(root, "study.toml"), TaskConcurrency: 1, DryRun: true,
+	}, &postInferenceReplayExecutor{rejectCalls: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(root, ".agent-layer", "state", "benchmarks", "deepswe", "studies", dry.StudyID, "study-manifest.json")
+	var manifest immutableStudyManifest
+	if err := readStudyJSON(manifestPath, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.Arms) != 1 {
+		t.Fatalf("fixture replay study arms=%#v", manifest.Arms)
+	}
+	model, effort, err := ParseModelSelection(modelGrok45 + ":minimal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidenceDir := filepath.Join(filepath.Dir(manifestPath), "arms", manifest.Arms[0].ID)
+	for index, task := range []string{"first-task", "second-task"} {
+		writeRetainedGrokExecution(t, ExecutionRequest{
+			RepoRoot: root, EvidenceDir: evidenceDir, EventID: "retained-grok-event-" + strconv.Itoa(index+1),
+			Attempt: 1, Task: task, Model: model, Effort: effort, Arm: ArmBaseline,
+			TaskChecksum: task + "-checksum", EnvironmentIdentity: task + "-env",
+		})
+	}
+
+	executor := &postInferenceReplayExecutor{}
+	outcome, err := RunStudy(context.Background(), StudyOptions{
+		RepoRoot: root, StudyPath: filepath.Join(root, "study.toml"), TaskConcurrency: 1,
+	}, executor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executor.callCount() != 2 || outcome.Completed != 2 || outcome.Missing != 0 {
+		t.Fatalf("fixture replay outcome=%#v provider-boundary calls=%d", outcome, executor.callCount())
+	}
+	wantCost := 2 * replayGrokCellCostUSD
+	if math.Abs(outcome.ObservedInvocationCost.Midpoint-wantCost) > 1e-12 ||
+		outcome.ObservedInvocationCost.Minimum != outcome.ObservedInvocationCost.Midpoint ||
+		outcome.ObservedInvocationCost.Maximum != outcome.ObservedInvocationCost.Midpoint {
+		t.Fatalf("fixture replay cost=%#v, want %.8f", outcome.ObservedInvocationCost, wantCost)
+	}
+	for _, path := range []string{outcome.JSONPath, outcome.HTMLPath} {
+		info, statErr := os.Stat(path)
+		if statErr != nil || !info.Mode().IsRegular() || info.Size() == 0 {
+			t.Fatalf("fixture replay report %q: info=%v err=%v", path, info, statErr)
+		}
+	}
+	var report StudyReport
+	if err := readStudyJSON(outcome.JSONPath, &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.StudyID != outcome.StudyID || len(report.Experiments) != 1 ||
+		report.Experiments[0].CompletedCells != 2 || math.Abs(report.Experiments[0].ObservedCost.Midpoint-wantCost) > 1e-12 {
+		t.Fatalf("fixture replay report=%#v", report)
+	}
+	html, err := os.ReadFile(outcome.HTMLPath) // #nosec G304 -- path returned by the test-owned study.
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(html), "Download canonical report.json") {
+		t.Fatal("fixture replay HTML omitted the canonical report link")
+	}
+
+	stateDir := filepath.Dir(filepath.Dir(outcome.JSONPath))
+	results, err := filepath.Glob(filepath.Join(stateDir, "arms", "*", "attempts", "1", "tasks", "*", "result.json"))
+	if err != nil || len(results) != 2 {
+		t.Fatalf("fixture replay normalized results=%#v err=%v", results, err)
+	}
+	for _, path := range results {
+		var result AttemptResult
+		if err := readStudyJSON(path, &result); err != nil {
+			t.Fatal(err)
+		}
+		if result.Provider != adapterGrok || result.CostKind != costKindProviderTotal || result.InvocationCount != 1 ||
+			result.CostUSD == nil || math.Abs(*result.CostUSD-replayGrokCellCostUSD) > 1e-12 {
+			t.Fatalf("fixture replay normalized result=%#v", result)
+		}
+	}
+	streams, err := filepath.Glob(filepath.Join(stateDir, "arms", "*", "attempts", "1", "tasks", "*", "artifacts", "*", "jobs", "one", "agent", "grok.jsonl"))
+	if err != nil || len(streams) != 2 {
+		t.Fatalf("fixture replay retained streams=%#v err=%v", streams, err)
+	}
+
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return nil, errors.New("cached replay reached authentication")
+	}
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error {
+		return errors.New("cached replay reached runtime preflight")
+	}
+	cachedExecutor := &postInferenceReplayExecutor{rejectCalls: true}
+	cached, err := RunStudy(context.Background(), StudyOptions{
+		RepoRoot: root, StudyPath: filepath.Join(root, "study.toml"), TaskConcurrency: 1,
+	}, cachedExecutor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cachedExecutor.callCount() != 0 || cached.Completed != 2 || cached.Missing != 0 ||
+		cached.JSONPath == "" || cached.HTMLPath == "" || cached.ObservedInvocationCost.Midpoint != 0 {
+		t.Fatalf("cached fixture replay=%#v provider-boundary calls=%d", cached, cachedExecutor.callCount())
+	}
+}

--- a/internal/benchmark/study_treatment_test.go
+++ b/internal/benchmark/study_treatment_test.go
@@ -346,6 +346,24 @@ for cls, model, domains in [
             asyncio.run(agent._preflight_retained_stream_validator(object(), provider))
             assert not Path(f"/tmp/agent-layer-{provider}-stream-validator-preflight.jsonl").exists()
 
+        failed_path = Path("/tmp/agent-layer-grok-stream-validator-preflight.jsonl")
+        failed_commands = []
+        async def fail_validator_write(environment, command, **kwargs):
+            failed_commands.append(command)
+            if command.startswith("printf"):
+                failed_path.write_text("partial")
+                raise RuntimeError("simulated validator write failure")
+            completed = subprocess.run(command, shell=True, text=True, capture_output=True)
+            assert completed.returncode == 0, completed.stderr
+        agent.exec_as_agent = fail_validator_write
+        try:
+            asyncio.run(agent._preflight_retained_stream_validator(object(), "grok"))
+            raise AssertionError("validator write failure was not propagated")
+        except RuntimeError as error:
+            assert str(error) == "simulated validator write failure"
+        assert len(failed_commands) == 2 and failed_commands[-1] == f"rm -f {failed_path}"
+        assert not failed_path.exists()
+
 commands = []
 async def capture_command(environment, command, **kwargs):
     commands.append(command)

--- a/internal/benchmark/study_treatment_test.go
+++ b/internal/benchmark/study_treatment_test.go
@@ -338,6 +338,14 @@ for cls, model, domains in [
         assert completed.returncode == 0, completed.stderr
         assert out.read_text() == "stream" and err.read_text() == "diagnostic"
 
+        async def execute_validator(environment, command, **kwargs):
+            validated = subprocess.run(command, shell=True, text=True, capture_output=True)
+            assert validated.returncode == 0, validated.stderr
+        agent.exec_as_agent = execute_validator
+        for provider in ("grok", "antigravity"):
+            asyncio.run(agent._preflight_retained_stream_validator(object(), provider))
+            assert not Path(f"/tmp/agent-layer-{provider}-stream-validator-preflight.jsonl").exists()
+
 commands = []
 async def capture_command(environment, command, **kwargs):
     commands.append(command)
@@ -588,21 +596,26 @@ async def rendered_commands(preflight):
             commands.append(command)
         async def prepare(instruction, environment):
             return instruction
+        validations = []
+        async def capture_validation(environment, remote_path, provider, session_id=""):
+            validations.append((remote_path, provider, session_id))
         async def no_op(*args, **kwargs):
             pass
         agent.exec_as_agent = capture_exec
         agent._run_command = capture_run
         agent._prepare = prepare
-        agent._validate_retained_stream = no_op
+        agent._validate_retained_stream = capture_validation
         agent._collect_evidence = no_op
         await agent.run("task", Environment(), None)
-        return commands
+        return commands, validations
 
-dry_run = asyncio.run(rendered_commands(True))
-paid = asyncio.run(rendered_commands(False))
+dry_run, dry_validations = asyncio.run(rendered_commands(True))
+paid, paid_validations = asyncio.run(rendered_commands(False))
 assert any("grok --no-auto-update --sandbox devbox models" in command for command in dry_run), dry_run
 assert any("--trust --sandbox devbox --permission-mode bypassPermissions" in command for command in paid), paid
 assert not any("--sandbox workspace" in command for command in dry_run + paid), dry_run + paid
+assert len(dry_validations) == 1 and dry_validations[0][1] == "grok", dry_validations
+assert len(paid_validations) == 1 and paid_validations[0][1] == "grok", paid_validations
 `
 	command := exec.CommandContext(t.Context(), "uvx", "--from", "datacurve-pier=="+PierVersion, "python", "-c", script, path) // #nosec G204 -- embedded test loads the checked-in adapter against its pinned runtime.
 	if output, err := command.CombinedOutput(); err != nil {


### PR DESCRIPTION
## Summary

- Validate retained Grok and Antigravity streams before paid provider calls.
- Ensure post-inference replay can complete and reuse cached evidence without reaching provider or authentication boundaries.

## Changes

- Embed the stream byte cap in the remote validator script and add provider-specific preflight fixtures.
- Run the validator before live Grok and Antigravity benchmark calls.
- Add an end-to-end replay regression test covering normalized results, retained artifacts, reports, costs, and a provider-free cached rerun.

## Verification

- `go test ./internal/benchmark` — passed.
- Commit hooks (`gofmt + goimports`, `go mod tidy check`, `golangci-lint`, `go test ./...`) — passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of retained execution streams before processing provider results.
  * Prevented temporary validation artifacts from being left behind.
  * Improved reliability when replaying previously completed executions without contacting providers.

* **Tests**
  * Added coverage for replayed results, normalized outputs, costs, reports, HTML, and preserved streams.
  * Expanded validation coverage across supported providers and dry-run and paid execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->