### PR TITLE
feat: cache runtime preflights and warn on emulation

### DIFF
--- a/cmd/al/benchmark.go
+++ b/cmd/al/benchmark.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"time"
@@ -20,11 +21,18 @@ const (
 )
 
 var (
-	runStudy                               = bench.RunStudy
-	checkReadiness                         = bench.CheckAllTaskReadiness
-	initStudy                              = bench.InitStudy
-	benchmarkHeartbeatClock benchmarkClock = wallBenchmarkClock{}
+	runStudy                                    = bench.RunStudy
+	checkReadiness                              = bench.CheckAllTaskReadiness
+	initStudy                                   = bench.InitStudy
+	benchmarkArchitectureWarning                = bench.TaskContainerEmulationWarning
+	benchmarkHeartbeatClock      benchmarkClock = wallBenchmarkClock{}
 )
+
+func printBenchmarkArchitectureWarning(out io.Writer) {
+	if warning := benchmarkArchitectureWarning(); warning != "" {
+		_, _ = fmt.Fprintf(out, "[warning] %s\n", warning)
+	}
+}
 
 type benchmarkTimer interface {
 	C() <-chan time.Time
@@ -166,6 +174,7 @@ func newBenchmarkRunCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			printBenchmarkArchitectureWarning(cmd.OutOrStdout())
 			if taskConcurrency == 0 {
 				taskConcurrency = bench.AutomaticTaskConcurrency(true)
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "[setup] Automatic task concurrency: %d (host and container architecture aware).\n", taskConcurrency)
@@ -290,6 +299,7 @@ func newBenchmarkReadinessCmd() *cobra.Command {
 			if taskConcurrency > 1 && removeTaskImages && !cmd.Flags().Changed("remove-task-images") {
 				removeTaskImages = false
 			}
+			printBenchmarkArchitectureWarning(cmd.OutOrStdout())
 			if taskConcurrency == 0 {
 				if removeTaskImages {
 					taskConcurrency = 1

--- a/cmd/al/benchmark_test.go
+++ b/cmd/al/benchmark_test.go
@@ -249,6 +249,83 @@ func TestBenchmarkRunDryRunDoesNotInvokeProviderInference(t *testing.T) {
 	}
 }
 
+func TestBenchmarkCommandsWarnOnlyWhenTaskContainersRequireEmulation(t *testing.T) {
+	originalWarning := benchmarkArchitectureWarning
+	benchmarkArchitectureWarning = func() string {
+		return "DeepSWE uses linux/amd64 task containers. Host architecture arm64 requires emulation; the first wait can take 30+ minutes."
+	}
+	t.Cleanup(func() { benchmarkArchitectureWarning = originalWarning })
+
+	originalRun := runStudy
+	runStudy = func(_ context.Context, options bench.StudyOptions, _ bench.TaskExecutor) (bench.StudyOutcome, error) {
+		return bench.StudyOutcome{}, nil
+	}
+	t.Cleanup(func() { runStudy = originalRun })
+
+	root := newRootCmd()
+	root.SetArgs([]string{"benchmark", "run", "study.toml", "--dry-run", "--task-concurrency", "1"})
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); !strings.Contains(got, "[warning]") || !strings.Contains(got, "requires emulation") || !strings.Contains(got, "30+ minutes") {
+		t.Fatalf("emulation warning output = %q", got)
+	}
+
+	originalReadiness := checkReadiness
+	checkReadiness = func(_ context.Context, _ bench.ReadinessAuditOptions) (bench.ReadinessAuditOutcome, error) {
+		return bench.ReadinessAuditOutcome{}, nil
+	}
+	t.Cleanup(func() { checkReadiness = originalReadiness })
+	output.Reset()
+	root = newRootCmd()
+	root.SetArgs([]string{"benchmark", "readiness", "--task-concurrency", "1"})
+	root.SetOut(&output)
+	root.SetErr(&output)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); !strings.Contains(got, "[warning]") || !strings.Contains(got, "requires emulation") {
+		t.Fatalf("readiness emulation warning output = %q", got)
+	}
+
+	benchmarkArchitectureWarning = func() string { return "" }
+	output.Reset()
+	root = newRootCmd()
+	root.SetArgs([]string{"benchmark", "run", "study.toml", "--dry-run", "--task-concurrency", "1"})
+	root.SetOut(&output)
+	root.SetErr(&output)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(output.String(), "[warning]") {
+		t.Fatalf("native architecture output contained warning: %q", output.String())
+	}
+}
+
+func TestBenchmarkReadinessDoesNotWarnBeforeFlagValidation(t *testing.T) {
+	originalWarning := benchmarkArchitectureWarning
+	benchmarkArchitectureWarning = func() string {
+		return "DeepSWE uses linux/amd64 task containers. Host architecture arm64 requires emulation; the first wait can take 30+ minutes."
+	}
+	t.Cleanup(func() { benchmarkArchitectureWarning = originalWarning })
+
+	root := newRootCmd()
+	root.SetArgs([]string{"benchmark", "readiness", "--study", "study.toml", "--task", "first-task"})
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "use either --study or --task, not both") {
+		t.Fatalf("error = %v", err)
+	}
+	if strings.Contains(output.String(), "[warning]") {
+		t.Fatalf("usage error was preceded by emulation warning: %q", output.String())
+	}
+}
+
 func TestBenchmarkRunHeartbeatWaitsForInactivityAndUsesLatestProgress(t *testing.T) {
 	originalRun, originalClock := runStudy, benchmarkHeartbeatClock
 	clock := newBenchmarkTestClock()

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -48,7 +48,7 @@ This step is optional because `benchmark run` performs the same required task pr
 al benchmark run benchmark-study/study.toml --dry-run
 ```
 
-The dry run validates and snapshots all declared inputs, checks tools and provider authentication, prepares the treatment, certifies missing task environments, and reports cached versus missing cells. It never performs provider inference.
+The dry run validates and snapshots all declared inputs, checks tools and provider authentication, prepares the treatment, certifies missing task environments, and reports cached versus missing cells. Successful task-and-experiment runtime preflights are stored as content-addressed receipts and reused by later identical dry runs. It never performs provider inference.
 
 ### 4. Run or resume
 
@@ -66,6 +66,8 @@ The ordinary workflow requires no tuning:
 - Readiness uses one worker when automatic image reclamation is enabled.
 - Before pulling, the CLI checks Docker storage using a conservative 4 GiB budget per simultaneously retained task image. If the plan cannot fit, it stops with required-versus-available capacity instead of filling Docker's disk.
 - Certification-only images are removed automatically; durable readiness receipts remain.
+- Successful runtime preflight receipts are reused when the host architecture, pinned Pier version, task environment, provider client, adapter, model, reasoning, and treatment inputs still match. Authentication is checked on every invocation.
+- DeepSWE task containers are certified for `linux/amd64`. On a non-amd64 host, the CLI warns that Docker must emulate them and that initial pulls, builds, and preflights can take 30 minutes or longer.
 - Grok runs inside Pier's disposable task container with Grok's built-in `devbox` sandbox profile, avoiding a host Bubblewrap dependency while retaining the container boundary. Dry-run and paid command construction use the same profile.
 - Readiness prints task percentages. Study runs print preparation stages, task/arm preflight and cell percentages, and cumulative observed cost. During a silent long-running operation, the CLI prints one heartbeat after 60 seconds of inactivity and at most once per additional silent minute; genuine progress resets that timer.
 - Docker disk exhaustion is identified explicitly in both the task result and final error.

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -66,7 +66,7 @@ The ordinary workflow requires no tuning:
 - Readiness uses one worker when automatic image reclamation is enabled.
 - Before pulling, the CLI checks Docker storage using a conservative 4 GiB budget per simultaneously retained task image. If the plan cannot fit, it stops with required-versus-available capacity instead of filling Docker's disk.
 - Certification-only images are removed automatically; durable readiness receipts remain.
-- Successful runtime preflight receipts are reused when the host architecture, pinned Pier version, task environment, provider client, adapter, model, reasoning, and treatment inputs still match. Authentication is checked on every invocation.
+- Successful runtime preflight receipts are recorded after any required task-image reclamation succeeds and reused when the Docker host architecture, pinned Pier version, task environment, provider client, adapter, model, reasoning, and treatment inputs still match. Authentication is checked on every invocation.
 - DeepSWE task containers are certified for `linux/amd64`. On a non-amd64 host, the CLI warns that Docker must emulate them and that initial pulls, builds, and preflights can take 30 minutes or longer.
 - Grok runs inside Pier's disposable task container with Grok's built-in `devbox` sandbox profile, avoiding a host Bubblewrap dependency while retaining the container boundary. Dry-run and paid command construction use the same profile.
 - Readiness prints task percentages. Study runs print preparation stages, task/arm preflight and cell percentages, and cumulative observed cost. During a silent long-running operation, the CLI prints one heartbeat after 60 seconds of inactivity and at most once per additional silent minute; genuine progress resets that timer.

--- a/internal/benchmark/auth_preflight_test.go
+++ b/internal/benchmark/auth_preflight_test.go
@@ -1612,9 +1612,11 @@ func stubStudyInfrastructure(t *testing.T, root string) *int {
 	originalPreflight := preflightBenchmark
 	originalVerifyPier := verifyBenchmarkPier
 	originalPrepareTasks := prepareBenchmarkTaskSet
+	originalArchitecture := dockerHostArchitecture
 	preparedCalls := 0
 	preflightBenchmark = func([]parsedSelection) error { return nil }
 	verifyBenchmarkPier = func(context.Context) error { return nil }
+	dockerHostArchitecture = func(context.Context) (string, error) { return "amd64", nil }
 	prepareBenchmarkTaskSet = func(_ context.Context, gotRoot string, tasks []benchmarkPlanTask) (map[string]string, map[string]string, error) {
 		preparedCalls++
 		if gotRoot != root {
@@ -1632,6 +1634,7 @@ func stubStudyInfrastructure(t *testing.T, root string) *int {
 		preflightBenchmark = originalPreflight
 		verifyBenchmarkPier = originalVerifyPier
 		prepareBenchmarkTaskSet = originalPrepareTasks
+		dockerHostArchitecture = originalArchitecture
 	})
 	return &preparedCalls
 }

--- a/internal/benchmark/execution.go
+++ b/internal/benchmark/execution.go
@@ -91,6 +91,7 @@ type ExecutionRequest struct {
 	TaskChecksum           string
 	EnvironmentIdentity    string
 	AgentTimeoutMultiplier float64
+	AdapterSHA256          string
 	PreflightOnly          bool
 	// ResumeFailedInfrastructure is set only by the study scheduler for a new
 	// user-authorized benchmark invocation. It permits a fresh event after an

--- a/internal/benchmark/operator.go
+++ b/internal/benchmark/operator.go
@@ -18,6 +18,20 @@ import (
 
 const estimatedTaskImageBytes int64 = 4 << 30
 
+// TaskContainerEmulationWarning describes the expensive cross-architecture
+// execution path only when the host cannot run the certified task containers
+// natively.
+func TaskContainerEmulationWarning() string {
+	return taskContainerEmulationWarning(runtime.GOARCH)
+}
+
+func taskContainerEmulationWarning(hostArchitecture string) string {
+	if hostArchitecture == benchmarkTaskContainerArchitecture {
+		return ""
+	}
+	return fmt.Sprintf("DeepSWE uses linux/%s task containers. Host architecture %s requires emulation; the first image pulls, builds, and runtime preflights can take 30+ minutes.", benchmarkTaskContainerArchitecture, hostArchitecture)
+}
+
 // AutomaticTaskConcurrency chooses a conservative worker count. DeepSWE's
 // certified amd64 containers are emulated on ARM hosts, where parallel task
 // execution is usually slower and substantially more failure-prone.

--- a/internal/benchmark/operator.go
+++ b/internal/benchmark/operator.go
@@ -93,7 +93,22 @@ type dockerDesktopSettings struct {
 	DiskSizeMiB int64 `json:"DiskSizeMiB"`
 }
 
-var readinessDiskCapacity = detectDockerDiskAvailable
+var (
+	readinessDiskCapacity  = detectDockerDiskAvailable
+	dockerHostArchitecture = detectDockerHostArchitecture
+)
+
+func detectDockerHostArchitecture(ctx context.Context) (string, error) {
+	output, err := runBenchmarkDockerCommand(ctx, "version", "--format", "{{.Server.Arch}}")
+	if err != nil {
+		return "", fmt.Errorf("determine Docker host architecture: %w: %s", err, string(bytes.TrimSpace(output)))
+	}
+	architecture := string(bytes.TrimSpace(output))
+	if architecture == "" || architecture == "<no value>" {
+		return "", errors.New("docker daemon did not report a server architecture")
+	}
+	return architecture, nil
+}
 
 func preflightReadinessDisk(ctx context.Context, tasks []benchmarkPlanTask, keepImages bool) error {
 	if len(tasks) == 0 {

--- a/internal/benchmark/operator_test.go
+++ b/internal/benchmark/operator_test.go
@@ -177,7 +177,7 @@ func TestStudyTreatmentPreflightReclaimsImagesEvenOnFailure(t *testing.T) {
 	err := preflightStudyTaskRuntimes(context.Background(), "task", []studyRuntimePreflight{
 		{experiment: "first", request: ExecutionRequest{EvidenceDir: evidenceDir, Arm: "first"}},
 		{experiment: "second", request: ExecutionRequest{EvidenceDir: evidenceDir, Arm: "second"}},
-	}, true, "checkout", &completed, 2, StudyOptions{})
+	}, true, "checkout", &completed, 2, StudyOptions{}, "amd64")
 	if !errors.Is(err, preflightFailure) {
 		t.Fatalf("preflight failure = %v", err)
 	}
@@ -188,7 +188,7 @@ func TestStudyTreatmentPreflightReclaimsImagesEvenOnFailure(t *testing.T) {
 	err = preflightStudyTaskRuntimes(context.Background(), "task", []studyRuntimePreflight{
 		{experiment: "first", request: ExecutionRequest{EvidenceDir: evidenceDir, Arm: "first"}},
 		{experiment: "second", request: ExecutionRequest{EvidenceDir: evidenceDir, Arm: "second"}},
-	}, true, "checkout", &completed, 2, StudyOptions{})
+	}, true, "checkout", &completed, 2, StudyOptions{}, "amd64")
 	if !errors.Is(err, preflightFailure) {
 		t.Fatalf("retry preflight failure = %v", err)
 	}
@@ -197,31 +197,91 @@ func TestStudyTreatmentPreflightReclaimsImagesEvenOnFailure(t *testing.T) {
 	}
 }
 
+func TestStudyTreatmentPreflightDoesNotPersistReceiptWhenCleanupFails(t *testing.T) {
+	originalPreflight := preflightTreatmentRuntime
+	originalLoad := loadStudyTaskReadiness
+	originalCleanup := reclaimStudyTaskImages
+	t.Cleanup(func() {
+		preflightTreatmentRuntime = originalPreflight
+		loadStudyTaskReadiness = originalLoad
+		reclaimStudyTaskImages = originalCleanup
+	})
+	cleanupFailure := errors.New("cleanup failed")
+	var preflightCalls, cleanupCalls int
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error {
+		preflightCalls++
+		return nil
+	}
+	loadStudyTaskReadiness = func(string, string) (loadedTaskReadiness, error) {
+		return loadedTaskReadiness{pinnedImage: "task-image"}, nil
+	}
+	reclaimStudyTaskImages = func(context.Context, loadedTaskReadiness) error {
+		cleanupCalls++
+		if cleanupCalls == 1 {
+			return cleanupFailure
+		}
+		return nil
+	}
+	evidenceDir := t.TempDir()
+	request := ExecutionRequest{EvidenceDir: evidenceDir, Arm: "arm", Task: "task"}
+	work := []studyRuntimePreflight{{experiment: "arm", request: request}}
+	completed := 0
+	err := preflightStudyTaskRuntimes(context.Background(), "task", work, true, "checkout", &completed, 1, StudyOptions{}, "amd64")
+	if !errors.Is(err, cleanupFailure) {
+		t.Fatalf("cleanup failure = %v", err)
+	}
+	if preflightCalls != 1 || cleanupCalls != 1 {
+		t.Fatalf("preflights=%d cleanup=%d", preflightCalls, cleanupCalls)
+	}
+	entries, readErr := os.ReadDir(filepath.Join(evidenceDir, "runtime-preflights"))
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("cleanup failure persisted receipts: %#v", entries)
+	}
+	completed = 0
+	if err := preflightStudyTaskRuntimes(context.Background(), "task", work, true, "checkout", &completed, 1, StudyOptions{}, "amd64"); err != nil {
+		t.Fatal(err)
+	}
+	if preflightCalls != 2 || cleanupCalls != 2 {
+		t.Fatalf("retry preflights=%d cleanup=%d", preflightCalls, cleanupCalls)
+	}
+	cached, _, _, err := completedRuntimePreflight(request, "amd64")
+	if err != nil || !cached {
+		t.Fatalf("successful retry receipt = cached %t err %v", cached, err)
+	}
+}
+
 func TestCompletedRuntimePreflightRejectsMismatchedReceipt(t *testing.T) {
 	request := ExecutionRequest{EvidenceDir: t.TempDir(), Arm: "arm"}
-	cached, receipt, path, err := completedRuntimePreflight(request)
+	cached, receipt, path, err := completedRuntimePreflight(request, "amd64")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if cached {
 		t.Fatal("missing receipt was treated as complete")
 	}
-	if receipt.HostOS != runtime.GOOS || receipt.HostArchitecture != runtime.GOARCH {
-		t.Fatalf("host platform = %s/%s, want %s/%s", receipt.HostOS, receipt.HostArchitecture, runtime.GOOS, runtime.GOARCH)
+	if receipt.HostOS != runtime.GOOS || receipt.HostArchitecture != "amd64" {
+		t.Fatalf("host platform = %s/%s, want %s/amd64", receipt.HostOS, receipt.HostArchitecture, runtime.GOOS)
 	}
 	if err := writeJSON(path, receipt); err != nil {
 		t.Fatal(err)
 	}
-	cached, _, _, err = completedRuntimePreflight(request)
+	cached, _, _, err = completedRuntimePreflight(request, "amd64")
 	if err != nil || !cached {
 		t.Fatalf("matching receipt reuse = cached %t err %v", cached, err)
+	}
+	cached, _, _, err = completedRuntimePreflight(request, "arm64")
+	if err != nil || cached {
+		t.Fatalf("different Docker host architecture reused receipt: cached %t err %v", cached, err)
 	}
 	mismatch := receipt
 	mismatch.HostArchitecture = "other"
 	if err := writeJSON(path, mismatch); err != nil {
 		t.Fatal(err)
 	}
-	cached, _, _, err = completedRuntimePreflight(request)
+	cached, _, _, err = completedRuntimePreflight(request, "amd64")
 	if cached || err == nil || !strings.Contains(err.Error(), "does not match its content-addressed identity") {
 		t.Fatalf("mismatched receipt = cached %t err %v", cached, err)
 	}
@@ -251,7 +311,7 @@ func TestStudyTreatmentPreflightReclaimsImageAfterCancellation(t *testing.T) {
 		return nil
 	}
 	completed := 0
-	err := preflightStudyTaskRuntimes(ctx, "task", []studyRuntimePreflight{{experiment: "arm", request: ExecutionRequest{EvidenceDir: t.TempDir(), Arm: "arm"}}}, true, "checkout", &completed, 1, StudyOptions{})
+	err := preflightStudyTaskRuntimes(ctx, "task", []studyRuntimePreflight{{experiment: "arm", request: ExecutionRequest{EvidenceDir: t.TempDir(), Arm: "arm"}}}, true, "checkout", &completed, 1, StudyOptions{}, "amd64")
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("preflight cancellation = %v", err)
 	}
@@ -264,11 +324,14 @@ func TestStudyRuntimePreflightsGroupArmsByTaskAndReclaimOnce(t *testing.T) {
 	originalPreflight := preflightTreatmentRuntime
 	originalLoad := loadStudyTaskReadiness
 	originalCleanup := reclaimStudyTaskImages
+	originalArchitecture := dockerHostArchitecture
 	t.Cleanup(func() {
 		preflightTreatmentRuntime = originalPreflight
 		loadStudyTaskReadiness = originalLoad
 		reclaimStudyTaskImages = originalCleanup
+		dockerHostArchitecture = originalArchitecture
 	})
+	dockerHostArchitecture = func(context.Context) (string, error) { return "amd64", nil }
 	tasks := []benchmarkPlanTask{{ID: "first"}, {ID: "duplicate"}, {ID: "second"}}
 	checksums := map[string]string{"first": "first-checksum", "duplicate": "duplicate-checksum", "second": "second-checksum"}
 	environments := map[string]string{"first": "shared", "duplicate": "shared", "second": "second"}
@@ -451,6 +514,83 @@ func TestStudyTaskIDsReadsSelectionWithoutTreatmentSetup(t *testing.T) {
 	}
 	if got := strings.Join(tasks, ","); got != "first-task,second-task" {
 		t.Fatalf("study tasks = %q", got)
+	}
+}
+
+func TestDetectDockerHostArchitecture(t *testing.T) {
+	original := runBenchmarkDockerCommand
+	t.Cleanup(func() { runBenchmarkDockerCommand = original })
+	runBenchmarkDockerCommand = func(context.Context, ...string) ([]byte, error) {
+		return []byte("  arm64\n"), nil
+	}
+	got, err := detectDockerHostArchitecture(context.Background())
+	if err != nil || got != "arm64" {
+		t.Fatalf("architecture = %q err %v", got, err)
+	}
+	runBenchmarkDockerCommand = func(context.Context, ...string) ([]byte, error) {
+		return []byte("denied"), errors.New("daemon unavailable")
+	}
+	if _, err := detectDockerHostArchitecture(context.Background()); err == nil || !strings.Contains(err.Error(), "daemon unavailable") {
+		t.Fatalf("command failure = %v", err)
+	}
+	for _, output := range []string{"\n", "<no value>\n"} {
+		runBenchmarkDockerCommand = func(context.Context, ...string) ([]byte, error) {
+			return []byte(output), nil
+		}
+		if _, err := detectDockerHostArchitecture(context.Background()); err == nil || !strings.Contains(err.Error(), "did not report a server architecture") {
+			t.Fatalf("missing architecture %q = %v", output, err)
+		}
+	}
+}
+
+func TestStudyRuntimePreflightsFailWhenDockerArchitectureIsUnknown(t *testing.T) {
+	originalArchitecture := dockerHostArchitecture
+	originalPreflight := preflightTreatmentRuntime
+	t.Cleanup(func() {
+		dockerHostArchitecture = originalArchitecture
+		preflightTreatmentRuntime = originalPreflight
+	})
+	lookupErr := errors.New("daemon architecture unavailable")
+	dockerHostArchitecture = func(context.Context) (string, error) { return "", lookupErr }
+	called := false
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error {
+		called = true
+		return nil
+	}
+	err := preflightStudyRuntimes(context.Background(), StudyOptions{}, []benchmarkPlanTask{{ID: "task"}}, [][]studyRuntimePreflight{{{
+		experiment: "arm",
+		request:    ExecutionRequest{EvidenceDir: t.TempDir(), Arm: "arm"},
+	}}}, false, "")
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("architecture failure = %v", err)
+	}
+	if called {
+		t.Fatal("ran runtime preflight without a Docker host architecture")
+	}
+}
+
+func TestStudyRuntimePreflightsKeyReceiptsByDockerHostArchitecture(t *testing.T) {
+	originalArchitecture := dockerHostArchitecture
+	originalPreflight := preflightTreatmentRuntime
+	t.Cleanup(func() {
+		dockerHostArchitecture = originalArchitecture
+		preflightTreatmentRuntime = originalPreflight
+	})
+	dockerHostArchitecture = func(context.Context) (string, error) { return "s390x", nil }
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error { return nil }
+	request := ExecutionRequest{EvidenceDir: t.TempDir(), Arm: "arm", Task: "task"}
+	if err := preflightStudyRuntimes(context.Background(), StudyOptions{}, []benchmarkPlanTask{{ID: "task"}}, [][]studyRuntimePreflight{{{
+		experiment: "arm", request: request,
+	}}}, false, ""); err != nil {
+		t.Fatal(err)
+	}
+	cached, receipt, _, err := completedRuntimePreflight(request, "s390x")
+	if err != nil || !cached || receipt.HostArchitecture != "s390x" {
+		t.Fatalf("docker-host receipt = cached %t arch %q err %v", cached, receipt.HostArchitecture, err)
+	}
+	cached, _, _, err = completedRuntimePreflight(request, "amd64")
+	if err != nil || cached {
+		t.Fatalf("different Docker host architecture reused receipt: cached %t err %v", cached, err)
 	}
 }
 

--- a/internal/benchmark/operator_test.go
+++ b/internal/benchmark/operator_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -26,6 +27,16 @@ func TestReadinessDiskPreflightRefusesImpossiblePlanBeforePulls(t *testing.T) {
 	readinessDiskCapacity = func(context.Context) (int64, error) { return 5 << 30, nil }
 	if err := preflightReadinessDisk(context.Background(), tasks, false); err != nil {
 		t.Fatalf("bounded plan rejected: %v", err)
+	}
+}
+
+func TestTaskContainerEmulationWarningOnlyForNonAMD64Hosts(t *testing.T) {
+	if got := taskContainerEmulationWarning("amd64"); got != "" {
+		t.Fatalf("native amd64 warning = %q", got)
+	}
+	got := taskContainerEmulationWarning("arm64")
+	if !strings.Contains(got, "linux/amd64") || !strings.Contains(got, "Host architecture arm64 requires emulation") || !strings.Contains(got, "30+ minutes") {
+		t.Fatalf("arm64 emulation warning = %q", got)
 	}
 }
 
@@ -162,15 +173,57 @@ func TestStudyTreatmentPreflightReclaimsImagesEvenOnFailure(t *testing.T) {
 		return nil
 	}
 	completed := 0
+	evidenceDir := t.TempDir()
 	err := preflightStudyTaskRuntimes(context.Background(), "task", []studyRuntimePreflight{
-		{experiment: "first", request: ExecutionRequest{Arm: "first"}},
-		{experiment: "second", request: ExecutionRequest{Arm: "second"}},
+		{experiment: "first", request: ExecutionRequest{EvidenceDir: evidenceDir, Arm: "first"}},
+		{experiment: "second", request: ExecutionRequest{EvidenceDir: evidenceDir, Arm: "second"}},
 	}, true, "checkout", &completed, 2, StudyOptions{})
 	if !errors.Is(err, preflightFailure) {
 		t.Fatalf("preflight failure = %v", err)
 	}
 	if preflightCalls != 2 || completed != 1 || cleanupCalls != 1 {
 		t.Fatalf("preflights=%d completed=%d cleanup=%d", preflightCalls, completed, cleanupCalls)
+	}
+	completed = 0
+	err = preflightStudyTaskRuntimes(context.Background(), "task", []studyRuntimePreflight{
+		{experiment: "first", request: ExecutionRequest{EvidenceDir: evidenceDir, Arm: "first"}},
+		{experiment: "second", request: ExecutionRequest{EvidenceDir: evidenceDir, Arm: "second"}},
+	}, true, "checkout", &completed, 2, StudyOptions{})
+	if !errors.Is(err, preflightFailure) {
+		t.Fatalf("retry preflight failure = %v", err)
+	}
+	if preflightCalls != 3 || completed != 1 || cleanupCalls != 2 {
+		t.Fatalf("retry preflights=%d completed=%d cleanup=%d", preflightCalls, completed, cleanupCalls)
+	}
+}
+
+func TestCompletedRuntimePreflightRejectsMismatchedReceipt(t *testing.T) {
+	request := ExecutionRequest{EvidenceDir: t.TempDir(), Arm: "arm"}
+	cached, receipt, path, err := completedRuntimePreflight(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cached {
+		t.Fatal("missing receipt was treated as complete")
+	}
+	if receipt.HostOS != runtime.GOOS || receipt.HostArchitecture != runtime.GOARCH {
+		t.Fatalf("host platform = %s/%s, want %s/%s", receipt.HostOS, receipt.HostArchitecture, runtime.GOOS, runtime.GOARCH)
+	}
+	if err := writeJSON(path, receipt); err != nil {
+		t.Fatal(err)
+	}
+	cached, _, _, err = completedRuntimePreflight(request)
+	if err != nil || !cached {
+		t.Fatalf("matching receipt reuse = cached %t err %v", cached, err)
+	}
+	mismatch := receipt
+	mismatch.HostArchitecture = "other"
+	if err := writeJSON(path, mismatch); err != nil {
+		t.Fatal(err)
+	}
+	cached, _, _, err = completedRuntimePreflight(request)
+	if cached || err == nil || !strings.Contains(err.Error(), "does not match its content-addressed identity") {
+		t.Fatalf("mismatched receipt = cached %t err %v", cached, err)
 	}
 }
 
@@ -198,7 +251,7 @@ func TestStudyTreatmentPreflightReclaimsImageAfterCancellation(t *testing.T) {
 		return nil
 	}
 	completed := 0
-	err := preflightStudyTaskRuntimes(ctx, "task", []studyRuntimePreflight{{experiment: "arm", request: ExecutionRequest{Arm: "arm"}}}, true, "checkout", &completed, 1, StudyOptions{})
+	err := preflightStudyTaskRuntimes(ctx, "task", []studyRuntimePreflight{{experiment: "arm", request: ExecutionRequest{EvidenceDir: t.TempDir(), Arm: "arm"}}}, true, "checkout", &completed, 1, StudyOptions{})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("preflight cancellation = %v", err)
 	}
@@ -222,8 +275,8 @@ func TestStudyRuntimePreflightsGroupArmsByTaskAndReclaimOnce(t *testing.T) {
 	controlBundle, treatmentBundle := fakeStudyTreatmentBundle(), fakeStudyTreatmentBundle()
 	controlBundle.ManifestHash, treatmentBundle.ManifestHash = "control", "treatment"
 	arms := []matrixArm{
-		{Label: "control", Mode: ArmTreatment, Bundle: controlBundle},
-		{Label: "treatment", Mode: ArmTreatment, Bundle: treatmentBundle},
+		{Label: "control", Mode: ArmTreatment, StateDir: t.TempDir(), Bundle: controlBundle},
+		{Label: "treatment", Mode: ArmTreatment, StateDir: t.TempDir(), Bundle: treatmentBundle},
 	}
 	work := scheduleStudyRuntimePreflights("repo", tasks, checksums, environments, arms)
 	var calls []string

--- a/internal/benchmark/study.go
+++ b/internal/benchmark/study.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -282,6 +283,28 @@ var stageBenchmarkExperimentBundles = stageStudyExperimentBundles
 
 const runtimePreflightProgressMessage = "Preflighting benchmark runtime"
 
+const runtimePreflightReceiptSchema = "deepswe-runtime-preflight-v1"
+
+type runtimePreflightReceipt struct {
+	Schema                 string  `json:"schema"`
+	DeepSWECommit          string  `json:"deep_swe_commit"`
+	PierVersion            string  `json:"pier_version"`
+	TaskContainerPlatform  string  `json:"task_container_platform"`
+	HostOS                 string  `json:"host_os"`
+	HostArchitecture       string  `json:"host_architecture"`
+	Task                   string  `json:"task"`
+	TaskChecksum           string  `json:"task_checksum"`
+	EnvironmentIdentity    string  `json:"environment_identity"`
+	Arm                    string  `json:"arm"`
+	ProviderAdapter        string  `json:"provider_adapter"`
+	RuntimeModel           string  `json:"runtime_model"`
+	ReasoningEffort        string  `json:"reasoning_effort"`
+	ProviderClientVersion  string  `json:"provider_client_version"`
+	AdapterSHA256          string  `json:"adapter_sha256,omitempty"`
+	TreatmentHash          string  `json:"treatment_manifest_hash,omitempty"`
+	AgentTimeoutMultiplier float64 `json:"agent_timeout_multiplier"`
+}
+
 var (
 	loadStudyTaskReadiness = loadTaskReadiness
 	reclaimStudyTaskImages = removeTaskReadinessImages
@@ -427,7 +450,7 @@ func scheduleStudyRuntimePreflights(repoRoot string, tasks []benchmarkPlanTask, 
 	work := make([][]studyRuntimePreflight, len(tasks))
 	for armIndex := range arms {
 		arm := &arms[armIndex]
-		request := ExecutionRequest{RepoRoot: repoRoot, EvidenceDir: arm.StateDir, Attempt: 1, Model: arm.Loaded.Model, Effort: arm.Loaded.Effort, Arm: arm.Mode, Bundle: arm.Bundle, AgentTimeoutMultiplier: arm.AgentTimeoutMultiplier}
+		request := ExecutionRequest{RepoRoot: repoRoot, EvidenceDir: arm.StateDir, Attempt: 1, Model: arm.Loaded.Model, Effort: arm.Loaded.Effort, Arm: arm.Mode, Bundle: arm.Bundle, AgentTimeoutMultiplier: arm.AgentTimeoutMultiplier, AdapterSHA256: arm.AdapterSHA256}
 		if !usesAgentLayerPierAdapter(request) {
 			continue
 		}
@@ -469,22 +492,42 @@ func preflightStudyRuntimes(ctx context.Context, options StudyOptions, tasks []b
 }
 
 func preflightStudyTaskRuntimes(ctx context.Context, task string, work []studyRuntimePreflight, reclaimTaskImages bool, checkout string, completed *int, required int, options StudyOptions) (err error) {
-	if reclaimTaskImages {
+	var cleanupReadiness *loadedTaskReadiness
+	defer func() {
+		if cleanupReadiness == nil {
+			return
+		}
+		cleanupCtx, cancelCleanup := detachedBenchmarkCleanupContext(ctx)
+		cleanupErr := reclaimStudyTaskImages(cleanupCtx, *cleanupReadiness)
+		cancelCleanup()
+		if cleanupErr != nil {
+			cleanupErr = fmt.Errorf("reclaim task images after runtime preflights for %q: %w", task, cleanupErr)
+		}
+		err = errors.Join(err, cleanupErr)
+	}()
+	installCleanup := func() error {
+		if !reclaimTaskImages || cleanupReadiness != nil {
+			return nil
+		}
 		readiness, loadErr := loadStudyTaskReadiness(checkout, task)
 		if loadErr != nil {
 			return loadErr
 		}
-		defer func() {
-			cleanupCtx, cancelCleanup := detachedBenchmarkCleanupContext(ctx)
-			cleanupErr := reclaimStudyTaskImages(cleanupCtx, readiness)
-			cancelCleanup()
-			if cleanupErr != nil {
-				cleanupErr = fmt.Errorf("reclaim task images after runtime preflights for %q: %w", task, cleanupErr)
-			}
-			err = errors.Join(err, cleanupErr)
-		}()
+		cleanupReadiness = &readiness
+		return nil
 	}
 	for _, item := range work {
+		cached, receipt, receiptPath, receiptErr := completedRuntimePreflight(item.request)
+		if receiptErr != nil {
+			return receiptErr
+		}
+		if cached {
+			(*completed)++
+			continue
+		}
+		if cleanupErr := installCleanup(); cleanupErr != nil {
+			return cleanupErr
+		}
 		eventID, eventErr := NewEventID()
 		if eventErr != nil {
 			return fmt.Errorf("create runtime preflight event for experiment %q task %q: %w", item.experiment, task, eventErr)
@@ -494,9 +537,43 @@ func preflightStudyTaskRuntimes(ctx context.Context, task string, work []studyRu
 		if preflightErr := preflightTreatmentRuntime(ctx, item.request); preflightErr != nil {
 			return fmt.Errorf("preflight experiment %q task %q runtime: %w", item.experiment, task, preflightErr)
 		}
+		if writeErr := writeJSON(receiptPath, receipt); writeErr != nil {
+			return fmt.Errorf("record successful runtime preflight for experiment %q task %q: %w", item.experiment, task, writeErr)
+		}
 		(*completed)++
 	}
 	return nil
+}
+
+func completedRuntimePreflight(request ExecutionRequest) (bool, runtimePreflightReceipt, string, error) {
+	if request.EvidenceDir == "" {
+		return false, runtimePreflightReceipt{}, "", errors.New("benchmark runtime preflight requires an evidence directory")
+	}
+	receipt := runtimePreflightReceipt{
+		Schema: runtimePreflightReceiptSchema, DeepSWECommit: DeepSWECommit, PierVersion: PierVersion,
+		TaskContainerPlatform: benchmarkTaskContainerPlatform, HostOS: runtime.GOOS, HostArchitecture: runtime.GOARCH,
+		Task:         request.Task,
+		TaskChecksum: request.TaskChecksum, EnvironmentIdentity: request.EnvironmentIdentity,
+		Arm: request.Arm, ProviderAdapter: request.Model.Adapter,
+		RuntimeModel: request.Model.RuntimeIdentifier, ReasoningEffort: request.Effort,
+		ProviderClientVersion: request.Model.ProviderClientVersion, AdapterSHA256: request.AdapterSHA256,
+		TreatmentHash: executionTreatmentHash(request), AgentTimeoutMultiplier: request.AgentTimeoutMultiplier,
+	}
+	identity, err := hashCanonical(receipt)
+	if err != nil {
+		return false, runtimePreflightReceipt{}, "", fmt.Errorf("identify benchmark runtime preflight: %w", err)
+	}
+	path := filepath.Join(request.EvidenceDir, "runtime-preflights", identity+".json")
+	var existing runtimePreflightReceipt
+	if err := readStudyJSON(path, &existing); errors.Is(err, os.ErrNotExist) {
+		return false, receipt, path, nil
+	} else if err != nil {
+		return false, runtimePreflightReceipt{}, "", fmt.Errorf("read benchmark runtime preflight receipt: %w", err)
+	}
+	if existing != receipt {
+		return false, runtimePreflightReceipt{}, "", fmt.Errorf("benchmark runtime preflight receipt %s does not match its content-addressed identity", path)
+	}
+	return true, receipt, path, nil
 }
 
 func stageStudyExperimentBundles(repoRoot string, prepared *preparedStudy) ([]*TreatmentBundle, error) {

--- a/internal/benchmark/study.go
+++ b/internal/benchmark/study.go
@@ -474,36 +474,57 @@ func preflightStudyRuntimes(ctx context.Context, options StudyOptions, tasks []b
 	for _, taskWork := range work {
 		required += len(taskWork)
 	}
+	if required == 0 {
+		return nil
+	}
+	hostArchitecture, err := dockerHostArchitecture(ctx)
+	if err != nil {
+		return err
+	}
 	completed := 0
 	var last StudyProgress
 	for taskIndex, taskWork := range work {
 		if len(taskWork) == 0 {
 			continue
 		}
-		if err := preflightStudyTaskRuntimes(ctx, tasks[taskIndex].ID, taskWork, reclaimTaskImages, checkout, &completed, required, options); err != nil {
+		if err := preflightStudyTaskRuntimes(ctx, tasks[taskIndex].ID, taskWork, reclaimTaskImages, checkout, &completed, required, options, hostArchitecture); err != nil {
 			return err
 		}
 		last = StudyProgress{Phase: "runtime-preflight", Message: runtimePreflightProgressMessage, Task: tasks[taskIndex].ID, Experiment: taskWork[len(taskWork)-1].experiment, Completed: completed, Required: required}
 	}
-	if required > 0 {
-		emitStudyProgress(options, last)
+	emitStudyProgress(options, last)
+	return nil
+}
+
+type pendingRuntimePreflightReceipt struct {
+	experiment string
+	path       string
+	receipt    runtimePreflightReceipt
+}
+
+func commitRuntimePreflightReceipts(task string, pending []pendingRuntimePreflightReceipt) error {
+	for _, item := range pending {
+		if err := writeJSON(item.path, item.receipt); err != nil {
+			return fmt.Errorf("record successful runtime preflight for experiment %q task %q: %w", item.experiment, task, err)
+		}
 	}
 	return nil
 }
 
-func preflightStudyTaskRuntimes(ctx context.Context, task string, work []studyRuntimePreflight, reclaimTaskImages bool, checkout string, completed *int, required int, options StudyOptions) (err error) {
+func preflightStudyTaskRuntimes(ctx context.Context, task string, work []studyRuntimePreflight, reclaimTaskImages bool, checkout string, completed *int, required int, options StudyOptions, hostArchitecture string) (err error) {
 	var cleanupReadiness *loadedTaskReadiness
+	var pending []pendingRuntimePreflightReceipt
 	defer func() {
-		if cleanupReadiness == nil {
-			return
+		if cleanupReadiness != nil {
+			cleanupCtx, cancelCleanup := detachedBenchmarkCleanupContext(ctx)
+			cleanupErr := reclaimStudyTaskImages(cleanupCtx, *cleanupReadiness)
+			cancelCleanup()
+			if cleanupErr != nil {
+				err = errors.Join(err, fmt.Errorf("reclaim task images after runtime preflights for %q: %w", task, cleanupErr))
+				return
+			}
 		}
-		cleanupCtx, cancelCleanup := detachedBenchmarkCleanupContext(ctx)
-		cleanupErr := reclaimStudyTaskImages(cleanupCtx, *cleanupReadiness)
-		cancelCleanup()
-		if cleanupErr != nil {
-			cleanupErr = fmt.Errorf("reclaim task images after runtime preflights for %q: %w", task, cleanupErr)
-		}
-		err = errors.Join(err, cleanupErr)
+		err = errors.Join(err, commitRuntimePreflightReceipts(task, pending))
 	}()
 	installCleanup := func() error {
 		if !reclaimTaskImages || cleanupReadiness != nil {
@@ -517,7 +538,7 @@ func preflightStudyTaskRuntimes(ctx context.Context, task string, work []studyRu
 		return nil
 	}
 	for _, item := range work {
-		cached, receipt, receiptPath, receiptErr := completedRuntimePreflight(item.request)
+		cached, receipt, receiptPath, receiptErr := completedRuntimePreflight(item.request, hostArchitecture)
 		if receiptErr != nil {
 			return receiptErr
 		}
@@ -537,21 +558,22 @@ func preflightStudyTaskRuntimes(ctx context.Context, task string, work []studyRu
 		if preflightErr := preflightTreatmentRuntime(ctx, item.request); preflightErr != nil {
 			return fmt.Errorf("preflight experiment %q task %q runtime: %w", item.experiment, task, preflightErr)
 		}
-		if writeErr := writeJSON(receiptPath, receipt); writeErr != nil {
-			return fmt.Errorf("record successful runtime preflight for experiment %q task %q: %w", item.experiment, task, writeErr)
-		}
+		pending = append(pending, pendingRuntimePreflightReceipt{experiment: item.experiment, path: receiptPath, receipt: receipt})
 		(*completed)++
 	}
 	return nil
 }
 
-func completedRuntimePreflight(request ExecutionRequest) (bool, runtimePreflightReceipt, string, error) {
+func completedRuntimePreflight(request ExecutionRequest, hostArchitecture string) (bool, runtimePreflightReceipt, string, error) {
 	if request.EvidenceDir == "" {
 		return false, runtimePreflightReceipt{}, "", errors.New("benchmark runtime preflight requires an evidence directory")
 	}
+	if hostArchitecture == "" {
+		return false, runtimePreflightReceipt{}, "", errors.New("benchmark runtime preflight requires a Docker host architecture")
+	}
 	receipt := runtimePreflightReceipt{
 		Schema: runtimePreflightReceiptSchema, DeepSWECommit: DeepSWECommit, PierVersion: PierVersion,
-		TaskContainerPlatform: benchmarkTaskContainerPlatform, HostOS: runtime.GOOS, HostArchitecture: runtime.GOARCH,
+		TaskContainerPlatform: benchmarkTaskContainerPlatform, HostOS: runtime.GOOS, HostArchitecture: hostArchitecture,
 		Task:         request.Task,
 		TaskChecksum: request.TaskChecksum, EnvironmentIdentity: request.EnvironmentIdentity,
 		Arm: request.Arm, ProviderAdapter: request.Model.Adapter,

--- a/internal/benchmark/study_treatment_test.go
+++ b/internal/benchmark/study_treatment_test.go
@@ -472,10 +472,14 @@ func TestTreatmentStudyDryRunIdentityIsDeterministicAcrossInvocations(t *testing
 
 	originalAuthentication := validateBenchmarkAuthentication
 	originalRuntimePreflight := preflightTreatmentRuntime
+	runtimePreflights := 0
 	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
 		return map[string]AuthenticationPreflight{}, nil
 	}
-	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error { return nil }
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error {
+		runtimePreflights++
+		return nil
+	}
 	t.Cleanup(func() {
 		validateBenchmarkAuthentication = originalAuthentication
 		preflightTreatmentRuntime = originalRuntimePreflight
@@ -495,6 +499,9 @@ func TestTreatmentStudyDryRunIdentityIsDeterministicAcrossInvocations(t *testing
 	}
 	if second.StudyID != first.StudyID || second.Experiments[0].Identity != first.Experiments[0].Identity {
 		t.Fatalf("identical dry-run preparations changed identity:\nfirst:  %#v\nsecond: %#v", first, second)
+	}
+	if runtimePreflights != 2 {
+		t.Fatalf("second identical dry run should reuse the first run's preflight receipts: executed %d runtime preflights", runtimePreflights)
 	}
 	studies, err := os.ReadDir(filepath.Join(root, ".agent-layer", "state", "benchmarks", "deepswe", "studies"))
 	if err != nil {


### PR DESCRIPTION
## Summary

- Cache successful task-and-arm Pier preflights as content-addressed receipts so identical later invocations skip the slow runtime check.
- Warn operators when DeepSWE `linux/amd64` task containers require host emulation.

## Changes

- Persist runtime preflight receipts under each arm's state directory, keyed by Pier version, task environment, provider client, adapter, model, reasoning, treatment, timeout multiplier, and host OS/architecture.
- Load task images lazily during runtime preflight and reclaim them only when a preflight actually ran.
- Print the emulation warning from `al benchmark run` and `al benchmark readiness` after command validation.
- Document receipt reuse and the cross-architecture warning.

## Verification

- `go test ./internal/benchmark ./cmd/al` — passed.
- Commit hooks (`gofmt + goimports`, `go mod tidy check`, `golangci-lint`, `go test ./...`) — passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added architecture warnings when benchmark task containers require emulation.
  * Added reusable runtime preflight receipts for successful dry runs.
  * Added host architecture checks and support for certified `linux/amd64` task containers.
  * Preflight receipts now validate runtime, task, environment, adapter, treatment, and host details.

* **Documentation**
  * Updated the benchmark guide with receipt reuse, authentication checks, and architecture requirements.

* **Bug Fixes**
  * Improved cleanup and error handling during benchmark preflight checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->