### PR TITLE
Fix release upgrade and benchmark recovery safeguards

### DIFF
--- a/cmd/al/benchmark.go
+++ b/cmd/al/benchmark.go
@@ -348,7 +348,11 @@ func newBenchmarkRunCmd() *cobra.Command {
 				return nil
 			}
 			if recoveryOnly {
-				_, err = fmt.Fprintf(cmd.OutOrStdout(), "Recovery completed: %d terminal verifier timeout cell(s) canonicalized; %d of %d cells cached, %d still missing. No provider or verifier process was started.\n", outcome.RecoveredCells, outcome.Completed, outcome.Required, outcome.Missing)
+				report := ""
+				if outcome.JSONPath != "" {
+					report = fmt.Sprintf(" Report: %s.", outcome.JSONPath)
+				}
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "Recovery completed: %d terminal verifier timeout cell(s) canonicalized; %d of %d cells cached, %d still missing.%s No provider or verifier process was started.\n", outcome.RecoveredCells, outcome.Completed, outcome.Required, outcome.Missing, report)
 				return err
 			}
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Study %.12s: %d of %d cells cached, $%.2f cumulative observed cost in this invocation (range $%.2f–$%.2f). Report: %s\n", outcome.StudyID, outcome.Completed, outcome.Required, outcome.ObservedInvocationCost.Midpoint, outcome.ObservedInvocationCost.Minimum, outcome.ObservedInvocationCost.Maximum, outcome.JSONPath)

--- a/cmd/al/benchmark.go
+++ b/cmd/al/benchmark.go
@@ -356,7 +356,7 @@ func newBenchmarkRunCmd() *cobra.Command {
 		},
 	}
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "validate and preflight without inference calls")
-	command.Flags().BoolVar(&recoveryOnly, "recover-only", false, "finalize retained terminal verifier test timeouts without provider or verifier execution")
+	command.Flags().BoolVar(&recoveryOnly, "recover-only", false, "finalize retained terminal verifier test timeouts or regenerate a completed study report without provider or verifier execution")
 	command.Flags().IntVar(&taskConcurrency, "task-concurrency", 0, "parallel task cells, from 1 to 8 (default: automatic)")
 	command.Flags().StringArrayVar(&tasks, "task", nil, "execute only this selected task; repeatable")
 	return command

--- a/cmd/al/benchmark_test.go
+++ b/cmd/al/benchmark_test.go
@@ -353,8 +353,35 @@ func TestBenchmarkRunRecoveryOnlyDoesNotAuthorizeExecution(t *testing.T) {
 	got := output.String()
 	if !strings.Contains(got, "Recovery-only mode: no provider or verifier process will be started") ||
 		!strings.Contains(got, "1 terminal verifier timeout cell(s) canonicalized") ||
-		strings.Contains(got, "authorizes paid provider calls") {
+		strings.Contains(got, "authorizes paid provider calls") ||
+		strings.Contains(got, "Report:") {
 		t.Fatalf("recovery-only output = %q", got)
+	}
+}
+
+func TestBenchmarkRunRecoveryOnlyPrintsRegeneratedReportPath(t *testing.T) {
+	original := runStudy
+	runStudy = func(_ context.Context, options bench.StudyOptions, executor bench.TaskExecutor) (bench.StudyOutcome, error) {
+		if !options.RecoveryOnly || executor != nil {
+			t.Fatalf("recovery options = %#v executor=%#v", options, executor)
+		}
+		return bench.StudyOutcome{
+			StudyID: strings.Repeat("a", 64), Required: 16, Completed: 16, Missing: 0, JSONPath: "/tmp/report.json",
+		}, nil
+	}
+	t.Cleanup(func() { runStudy = original })
+	root := newRootCmd()
+	root.SetArgs([]string{"benchmark", "run", "study.toml", "--recover-only"})
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetErr(&output)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := output.String()
+	if !strings.Contains(got, "16 of 16 cells cached, 0 still missing. Report: /tmp/report.json.") ||
+		!strings.Contains(got, "No provider or verifier process was started") {
+		t.Fatalf("recovery-only report output = %q", got)
 	}
 }
 

--- a/cmd/al/upgrade.go
+++ b/cmd/al/upgrade.go
@@ -691,12 +691,16 @@ func requireUpgradeTargetCLI(targetVersion string) error {
 	if err != nil {
 		return err
 	}
-	comparison, err := version.Compare(currentVersion, targetVersion)
+	normalizedTargetVersion, err := version.Normalize(targetVersion)
+	if err != nil {
+		return err
+	}
+	comparison, err := version.Compare(currentVersion, normalizedTargetVersion)
 	if err != nil {
 		return err
 	}
 	if comparison < 0 {
-		return fmt.Errorf(messages.UpgradeTargetRequiresNewerCLIFmt, currentVersion, targetVersion, targetVersion)
+		return fmt.Errorf(messages.UpgradeTargetRequiresNewerCLIFmt, currentVersion, normalizedTargetVersion, normalizedTargetVersion)
 	}
 	return nil
 }

--- a/cmd/al/upgrade.go
+++ b/cmd/al/upgrade.go
@@ -14,6 +14,7 @@ import (
 	"github.com/conn-castle/agent-layer/internal/config"
 	"github.com/conn-castle/agent-layer/internal/install"
 	"github.com/conn-castle/agent-layer/internal/messages"
+	"github.com/conn-castle/agent-layer/internal/version"
 	"github.com/conn-castle/agent-layer/internal/versiondispatch"
 	"github.com/conn-castle/agent-layer/internal/wizard"
 )
@@ -65,6 +66,9 @@ func newUpgradeCmd() *cobra.Command {
 
 			targetPin, err := resolvePinVersionForInit(cmd.Context(), pinVersion, Version)
 			if err != nil {
+				return err
+			}
+			if err := requireUpgradeTargetCLI(targetPin); err != nil {
 				return err
 			}
 			if strings.TrimSpace(pinVersion) != "" && !strings.EqualFold(strings.TrimSpace(pinVersion), "latest") {
@@ -650,6 +654,9 @@ func newUpgradePlanCmd(diffLines *int) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if err := requireUpgradeTargetCLI(targetPin); err != nil {
+				return err
+			}
 			if strings.TrimSpace(pinVersion) != "" && !strings.EqualFold(strings.TrimSpace(pinVersion), "latest") {
 				if err := validatePinnedReleaseVersionFunc(cmd.Context(), targetPin); err != nil {
 					return err
@@ -674,6 +681,24 @@ func newUpgradePlanCmd(diffLines *int) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&pinVersion, "version", "", messages.UpgradeFlagVersion)
 	return cmd
+}
+
+func requireUpgradeTargetCLI(targetVersion string) error {
+	if targetVersion == "" || version.IsDev(Version) {
+		return nil
+	}
+	currentVersion, err := version.Normalize(Version)
+	if err != nil {
+		return err
+	}
+	comparison, err := version.Compare(currentVersion, targetVersion)
+	if err != nil {
+		return err
+	}
+	if comparison < 0 {
+		return fmt.Errorf(messages.UpgradeTargetRequiresNewerCLIFmt, currentVersion, targetVersion, targetVersion)
+	}
+	return nil
 }
 
 func renderUpgradePlanText(out io.Writer, plan install.UpgradePlan, previews map[string]install.DiffPreview) error {

--- a/cmd/al/upgrade_plan_test.go
+++ b/cmd/al/upgrade_plan_test.go
@@ -232,6 +232,36 @@ func TestUpgradePlanCmd_VersionFlagValidatesExplicitPin(t *testing.T) {
 	}
 }
 
+func TestUpgradePlanCmdRejectsTargetNewerThanInvokingCLI(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".agent-layer"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	originalVersion := Version
+	Version = "v0.18.3"
+	t.Cleanup(func() { Version = originalVersion })
+
+	originalValidate := validatePinnedReleaseVersionFunc
+	validatePinnedReleaseVersionFunc = func(context.Context, string) error {
+		t.Fatal("newer target reached remote release validation")
+		return nil
+	}
+	t.Cleanup(func() { validatePinnedReleaseVersionFunc = originalValidate })
+
+	testutil.WithWorkingDir(t, root, func() {
+		diffLines := install.DefaultDiffMaxLines
+		cmd := newUpgradePlanCmd(&diffLines)
+		cmd.SetArgs([]string{"--version", "v0.18.4"})
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "CLI v0.18.3 cannot upgrade to v0.18.4") ||
+			!strings.Contains(err.Error(), "al update") || !strings.Contains(err.Error(), "prefetch") {
+			t.Fatalf("newer target error = %v", err)
+		}
+	})
+}
+
 func TestUpgradePlanCmd_VersionFlagValidationError(t *testing.T) {
 	root := prepareUpgradeTestRepo(t)
 

--- a/cmd/al/upgrade_test.go
+++ b/cmd/al/upgrade_test.go
@@ -54,6 +54,16 @@ func TestUpgradeCmd_RequiresTerminalWithoutApplyFlags(t *testing.T) {
 	})
 }
 
+func TestRequireUpgradeTargetCLIAllowsDevelopmentBuild(t *testing.T) {
+	originalVersion := Version
+	Version = "dev"
+	t.Cleanup(func() { Version = originalVersion })
+
+	if err := requireUpgradeTargetCLI("v999.0.0"); err != nil {
+		t.Fatalf("development build rejected newer upgrade target: %v", err)
+	}
+}
+
 func TestUpgradeCmd_YesWithoutApplyFlagsErrors(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".agent-layer"), 0o700); err != nil {
@@ -699,6 +709,46 @@ func TestUpgradeCmd_VersionFlagValidatesExplicitPin(t *testing.T) {
 	if !calledInstall {
 		t.Fatal("expected installRun to be called")
 	}
+}
+
+func TestUpgradeCmdRejectsTargetNewerThanInvokingCLI(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".agent-layer"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	originalVersion := Version
+	Version = "v0.18.3"
+	t.Cleanup(func() { Version = originalVersion })
+
+	originalTerminal := isTerminal
+	isTerminal = func() bool { return false }
+	t.Cleanup(func() { isTerminal = originalTerminal })
+
+	originalValidate := validatePinnedReleaseVersionFunc
+	validatePinnedReleaseVersionFunc = func(context.Context, string) error {
+		t.Fatal("newer target reached remote release validation")
+		return nil
+	}
+	t.Cleanup(func() { validatePinnedReleaseVersionFunc = originalValidate })
+
+	originalInstall := installRun
+	installRun = func(string, install.Options) error {
+		t.Fatal("newer target reached installation")
+		return nil
+	}
+	t.Cleanup(func() { installRun = originalInstall })
+
+	testutil.WithWorkingDir(t, root, func() {
+		cmd := newUpgradeCmd()
+		cmd.SetArgs([]string{"--yes", "--apply-managed-updates", "--version", "v0.18.4"})
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "CLI v0.18.3 cannot upgrade to v0.18.4") ||
+			!strings.Contains(err.Error(), "al update") || !strings.Contains(err.Error(), "prefetch") {
+			t.Fatalf("newer target error = %v", err)
+		}
+	})
 }
 
 func TestWriteMigrationReportSection_BreakingAnnotation(t *testing.T) {

--- a/cmd/al/upgrade_test.go
+++ b/cmd/al/upgrade_test.go
@@ -64,6 +64,18 @@ func TestRequireUpgradeTargetCLIAllowsDevelopmentBuild(t *testing.T) {
 	}
 }
 
+func TestRequireUpgradeTargetCLIFormatsNormalizedTarget(t *testing.T) {
+	originalVersion := Version
+	Version = "v0.18.3"
+	t.Cleanup(func() { Version = originalVersion })
+
+	err := requireUpgradeTargetCLI("v0.18.4")
+	if err == nil || !strings.Contains(err.Error(), "CLI v0.18.3 cannot upgrade to v0.18.4") ||
+		strings.Contains(err.Error(), "vv0.18.4") || !strings.Contains(err.Error(), "al --version") {
+		t.Fatalf("normalized target error = %v", err)
+	}
+}
+
 func TestUpgradeCmd_YesWithoutApplyFlagsErrors(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".agent-layer"), 0o700); err != nil {

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -95,14 +95,15 @@ al benchmark readiness --study benchmark-study/study.toml --remove-task-images=f
 # Run only one task from the immutable study membership.
 al benchmark run benchmark-study/study.toml --task first-task
 
-# Canonicalize retained terminal test timeouts without provider or verifier execution.
+# Canonicalize retained terminal test timeouts or regenerate a completed report
+# without provider or verifier execution.
 al benchmark run benchmark-study/study.toml --recover-only
 
 # Override the automatic worker choice.
 al benchmark run benchmark-study/study.toml --task-concurrency 2
 ```
 
-`--recover-only` inspects retained checkpoints and finalizes only evidence-backed terminal candidate test timeouts; it skips every ordinary missing cell and every replayable infrastructure/interrupted verifier state. If no compatible retained study with those checkpoints exists, the command fails instead of certifying task images or creating a new study. `--task` and worker count affect only the current invocation; they do not change study identity or report membership. A run concurrency greater than one is an explicit throughput override and disables task-image reclamation because concurrent cells may still be using the same image.
+`--recover-only` first inspects retained checkpoints and finalizes only evidence-backed terminal candidate test timeouts; it skips every ordinary missing cell and every replayable infrastructure/interrupted verifier state. It can also regenerate a report for a compatible completed study from that study's immutable manifest, treatment pins, and cell evidence without restaging current treatment inputs. If neither kind of compatible retained study exists, the command fails instead of certifying task images or creating a new study. `--task` and worker count affect only the current invocation; they do not change study identity or report membership. A run concurrency greater than one is an explicit throughput override and disables task-image reclamation because concurrent cells may still be using the same image.
 
 Readiness also supports deterministic sharding and per-task timeouts:
 

--- a/internal/benchmark/auth_preflight_test.go
+++ b/internal/benchmark/auth_preflight_test.go
@@ -1219,6 +1219,107 @@ func TestManifestOnlyCachedStudyCompleteDoesNotMutateCallerStudyID(t *testing.T)
 	}
 }
 
+func TestRecoveryOnlyRegeneratesCompletedHistoricalTreatmentReportWithoutRestagingCurrentInputs(t *testing.T) {
+	root := t.TempDir()
+	selectionData, err := json.Marshal(matrixSelectionFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeStudyInputFixture(t, root, "selection.json", string(selectionData))
+	writeStudyTreatmentConfig(t, root)
+	if err := os.Mkdir(filepath.Join(root, "instructions"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeStudyInputFixture(t, filepath.Join(root, "instructions"), "01_prime_directive.md", "Read CONTEXT.md before starting.\n")
+	writeStudyInputFixture(t, root, "study.toml", "selection = \"selection.json\"\n[[experiments]]\nname = \"Treatment\"\nmodel = \"luna\"\nreasoning = \"low\"\nconfig = \"config.toml\"\ninstructions = \"instructions\"\n")
+	if err := validateTreatmentInstructionDependencies(filepath.Join(root, "instructions")); err == nil {
+		t.Fatal("test instructions must be rejected by current treatment staging")
+	}
+
+	preparedCalls := stubStudyInfrastructure(t, root)
+	originalAuth := validateBenchmarkAuthentication
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{}, nil
+	}
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	originalRuntime := preflightTreatmentRuntime
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error { return nil }
+	t.Cleanup(func() { preflightTreatmentRuntime = originalRuntime })
+	originalBundles := stageBenchmarkExperimentBundles
+	stageCalls := 0
+	manifest := TreatmentManifest{
+		SchemaVersion: TreatmentSchemaVersion,
+		Mode:          TreatmentInstructionsOnly,
+		Files:         []TreatmentFile{{Path: "AGENTS.md", SHA256: strings.Repeat("a", 64)}},
+	}
+	manifestHash, err := hashCanonical(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle := &TreatmentBundle{
+		Manifest: manifest, ManifestHash: manifestHash, LinuxArchitecture: benchmarkTaskContainerArchitecture,
+		AdapterSHA256: "adapter-hash", LinuxBinarySHA256: "runtime-hash", TemplatesCommit: strings.Repeat("c", 40),
+		RuntimeSourceKind: treatmentRuntimeSourceRelease, RuntimeVersion: "test",
+	}
+	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
+		stageCalls++
+		return []*TreatmentBundle{bundle}, nil
+	}
+	t.Cleanup(func() { stageBenchmarkExperimentBundles = originalBundles })
+
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var originalReport StudyReport
+	if err := readStudyJSON(first.JSONPath, &originalReport); err != nil {
+		t.Fatal(err)
+	}
+	pinRoot := studyTreatmentPinRoot(root, bundle.ManifestHash)
+	pin := studyTreatmentPin{
+		SchemaVersion: studyTreatmentPinSchema, PinID: bundle.ManifestHash, Architecture: bundle.LinuxArchitecture,
+		ManifestHash: bundle.ManifestHash, Manifest: bundle.Manifest, LinuxBinarySHA256: bundle.LinuxBinarySHA256,
+		AdapterSHA256: bundle.AdapterSHA256, TemplatesCommit: bundle.TemplatesCommit, TemplatesDirty: bundle.TemplatesDirty,
+		RuntimeSourceKind: bundle.RuntimeSourceKind, RuntimeVersion: bundle.RuntimeVersion,
+	}
+	if err := writeJSON(filepath.Join(pinRoot, "pin.json"), pin); err != nil {
+		t.Fatal(err)
+	}
+	removeStudyReport(t, root, first.StudyID)
+	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
+		t.Fatal("recovery-only restaged mutable treatment inputs")
+		return nil, nil
+	}
+
+	recovered, err := RunStudy(context.Background(), StudyOptions{
+		RepoRoot: root, StudyPath: filepath.Join(root, "study.toml"), RecoveryOnly: true,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stageCalls != 1 || *preparedCalls != 1 {
+		t.Fatalf("historical report regeneration restaged inputs: stage=%d tasks=%d", stageCalls, *preparedCalls)
+	}
+	if recovered.StudyID != first.StudyID || recovered.Completed != recovered.Required || recovered.Missing != 0 || recovered.JSONPath == "" || recovered.HTMLPath == "" {
+		t.Fatalf("recovered outcome = %#v", recovered)
+	}
+	for _, path := range []string{recovered.JSONPath, recovered.HTMLPath} {
+		if info, err := os.Stat(path); err != nil || !info.Mode().IsRegular() {
+			t.Fatalf("regenerated report %q: info=%v err=%v", path, info, err)
+		}
+	}
+	var recoveredReport StudyReport
+	if err := readStudyJSON(recovered.JSONPath, &recoveredReport); err != nil {
+		t.Fatal(err)
+	}
+	want, got := originalReport.Experiments[0], recoveredReport.Experiments[0]
+	if got.BundleManifest == nil || got.BundleManifest.SchemaVersion != want.BundleManifest.SchemaVersion ||
+		len(got.BundleManifest.Files) != 1 || got.BundleManifest.Files[0] != want.BundleManifest.Files[0] ||
+		got.SourceCommit != want.SourceCommit || got.LinuxBinarySHA256 != want.LinuxBinarySHA256 {
+		t.Fatalf("regenerated report lost immutable treatment provenance: want=%#v got=%#v", want, got)
+	}
+}
+
 func TestRunStudyRejectsMultipleCompleteManifestOnlyMatches(t *testing.T) {
 	root := t.TempDir()
 	writeParsedBareStudy(t, root, "luna:low")
@@ -1476,7 +1577,7 @@ func fakeStudyTreatmentBundle() *TreatmentBundle {
 		ManifestHash:      "treatment-manifest-hash",
 		AdapterSHA256:     "adapter-hash",
 		LinuxBinarySHA256: "runtime-hash",
-		RuntimeSourceKind: "release",
+		RuntimeSourceKind: treatmentRuntimeSourceRelease,
 		RuntimeVersion:    "test",
 		Manifest:          TreatmentManifest{Mode: TreatmentInstructionsOnly, AgentTimeoutMultiplier: skillsAgentTimeoutFactor},
 	}

--- a/internal/benchmark/auth_preflight_test.go
+++ b/internal/benchmark/auth_preflight_test.go
@@ -1220,87 +1220,20 @@ func TestManifestOnlyCachedStudyCompleteDoesNotMutateCallerStudyID(t *testing.T)
 }
 
 func TestRecoveryOnlyRegeneratesCompletedHistoricalTreatmentReportWithoutRestagingCurrentInputs(t *testing.T) {
-	root := t.TempDir()
-	selectionData, err := json.Marshal(matrixSelectionFixture())
-	if err != nil {
-		t.Fatal(err)
-	}
-	writeStudyInputFixture(t, root, "selection.json", string(selectionData))
-	writeStudyTreatmentConfig(t, root)
-	if err := os.Mkdir(filepath.Join(root, "instructions"), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	writeStudyInputFixture(t, filepath.Join(root, "instructions"), "01_prime_directive.md", "Read CONTEXT.md before starting.\n")
-	writeStudyInputFixture(t, root, "study.toml", "selection = \"selection.json\"\n[[experiments]]\nname = \"Treatment\"\nmodel = \"luna\"\nreasoning = \"low\"\nconfig = \"config.toml\"\ninstructions = \"instructions\"\n")
-	if err := validateTreatmentInstructionDependencies(filepath.Join(root, "instructions")); err == nil {
-		t.Fatal("test instructions must be rejected by current treatment staging")
-	}
-
-	preparedCalls := stubStudyInfrastructure(t, root)
-	originalAuth := validateBenchmarkAuthentication
-	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
-		return map[string]AuthenticationPreflight{}, nil
-	}
-	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
-	originalRuntime := preflightTreatmentRuntime
-	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error { return nil }
-	t.Cleanup(func() { preflightTreatmentRuntime = originalRuntime })
-	originalBundles := stageBenchmarkExperimentBundles
-	stageCalls := 0
-	manifest := TreatmentManifest{
-		SchemaVersion: TreatmentSchemaVersion,
-		Mode:          TreatmentInstructionsOnly,
-		Files:         []TreatmentFile{{Path: "AGENTS.md", SHA256: strings.Repeat("a", 64)}},
-	}
-	manifestHash, err := hashCanonical(manifest)
-	if err != nil {
-		t.Fatal(err)
-	}
-	bundle := &TreatmentBundle{
-		Manifest: manifest, ManifestHash: manifestHash, LinuxArchitecture: benchmarkTaskContainerArchitecture,
-		AdapterSHA256: "adapter-hash", LinuxBinarySHA256: "runtime-hash", TemplatesCommit: strings.Repeat("c", 40),
-		RuntimeSourceKind: treatmentRuntimeSourceRelease, RuntimeVersion: "test",
-	}
-	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
-		stageCalls++
-		return []*TreatmentBundle{bundle}, nil
-	}
-	t.Cleanup(func() { stageBenchmarkExperimentBundles = originalBundles })
-
-	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	var originalReport StudyReport
-	if err := readStudyJSON(first.JSONPath, &originalReport); err != nil {
-		t.Fatal(err)
-	}
-	pinRoot := studyTreatmentPinRoot(root, bundle.ManifestHash)
-	pin := studyTreatmentPin{
-		SchemaVersion: studyTreatmentPinSchema, PinID: bundle.ManifestHash, Architecture: bundle.LinuxArchitecture,
-		ManifestHash: bundle.ManifestHash, Manifest: bundle.Manifest, LinuxBinarySHA256: bundle.LinuxBinarySHA256,
-		AdapterSHA256: bundle.AdapterSHA256, TemplatesCommit: bundle.TemplatesCommit, TemplatesDirty: bundle.TemplatesDirty,
-		RuntimeSourceKind: bundle.RuntimeSourceKind, RuntimeVersion: bundle.RuntimeVersion,
-	}
-	if err := writeJSON(filepath.Join(pinRoot, "pin.json"), pin); err != nil {
-		t.Fatal(err)
-	}
-	removeStudyReport(t, root, first.StudyID)
-	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
-		t.Fatal("recovery-only restaged mutable treatment inputs")
-		return nil, nil
-	}
+	fixture := setupCompletedHistoricalTreatmentStudyForRecovery(t)
+	removeStudyReport(t, fixture.root, fixture.first.StudyID)
+	blockHistoricalTreatmentRestaging(t)
 
 	recovered, err := RunStudy(context.Background(), StudyOptions{
-		RepoRoot: root, StudyPath: filepath.Join(root, "study.toml"), RecoveryOnly: true,
+		RepoRoot: fixture.root, StudyPath: filepath.Join(fixture.root, "study.toml"), RecoveryOnly: true,
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stageCalls != 1 || *preparedCalls != 1 {
-		t.Fatalf("historical report regeneration restaged inputs: stage=%d tasks=%d", stageCalls, *preparedCalls)
+	if *fixture.stageCalls != 1 || *fixture.preparedCalls != 1 {
+		t.Fatalf("historical report regeneration restaged inputs: stage=%d tasks=%d", *fixture.stageCalls, *fixture.preparedCalls)
 	}
-	if recovered.StudyID != first.StudyID || recovered.Completed != recovered.Required || recovered.Missing != 0 || recovered.JSONPath == "" || recovered.HTMLPath == "" {
+	if recovered.StudyID != fixture.first.StudyID || recovered.Completed != recovered.Required || recovered.Missing != 0 || recovered.JSONPath == "" || recovered.HTMLPath == "" {
 		t.Fatalf("recovered outcome = %#v", recovered)
 	}
 	for _, path := range []string{recovered.JSONPath, recovered.HTMLPath} {
@@ -1312,11 +1245,74 @@ func TestRecoveryOnlyRegeneratesCompletedHistoricalTreatmentReportWithoutRestagi
 	if err := readStudyJSON(recovered.JSONPath, &recoveredReport); err != nil {
 		t.Fatal(err)
 	}
-	want, got := originalReport.Experiments[0], recoveredReport.Experiments[0]
+	want, got := fixture.originalReport.Experiments[0], recoveredReport.Experiments[0]
 	if got.BundleManifest == nil || got.BundleManifest.SchemaVersion != want.BundleManifest.SchemaVersion ||
 		len(got.BundleManifest.Files) != 1 || got.BundleManifest.Files[0] != want.BundleManifest.Files[0] ||
 		got.SourceCommit != want.SourceCommit || got.LinuxBinarySHA256 != want.LinuxBinarySHA256 {
 		t.Fatalf("regenerated report lost immutable treatment provenance: want=%#v got=%#v", want, got)
+	}
+}
+
+func TestRecoveryOnlyRejectsPinTemplateProvenanceThatConflictsWithStudyContract(t *testing.T) {
+	fixture := setupCompletedHistoricalTreatmentStudyForRecovery(t)
+	var pin studyTreatmentPin
+	if err := readStudyJSON(filepath.Join(studyTreatmentPinRoot(fixture.root, fixture.bundle.ManifestHash), "pin.json"), &pin); err != nil {
+		t.Fatal(err)
+	}
+	pin.TemplatesCommit = strings.Repeat("d", 40)
+	if err := writeJSON(filepath.Join(studyTreatmentPinRoot(fixture.root, fixture.bundle.ManifestHash), "pin.json"), pin); err != nil {
+		t.Fatal(err)
+	}
+	removeStudyReport(t, fixture.root, fixture.first.StudyID)
+	blockHistoricalTreatmentRestaging(t)
+
+	_, err := RunStudy(context.Background(), StudyOptions{
+		RepoRoot: fixture.root, StudyPath: filepath.Join(fixture.root, "study.toml"), RecoveryOnly: true,
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with its immutable arm contract") {
+		t.Fatalf("conflicting pin template provenance = %v", err)
+	}
+}
+
+func TestRecoveryOnlyOmitsUnauthenticatedLegacyTemplateProvenance(t *testing.T) {
+	fixture := setupCompletedHistoricalTreatmentStudyForRecovery(t)
+	hash := fixture.bundle.ManifestHash
+	manifestPath := filepath.Join(fixture.root, ".agent-layer", "state", "benchmarks", "deepswe", "studies", fixture.first.StudyID, "study-manifest.json")
+	var manifest immutableStudyManifest
+	if err := readStudyJSON(manifestPath, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	for i := range manifest.Arms {
+		manifest.Arms[i].TemplatesCommit = ""
+		manifest.Arms[i].TemplatesDirty = false
+	}
+	if err := writeJSON(manifestPath, manifest); err != nil {
+		t.Fatal(err)
+	}
+	var pin studyTreatmentPin
+	if err := readStudyJSON(filepath.Join(studyTreatmentPinRoot(fixture.root, hash), "pin.json"), &pin); err != nil {
+		t.Fatal(err)
+	}
+	pin.TemplatesCommit = strings.Repeat("e", 40)
+	pin.TemplatesDirty = true
+	if err := writeJSON(filepath.Join(studyTreatmentPinRoot(fixture.root, hash), "pin.json"), pin); err != nil {
+		t.Fatal(err)
+	}
+	removeStudyReport(t, fixture.root, fixture.first.StudyID)
+	blockHistoricalTreatmentRestaging(t)
+
+	recovered, err := RunStudy(context.Background(), StudyOptions{
+		RepoRoot: fixture.root, StudyPath: filepath.Join(fixture.root, "study.toml"), RecoveryOnly: true,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var recoveredReport StudyReport
+	if err := readStudyJSON(recovered.JSONPath, &recoveredReport); err != nil {
+		t.Fatal(err)
+	}
+	if recoveredReport.Experiments[0].SourceCommit != "" || recoveredReport.Experiments[0].SourceDirty {
+		t.Fatalf("legacy recovery published unauthenticated template provenance: %#v", recoveredReport.Experiments[0])
 	}
 }
 
@@ -1580,6 +1576,96 @@ func fakeStudyTreatmentBundle() *TreatmentBundle {
 		RuntimeSourceKind: treatmentRuntimeSourceRelease,
 		RuntimeVersion:    "test",
 		Manifest:          TreatmentManifest{Mode: TreatmentInstructionsOnly, AgentTimeoutMultiplier: skillsAgentTimeoutFactor},
+	}
+}
+
+type completedHistoricalTreatmentRecoveryFixture struct {
+	root           string
+	first          StudyOutcome
+	originalReport StudyReport
+	bundle         *TreatmentBundle
+	stageCalls     *int
+	preparedCalls  *int
+}
+
+func setupCompletedHistoricalTreatmentStudyForRecovery(t *testing.T) completedHistoricalTreatmentRecoveryFixture {
+	t.Helper()
+	root := t.TempDir()
+	selectionData, err := json.Marshal(matrixSelectionFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeStudyInputFixture(t, root, "selection.json", string(selectionData))
+	writeStudyTreatmentConfig(t, root)
+	if err := os.Mkdir(filepath.Join(root, "instructions"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeStudyInputFixture(t, filepath.Join(root, "instructions"), "01_prime_directive.md", "Read CONTEXT.md before starting.\n")
+	writeStudyInputFixture(t, root, "study.toml", "selection = \"selection.json\"\n[[experiments]]\nname = \"Treatment\"\nmodel = \"luna\"\nreasoning = \"low\"\nconfig = \"config.toml\"\ninstructions = \"instructions\"\n")
+	if err := validateTreatmentInstructionDependencies(filepath.Join(root, "instructions")); err == nil {
+		t.Fatal("test instructions must be rejected by current treatment staging")
+	}
+
+	preparedCalls := stubStudyInfrastructure(t, root)
+	originalAuth := validateBenchmarkAuthentication
+	validateBenchmarkAuthentication = func(context.Context, string, []parsedSelection) (map[string]AuthenticationPreflight, error) {
+		return map[string]AuthenticationPreflight{}, nil
+	}
+	t.Cleanup(func() { validateBenchmarkAuthentication = originalAuth })
+	originalRuntime := preflightTreatmentRuntime
+	preflightTreatmentRuntime = func(context.Context, ExecutionRequest) error { return nil }
+	t.Cleanup(func() { preflightTreatmentRuntime = originalRuntime })
+	originalBundles := stageBenchmarkExperimentBundles
+	stageCalls := 0
+	manifest := TreatmentManifest{
+		SchemaVersion: TreatmentSchemaVersion,
+		Mode:          TreatmentInstructionsOnly,
+		Files:         []TreatmentFile{{Path: "AGENTS.md", SHA256: strings.Repeat("a", 64)}},
+	}
+	manifestHash, err := hashCanonical(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle := &TreatmentBundle{
+		Manifest: manifest, ManifestHash: manifestHash, LinuxArchitecture: benchmarkTaskContainerArchitecture,
+		AdapterSHA256: "adapter-hash", LinuxBinarySHA256: "runtime-hash", TemplatesCommit: strings.Repeat("c", 40),
+		RuntimeSourceKind: treatmentRuntimeSourceRelease, RuntimeVersion: "test",
+	}
+	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
+		stageCalls++
+		return []*TreatmentBundle{bundle}, nil
+	}
+	t.Cleanup(func() { stageBenchmarkExperimentBundles = originalBundles })
+
+	first, err := RunStudy(context.Background(), StudyOptions{RepoRoot: root, StudyPath: filepath.Join(root, "study.toml")}, &studyWorkflowExecutor{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var originalReport StudyReport
+	if err := readStudyJSON(first.JSONPath, &originalReport); err != nil {
+		t.Fatal(err)
+	}
+	pinRoot := studyTreatmentPinRoot(root, bundle.ManifestHash)
+	pin := studyTreatmentPin{
+		SchemaVersion: studyTreatmentPinSchema, PinID: bundle.ManifestHash, Architecture: bundle.LinuxArchitecture,
+		ManifestHash: bundle.ManifestHash, Manifest: bundle.Manifest, LinuxBinarySHA256: bundle.LinuxBinarySHA256,
+		AdapterSHA256: bundle.AdapterSHA256, TemplatesCommit: bundle.TemplatesCommit, TemplatesDirty: bundle.TemplatesDirty,
+		RuntimeSourceKind: bundle.RuntimeSourceKind, RuntimeVersion: bundle.RuntimeVersion,
+	}
+	if err := writeJSON(filepath.Join(pinRoot, "pin.json"), pin); err != nil {
+		t.Fatal(err)
+	}
+	return completedHistoricalTreatmentRecoveryFixture{
+		root: root, first: first, originalReport: originalReport, bundle: bundle,
+		stageCalls: &stageCalls, preparedCalls: preparedCalls,
+	}
+}
+
+func blockHistoricalTreatmentRestaging(t *testing.T) {
+	t.Helper()
+	stageBenchmarkExperimentBundles = func(string, *preparedStudy) ([]*TreatmentBundle, error) {
+		t.Fatal("recovery-only restaged mutable treatment inputs")
+		return nil, nil
 	}
 }
 

--- a/internal/benchmark/study.go
+++ b/internal/benchmark/study.go
@@ -530,6 +530,14 @@ func prepareStudyExecution(ctx context.Context, options StudyOptions, prepared *
 		if found {
 			return recoverable, nil
 		}
+		complete, found, err := loadCompleteCachedStudyForRecovery(options.RepoRoot, prepared, candidates, tasks, options.TaskConcurrency)
+		if err != nil {
+			return matrixPreparation{}, err
+		}
+		if found {
+			return complete, nil
+		}
+		return matrixPreparation{}, fmt.Errorf("recovery-only mode found no retained terminal verifier timeout or complete study to recover")
 	}
 	cached, bundles, found, err := loadCompleteCachedStudy(options.RepoRoot, prepared, candidates, tasks, options.TaskConcurrency)
 	if err != nil {
@@ -538,21 +546,15 @@ func prepareStudyExecution(ctx context.Context, options StudyOptions, prepared *
 	if found {
 		return cached, nil
 	}
-	if options.RecoveryOnly {
-		return matrixPreparation{}, fmt.Errorf("recovery-only mode found no retained terminal verifier timeout study to canonicalize")
-	}
 	if err := preflightBenchmark(selections); err != nil {
 		return matrixPreparation{}, err
 	}
 	if err := verifyBenchmarkPier(ctx); err != nil {
 		return matrixPreparation{}, err
 	}
-	authentication := map[string]AuthenticationPreflight{}
-	if !options.RecoveryOnly {
-		authentication, err = validateBenchmarkAuthentication(ctx, options.RepoRoot, selections)
-		if err != nil {
-			return matrixPreparation{}, err
-		}
+	authentication, err := validateBenchmarkAuthentication(ctx, options.RepoRoot, selections)
+	if err != nil {
+		return matrixPreparation{}, err
 	}
 	if bundles == nil {
 		bundles, err = stageStudyBundlesIfNeeded(options.RepoRoot, prepared)
@@ -560,7 +562,7 @@ func prepareStudyExecution(ctx context.Context, options StudyOptions, prepared *
 			return matrixPreparation{}, err
 		}
 	}
-	if options.ResourcePreflight && !options.RecoveryOnly {
+	if options.ResourcePreflight {
 		emitStudyProgress(options, StudyProgress{Phase: "resources", Message: "Checking Docker disk capacity before image pulls"})
 		if err := preflightStudyDisk(ctx, tasks, options.ReclaimTaskImages && options.TaskConcurrency == 1); err != nil {
 			return matrixPreparation{}, err
@@ -592,11 +594,9 @@ func prepareStudyExecution(ctx context.Context, options StudyOptions, prepared *
 			return matrixPreparation{}, fmt.Errorf("reuse immutable historical evidence for experiment %q: %w", arm.Label, err)
 		}
 	}
-	if !options.RecoveryOnly {
-		work := scheduleStudyRuntimePreflights(options.RepoRoot, tasks, checksums, environments, preparation.arms)
-		if err := preflightStudyRuntimes(ctx, options, tasks, work, reclaimTaskImages, checkout); err != nil {
-			return matrixPreparation{}, err
-		}
+	work := scheduleStudyRuntimePreflights(options.RepoRoot, tasks, checksums, environments, preparation.arms)
+	if err := preflightStudyRuntimes(ctx, options, tasks, work, reclaimTaskImages, checkout); err != nil {
+		return matrixPreparation{}, err
 	}
 	if err := writeStudyManifest(prepared, preparation); err != nil {
 		return matrixPreparation{}, err
@@ -981,35 +981,9 @@ func loadCompleteCachedStudy(repoRoot string, prepared *preparedStudy, candidate
 func loadRecoverableCachedStudy(repoRoot string, prepared *preparedStudy, candidates []cachedStudyCandidate, tasks []benchmarkPlanTask, concurrency int) (matrixPreparation, bool, error) {
 	var matches []matrixPreparation
 	for _, candidate := range candidates {
-		var manifest immutableStudyManifest
-		if err := readStudyJSON(filepath.Join(candidate.stateDir, "study-manifest.json"), &manifest); err != nil {
-			return matrixPreparation{}, false, fmt.Errorf("read recoverable immutable study manifest %s: %w", filepath.Base(candidate.stateDir), err)
-		}
-		if !studyManifestDeclarationCompatible(manifest, prepared) {
-			continue
-		}
-		if filepath.Base(candidate.stateDir) != manifest.StudyID {
-			continue
-		}
-		preparation := recoveryPreparationFromManifest(prepared, manifest, candidate.stateDir, tasks, concurrency)
-		compatible := true
-		for index := range preparation.arms {
-			arm := &preparation.arms[index]
-			historicalID, err := studyArmIdentity(
-				prepared.selectionID, prepared.experiments[index].identity,
-				manifest.Checksums, manifest.Environments,
-				historicalTreatmentBundle(manifest.Arms[index]), manifest.Arms[index].Adapter,
-			)
-			if err != nil {
-				return matrixPreparation{}, false, err
-			}
-			if historicalID != manifest.Arms[index].ID || arm.Label != manifest.Arms[index].Name {
-				compatible = false
-				break
-			}
-			if err := requireStudyArmManifest(prepared.selectionID, tasks, preparation.checksums, arm); err != nil {
-				return matrixPreparation{}, false, err
-			}
+		preparation, manifest, compatible, err := recoveryPreparationFromCandidate(prepared, candidate.stateDir, tasks, concurrency)
+		if err != nil {
+			return matrixPreparation{}, false, err
 		}
 		if !compatible {
 			continue
@@ -1019,6 +993,9 @@ func loadRecoverableCachedStudy(repoRoot string, prepared *preparedStudy, candid
 			return matrixPreparation{}, false, err
 		}
 		if count > 0 {
+			if err := restoreHistoricalStudyTreatmentProvenance(repoRoot, candidate.stateDir, manifest, &preparation); err != nil {
+				return matrixPreparation{}, false, err
+			}
 			matches = append(matches, preparation)
 		}
 	}
@@ -1033,6 +1010,102 @@ func loadRecoverableCachedStudy(repoRoot string, prepared *preparedStudy, candid
 	}
 }
 
+func loadCompleteCachedStudyForRecovery(repoRoot string, prepared *preparedStudy, candidates []cachedStudyCandidate, tasks []benchmarkPlanTask, concurrency int) (matrixPreparation, bool, error) {
+	var matches []matrixPreparation
+	for _, candidate := range candidates {
+		preparation, manifest, compatible, err := recoveryPreparationFromCandidate(prepared, candidate.stateDir, tasks, concurrency)
+		if err != nil {
+			return matrixPreparation{}, false, err
+		}
+		if !compatible {
+			continue
+		}
+		progress, err := studyProgressChecked(preparation)
+		if err != nil {
+			return matrixPreparation{}, false, err
+		}
+		if progress.Missing > 0 {
+			continue
+		}
+		if err := restoreHistoricalStudyTreatmentProvenance(repoRoot, candidate.stateDir, manifest, &preparation); err != nil {
+			return matrixPreparation{}, false, err
+		}
+		authentication, err := cachedAuthenticationPreflight(candidate.stateDir, prepared)
+		if err != nil {
+			return matrixPreparation{}, false, err
+		}
+		preparation.authentication = authentication
+		matches = append(matches, preparation)
+	}
+	switch len(matches) {
+	case 0:
+		return matrixPreparation{}, false, nil
+	case 1:
+		prepared.studyID = filepath.Base(matches[0].stateDir)
+		return matches[0], true, nil
+	default:
+		return matrixPreparation{}, false, fmt.Errorf("complete benchmark study matches more than one historical state directory")
+	}
+}
+
+func restoreHistoricalStudyTreatmentProvenance(repoRoot, stateDir string, manifest immutableStudyManifest, preparation *matrixPreparation) error {
+	for index, contract := range manifest.Arms {
+		historical := historicalTreatmentBundle(contract)
+		if historical == nil {
+			preparation.arms[index].Bundle = nil
+			continue
+		}
+		if contract.Bundle == "" {
+			return fmt.Errorf("historical study %s arm %q has runtime provenance without a treatment manifest hash", filepath.Base(stateDir), contract.Name)
+		}
+		pinRoot := studyTreatmentPinRoot(repoRoot, contract.Bundle)
+		var pin studyTreatmentPin
+		if err := readStudyJSON(filepath.Join(pinRoot, "pin.json"), &pin); err != nil {
+			return fmt.Errorf("read historical study %s treatment pin %s: %w", filepath.Base(stateDir), contract.Bundle, err)
+		}
+		bundle, err := studyTreatmentBundleFromPin(pinRoot, pin)
+		if err != nil {
+			return fmt.Errorf("validate historical study %s treatment pin %s: %w", filepath.Base(stateDir), contract.Bundle, err)
+		}
+		if bundle.ManifestHash != contract.Bundle || bundle.AdapterSHA256 != contract.Adapter ||
+			bundle.LinuxBinarySHA256 != contract.Runtime || bundle.RuntimeSourceKind != contract.RuntimeSource ||
+			bundle.RuntimeVersion != contract.RuntimeVersion {
+			return fmt.Errorf("historical study %s treatment pin %s conflicts with its immutable arm contract", filepath.Base(stateDir), contract.Bundle)
+		}
+		preparation.arms[index].Bundle = bundle
+	}
+	return nil
+}
+
+func recoveryPreparationFromCandidate(prepared *preparedStudy, stateDir string, tasks []benchmarkPlanTask, concurrency int) (matrixPreparation, immutableStudyManifest, bool, error) {
+	var manifest immutableStudyManifest
+	if err := readStudyJSON(filepath.Join(stateDir, "study-manifest.json"), &manifest); err != nil {
+		return matrixPreparation{}, immutableStudyManifest{}, false, fmt.Errorf("read recovery immutable study manifest %s: %w", filepath.Base(stateDir), err)
+	}
+	if !studyManifestDeclarationCompatible(manifest, prepared) || filepath.Base(stateDir) != manifest.StudyID {
+		return matrixPreparation{}, immutableStudyManifest{}, false, nil
+	}
+	preparation := recoveryPreparationFromManifest(prepared, manifest, stateDir, tasks, concurrency)
+	for index := range preparation.arms {
+		arm := &preparation.arms[index]
+		historicalID, err := studyArmIdentity(
+			prepared.selectionID, prepared.experiments[index].identity,
+			manifest.Checksums, manifest.Environments,
+			historicalTreatmentBundle(manifest.Arms[index]), manifest.Arms[index].Adapter,
+		)
+		if err != nil {
+			return matrixPreparation{}, immutableStudyManifest{}, false, err
+		}
+		if historicalID != manifest.Arms[index].ID || arm.Label != manifest.Arms[index].Name {
+			return matrixPreparation{}, immutableStudyManifest{}, false, nil
+		}
+		if err := requireStudyArmManifest(prepared.selectionID, tasks, preparation.checksums, arm); err != nil {
+			return matrixPreparation{}, immutableStudyManifest{}, false, fmt.Errorf("validate recovery study %s: %w", filepath.Base(stateDir), err)
+		}
+	}
+	return preparation, manifest, true, nil
+}
+
 func recoveryPreparationFromManifest(prepared *preparedStudy, manifest immutableStudyManifest, stateDir string, tasks []benchmarkPlanTask, concurrency int) matrixPreparation {
 	preparation := matrixPreparation{
 		selection: prepared.selection, selectionID: prepared.selectionID, tasks: tasks,
@@ -1042,9 +1115,6 @@ func recoveryPreparationFromManifest(prepared *preparedStudy, manifest immutable
 	bundles := historicalBundlesFromManifest(manifest)
 	for index, experiment := range prepared.experiments {
 		bundle := bundles[index]
-		if bundle != nil {
-			bundle.Manifest = recoveryTreatmentManifest(experiment)
-		}
 		mode := ArmBaseline
 		if bundle != nil {
 			mode = ArmTreatment
@@ -1059,24 +1129,6 @@ func recoveryPreparationFromManifest(prepared *preparedStudy, manifest immutable
 		})
 	}
 	return preparation
-}
-
-// recoveryTreatmentManifest restores the workflow contract needed to normalize
-// retained treatment evidence. Historical manifests store only content hashes.
-func recoveryTreatmentManifest(experiment preparedStudyExperiment) TreatmentManifest {
-	mode := TreatmentInstructionsOnly
-	if experiment.Skills != "" {
-		mode = TreatmentInstructionsAndSkills
-	}
-	manifest := TreatmentManifest{
-		Mode:                   mode,
-		AgentTimeoutMultiplier: skillsAgentTimeoutFactor,
-		RequiredRoles:          append([]string(nil), experiment.RequiredDispatchRoles...),
-	}
-	if mode == TreatmentInstructionsAndSkills {
-		manifest.DispatchConfig = defaultTreatmentDispatchConfig(experiment.model, experiment.effort)
-	}
-	return manifest
 }
 
 func terminalVerifierTimeoutCheckpointCount(repoRoot string, preparation matrixPreparation) (int, error) {
@@ -1185,9 +1237,9 @@ func historicalBundlesFromManifest(manifest immutableStudyManifest) []*Treatment
 	return bundles
 }
 
-// historicalTreatmentBundle reconstructs the hashes needed to prove study/arm
-// identity and validate receipts. It is not a staged bundle and must not be
-// used for report generation.
+// historicalTreatmentBundle reconstructs the metadata needed to prove
+// study/arm identity and normalize retained receipts. Report generation and
+// verifier recovery replace it with the content-addressed historical pin.
 func historicalTreatmentBundle(contract studyArmContract) *TreatmentBundle {
 	if contract.Bundle == "" && contract.Runtime == "" && contract.RuntimeSource == "" && contract.RuntimeVersion == "" {
 		return nil

--- a/internal/benchmark/study.go
+++ b/internal/benchmark/study.go
@@ -149,14 +149,16 @@ type immutableStudyManifest struct {
 }
 
 type studyArmContract struct {
-	Name           string `json:"name"`
-	ID             string `json:"id"`
-	Target         string `json:"target"`
-	Bundle         string `json:"bundle_manifest_hash,omitempty"`
-	Adapter        string `json:"adapter_sha256,omitempty"`
-	Runtime        string `json:"runtime_sha256,omitempty"`
-	RuntimeSource  string `json:"runtime_source_kind,omitempty"`
-	RuntimeVersion string `json:"runtime_version,omitempty"`
+	Name            string `json:"name"`
+	ID              string `json:"id"`
+	Target          string `json:"target"`
+	Bundle          string `json:"bundle_manifest_hash,omitempty"`
+	Adapter         string `json:"adapter_sha256,omitempty"`
+	Runtime         string `json:"runtime_sha256,omitempty"`
+	RuntimeSource   string `json:"runtime_source_kind,omitempty"`
+	RuntimeVersion  string `json:"runtime_version,omitempty"`
+	TemplatesCommit string `json:"templates_commit,omitempty"`
+	TemplatesDirty  bool   `json:"templates_dirty,omitempty"`
 }
 
 func writeStudyManifest(study *preparedStudy, preparation matrixPreparation) error {
@@ -166,6 +168,7 @@ func writeStudyManifest(study *preparedStudy, preparation matrixPreparation) err
 		contract := studyArmContract{Name: arm.Label, ID: arm.ID, Target: arm.Loaded.Model.RuntimeIdentifier + ":" + arm.Loaded.Effort, Adapter: arm.AdapterSHA256}
 		if arm.Bundle != nil {
 			contract.Bundle, contract.Runtime, contract.RuntimeSource, contract.RuntimeVersion = arm.Bundle.ManifestHash, arm.Bundle.LinuxBinarySHA256, arm.Bundle.RuntimeSourceKind, arm.Bundle.RuntimeVersion
+			contract.TemplatesCommit, contract.TemplatesDirty = arm.Bundle.TemplatesCommit, arm.Bundle.TemplatesDirty
 		}
 		manifest.Arms = append(manifest.Arms, contract)
 	}
@@ -175,12 +178,11 @@ func writeStudyManifest(study *preparedStudy, preparation matrixPreparation) err
 		if err := readStudyJSON(path, &existing); err != nil {
 			return fmt.Errorf("read immutable study manifest: %w", err)
 		}
-		left, leftErr := hashCanonical(existing)
-		right, rightErr := hashCanonical(manifest)
-		if leftErr != nil || rightErr != nil {
-			return fmt.Errorf("hash immutable study manifest: %w", errors.Join(leftErr, rightErr))
+		same, err := sameImmutableStudyManifest(existing, manifest)
+		if err != nil {
+			return fmt.Errorf("hash immutable study manifest: %w", err)
 		}
-		if left != right {
+		if !same {
 			return fmt.Errorf("study %s conflicts with its immutable manifest", study.studyID)
 		}
 		return nil
@@ -188,6 +190,43 @@ func writeStudyManifest(study *preparedStudy, preparation matrixPreparation) err
 		return fmt.Errorf("inspect immutable study manifest: %w", err)
 	}
 	return writeJSON(path, manifest)
+}
+
+func sameImmutableStudyManifest(existing, next immutableStudyManifest) (bool, error) {
+	left, err := hashCanonical(existing)
+	if err != nil {
+		return false, err
+	}
+	right, err := hashCanonical(next)
+	if err != nil {
+		return false, err
+	}
+	if left == right {
+		return true, nil
+	}
+	if studyManifestHasTemplateProvenance(existing) {
+		return false, nil
+	}
+	stripped := next
+	stripped.Arms = append([]studyArmContract(nil), next.Arms...)
+	for i := range stripped.Arms {
+		stripped.Arms[i].TemplatesCommit = ""
+		stripped.Arms[i].TemplatesDirty = false
+	}
+	right, err = hashCanonical(stripped)
+	if err != nil {
+		return false, err
+	}
+	return left == right, nil
+}
+
+func studyManifestHasTemplateProvenance(manifest immutableStudyManifest) bool {
+	for _, arm := range manifest.Arms {
+		if arm.TemplatesCommit != "" || arm.TemplatesDirty {
+			return true
+		}
+	}
+	return false
 }
 
 // RunStudy is intentionally the only paid public entry point. The command itself
@@ -1071,6 +1110,13 @@ func restoreHistoricalStudyTreatmentProvenance(repoRoot, stateDir string, manife
 			bundle.LinuxBinarySHA256 != contract.Runtime || bundle.RuntimeSourceKind != contract.RuntimeSource ||
 			bundle.RuntimeVersion != contract.RuntimeVersion {
 			return fmt.Errorf("historical study %s treatment pin %s conflicts with its immutable arm contract", filepath.Base(stateDir), contract.Bundle)
+		}
+		if bundle.TemplatesCommit != contract.TemplatesCommit || bundle.TemplatesDirty != contract.TemplatesDirty {
+			if contract.TemplatesCommit != "" || contract.TemplatesDirty {
+				return fmt.Errorf("historical study %s treatment pin %s conflicts with its immutable arm contract", filepath.Base(stateDir), contract.Bundle)
+			}
+			bundle.TemplatesCommit = ""
+			bundle.TemplatesDirty = false
 		}
 		preparation.arms[index].Bundle = bundle
 	}

--- a/internal/benchmark/study_test.go
+++ b/internal/benchmark/study_test.go
@@ -14,6 +14,27 @@ import (
 	"time"
 )
 
+func TestSameImmutableStudyManifestAllowsLegacyTemplateProvenance(t *testing.T) {
+	existing := immutableStudyManifest{
+		SchemaVersion: immutableStudyManifestSchema, StudyID: "study", SelectionID: "selection",
+		Membership: []string{"Treatment"},
+		Arms:       []studyArmContract{{Name: "Treatment", ID: "arm", Target: "luna:low", Bundle: "bundle", Adapter: "adapter", Runtime: strings.Repeat("r", 64)}},
+	}
+	next := existing
+	next.Arms = append([]studyArmContract(nil), existing.Arms...)
+	next.Arms[0].TemplatesCommit = strings.Repeat("c", 40)
+	same, err := sameImmutableStudyManifest(existing, next)
+	if err != nil || !same {
+		t.Fatalf("legacy template provenance should remain compatible: same=%t err=%v", same, err)
+	}
+	existing.Arms[0].TemplatesCommit = strings.Repeat("c", 40)
+	next.Arms[0].TemplatesCommit = strings.Repeat("d", 40)
+	same, err = sameImmutableStudyManifest(existing, next)
+	if err != nil || same {
+		t.Fatalf("authenticated template provenance conflict accepted: same=%t err=%v", same, err)
+	}
+}
+
 func TestStudyPublishedBareEstimateRequiresMatchingSelectorTarget(t *testing.T) {
 	selection := matrixSelectionFixture()
 	luna, low, err := ParseModelSelection("luna:low")

--- a/internal/benchmark/study_test.go
+++ b/internal/benchmark/study_test.go
@@ -196,7 +196,7 @@ func TestRecoveryOnlyFailsWithoutPreparingTasksWhenNoRecoverableStudyExists(t *t
 	_, err = RunStudy(context.Background(), StudyOptions{
 		RepoRoot: root, StudyPath: filepath.Join(root, "study.toml"), RecoveryOnly: true, ResourcePreflight: true,
 	}, nil)
-	if err == nil || !strings.Contains(err.Error(), "no retained terminal verifier timeout study to canonicalize") {
+	if err == nil || !strings.Contains(err.Error(), "no retained terminal verifier timeout or complete study to recover") {
 		t.Fatalf("recovery-only without retained study = %v", err)
 	}
 }

--- a/internal/benchmark/treatment.go
+++ b/internal/benchmark/treatment.go
@@ -31,6 +31,7 @@ import (
 const treatmentContainerRoot = "/app"
 
 const studyTreatmentPinSchema = "deepswe-study-treatment-pin-v1"
+const treatmentRuntimeSourceRelease = "release"
 
 var benchmarkReleaseHTTPClient = &http.Client{Timeout: 30 * time.Second}
 var benchmarkReleasesBaseURL = update.ReleasesBaseURL
@@ -133,7 +134,7 @@ func pinStudyTreatmentBundle(repoRoot string, bundle *TreatmentBundle) (*Treatme
 	if err != nil || hash != bundle.ManifestHash {
 		return nil, fmt.Errorf("study treatment bundle content does not match its manifest")
 	}
-	root := filepath.Join(repoRoot, ".agent-layer", "state", "benchmarks", "deepswe", "study-pins", bundle.ManifestHash)
+	root := studyTreatmentPinRoot(repoRoot, bundle.ManifestHash)
 	pinPath := filepath.Join(root, "pin.json")
 	if _, err := os.Stat(pinPath); err == nil {
 		pinned, err := loadPinnedStudyTreatmentBundle(root, bundle)
@@ -174,6 +175,10 @@ func pinStudyTreatmentBundle(repoRoot string, bundle *TreatmentBundle) (*Treatme
 	}
 	_ = os.RemoveAll(stagedRoot)
 	return pinned, nil
+}
+
+func studyTreatmentPinRoot(repoRoot, manifestHash string) string {
+	return filepath.Join(repoRoot, ".agent-layer", "state", "benchmarks", "deepswe", "study-pins", manifestHash)
 }
 
 // loadPinnedStudyTreatmentBundle treats the persisted pin as the authority for
@@ -454,7 +459,7 @@ func BuildStudyTreatmentBundle(repoRoot string, experiment preparedStudyExperime
 	}
 	sourceKind, runtimeVersion := "development", ""
 	if commit == "" {
-		sourceKind = "release"
+		sourceKind = treatmentRuntimeSourceRelease
 		if executable, versionErr := os.Executable(); versionErr == nil {
 			if output, outputErr := exec.CommandContext(context.Background(), executable, "--version").Output(); outputErr == nil { // #nosec G204 -- executable is the current Agent Layer binary.
 				if fields := strings.Fields(string(output)); len(fields) > 0 {

--- a/internal/benchmark/verifier_timeout_test.go
+++ b/internal/benchmark/verifier_timeout_test.go
@@ -509,7 +509,18 @@ func TestRecoveryOnlyReconstructsTreatmentWorkflowForDispatchConformance(t *test
 		ReasoningEffort: config.Implementer.ReasoningEffort, Role: requiredRoleImplementer,
 		Mode: dispatchRunModeFresh, State: "completed",
 	})
-	bundleHash := strings.Repeat("b", 64)
+	pinnedManifest := TreatmentManifest{
+		SchemaVersion:          TreatmentSchemaVersion,
+		Mode:                   TreatmentInstructionsAndSkills,
+		AgentTimeoutMultiplier: skillsAgentTimeoutFactor,
+		Files:                  []TreatmentFile{{Path: "skills/implement/SKILL.md", SHA256: strings.Repeat("a", 64)}},
+		RequiredRoles:          roles,
+		DispatchConfig:         config,
+	}
+	bundleHash, err := hashCanonical(pinnedManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
 	oldAdapter := strings.Repeat("f", 64)
 	runtimeHash := strings.Repeat("r", 64)
 	request.Arm = ArmTreatment
@@ -557,6 +568,13 @@ func TestRecoveryOnlyReconstructsTreatmentWorkflowForDispatchConformance(t *test
 	if err := writeJSON(filepath.Join(stateDir, "study-manifest.json"), manifest); err != nil {
 		t.Fatal(err)
 	}
+	pin := studyTreatmentPin{
+		SchemaVersion: studyTreatmentPinSchema, PinID: bundleHash, Architecture: benchmarkTaskContainerArchitecture,
+		ManifestHash: bundleHash, Manifest: pinnedManifest, LinuxBinarySHA256: runtimeHash, AdapterSHA256: oldAdapter,
+	}
+	if err := writeJSON(filepath.Join(studyTreatmentPinRoot(request.RepoRoot, bundleHash), "pin.json"), pin); err != nil {
+		t.Fatal(err)
+	}
 	prepared := preparedStudy{
 		selection: selection, selectionID: selectionID,
 		experiments: []preparedStudyExperiment{{
@@ -567,21 +585,23 @@ func TestRecoveryOnlyReconstructsTreatmentWorkflowForDispatchConformance(t *test
 		}},
 	}
 	historical := recoveryPreparationFromManifest(&prepared, manifest, stateDir, tasks, 1)
-	if historical.arms[0].Bundle == nil || historical.arms[0].Bundle.Manifest.Mode != TreatmentInstructionsAndSkills ||
-		len(historical.arms[0].Bundle.Manifest.RequiredRoles) != 1 ||
-		historical.arms[0].Bundle.Manifest.RequiredRoles[0] != requiredRoleImplementer ||
-		historical.arms[0].Bundle.Manifest.DispatchConfig.Implementer != config.Implementer {
-		t.Fatalf("recovered treatment contract = %#v", historical.arms[0].Bundle)
-	}
 	if err := ensureStudyArmManifest(selectionID, tasks, manifest.Checksums, &historical.arms[0]); err != nil {
 		t.Fatal(err)
 	}
-	recovered, err := recoverTerminalVerifierTimeoutCells(context.Background(), request.RepoRoot, historical, nil)
+	loaded, found, err := loadRecoverableCachedStudy(request.RepoRoot, &prepared, []cachedStudyCandidate{{stateDir: stateDir}}, tasks, 1)
+	if err != nil || !found {
+		t.Fatalf("load treatment recovery = found=%t err=%v", found, err)
+	}
+	if loaded.arms[0].Bundle == nil || loaded.arms[0].Bundle.Manifest.SchemaVersion != TreatmentSchemaVersion ||
+		len(loaded.arms[0].Bundle.Manifest.Files) != 1 {
+		t.Fatalf("loaded recovery lost pinned treatment provenance: %#v", loaded.arms[0].Bundle)
+	}
+	recovered, err := recoverTerminalVerifierTimeoutCells(context.Background(), request.RepoRoot, loaded, nil)
 	if err != nil || recovered != 1 {
 		t.Fatalf("treatment recovery = %d, %v", recovered, err)
 	}
 	var result AttemptResult
-	if err := readStudyJSON(armResultPath(historical.arms[0].StateDir, request.Task, 1), &result); err != nil {
+	if err := readStudyJSON(armResultPath(loaded.arms[0].StateDir, request.Task, 1), &result); err != nil {
 		t.Fatal(err)
 	}
 	if result.VerifierOutcome != verifierOutcomeTestTimeout || !result.DispatchConformant {

--- a/internal/messages/cli.go
+++ b/internal/messages/cli.go
@@ -62,6 +62,7 @@ const (
 	UpgradeFlagApplyDeletions             = "Apply unknown file deletions outside .agent-layer/tmp/ (requires explicit confirmation unless combined with --yes; does NOT delete files under .agent-layer/tmp/)"
 	UpgradeFlagApplyTmpDeletions          = "Apply destructive deletion of files under .agent-layer/tmp/ (ephemeral agent run artifacts; requires explicit double confirmation unless combined with --yes)"
 	UpgradeFlagVersion                    = "Target Agent Layer version for the upgrade (vX.Y.Z, X.Y.Z, or latest)"
+	UpgradeTargetRequiresNewerCLIFmt      = "the Agent Layer CLI v%s cannot upgrade to v%s because the target release templates are not embedded in this executable; run 'al update', verify 'al --version' reports v%s or newer, then retry. 'al upgrade prefetch' only caches a binary and does not update the invoking CLI"
 
 	UpgradeOverwritePromptFmt                       = "Overwrite %s with the template version?"
 	UpgradeOverwriteAllPrompt                       = "Overwrite all existing managed files with template versions and update the pin if needed?"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -11,6 +11,16 @@ source_name="agent-layer-${version_no_v}"
 source_tar="${dist_dir}/${source_name}.tar"
 source_tgz="${source_tar}.gz"
 
+stable_release=0
+if [[ "$version" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  stable_release=1
+  migration_manifest="internal/templates/migrations/${version_no_v}.json"
+  if [[ ! -f "$migration_manifest" ]]; then
+    echo "ERROR: stable release ${version} is missing migration manifest ${migration_manifest}" >&2
+    exit 1
+  fi
+fi
+
 mkdir -p "$dist_dir"
 
 if ! command -v git >/dev/null 2>&1; then
@@ -34,6 +44,61 @@ build() {
   local output="$3"
   CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
     go build -o "${dist_dir}/${output}" -ldflags "-s -w -X main.Version=${version}" ./cmd/al
+}
+
+smoke_native_release_binary() {
+  if [[ "$stable_release" != "1" ]]; then
+    return 0
+  fi
+
+  local host_os host_arch binary
+  case "$(uname -s)" in
+    Darwin) host_os="darwin" ;;
+    Linux) host_os="linux" ;;
+    *)
+      echo "ERROR: unsupported host OS for release artifact smoke test: $(uname -s)" >&2
+      exit 1
+      ;;
+  esac
+  case "$(uname -m)" in
+    arm64|aarch64) host_arch="arm64" ;;
+    x86_64|amd64) host_arch="amd64" ;;
+    *)
+      echo "ERROR: unsupported host architecture for release artifact smoke test: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+  binary="${dist_dir}/al-${host_os}-${host_arch}"
+  binary="$(cd "$(dirname "$binary")" && pwd)/$(basename "$binary")"
+
+  (
+    set -euo pipefail
+    local smoke_root project_root actual_version actual_pin
+    smoke_root="$(mktemp -d "${TMPDIR:-/tmp}/agent-layer-release-smoke.XXXXXX")"
+    trap 'rm -rf "$smoke_root"' EXIT
+    project_root="${smoke_root}/project"
+    mkdir -p "$project_root" "${smoke_root}/home"
+    git -C "$project_root" init -q
+
+    export HOME="${smoke_root}/home"
+    export AL_NO_NETWORK=1
+    unset AL_VERSION
+    cd "$project_root"
+
+    actual_version="$("$binary" --version)"
+    if [[ "$actual_version" != "$version" ]]; then
+      echo "ERROR: release binary version is ${actual_version}; expected ${version}" >&2
+      exit 1
+    fi
+
+    "$binary" init --here --no-wizard >/dev/null
+    actual_pin="$(tr -d '[:space:]' < .agent-layer/al.version)"
+    if [[ "$actual_pin" != "$version_no_v" ]]; then
+      echo "ERROR: release binary initialized pin ${actual_pin}; expected ${version_no_v}" >&2
+      exit 1
+    fi
+    "$binary" upgrade plan >/dev/null
+  )
 }
 
 sign_darwin_binaries() {
@@ -67,6 +132,7 @@ build linux arm64 al-linux-arm64
 build linux amd64 al-linux-amd64
 
 sign_darwin_binaries
+smoke_native_release_binary
 
 git archive --format=tar --prefix="${source_name}/" HEAD > "$source_tar"
 gzip -n -f "$source_tar"

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -58,12 +58,15 @@ tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
 go_log="$tmp_dir/go-invocations.log"
 dist_dir="$tmp_dir/dist"
-expected_version="v1.0.0"
+# Stable release builds require the matching checked-in migration manifest.
+expected_version="v0.18.4"
 expected_version_no_v="${expected_version#v}"
 
 run_catalog_certification_script_tests
 run_release_workflow_security_tests
 run_release_generation_test
+run_missing_migration_manifest_test
+run_release_smoke_rejection_tests
 run_build_invocation_details
 run_artifact_verification
 run_source_tarball_verification

--- a/scripts/test-release/release_tests.sh
+++ b/scripts/test-release/release_tests.sh
@@ -48,7 +48,27 @@ fi
 printf '%s|%s|%s|%s|%s|%s\n' "${GOOS:-}" "${GOARCH:-}" "${CGO_ENABLED:-}" "$output" "$ldflags" "$pkg" >> "$log_path"
 
 mkdir -p "$(dirname "$output")"
-echo "mock binary: $output" > "$output"
+build_version="${ldflags##*=}"
+cat > "$output" <<MOCK_BINARY
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "\$*" >> "\${MOCK_RELEASE_BINARY_LOG:-/dev/null}"
+case "\${1:-}" in
+  --version)
+    printf '%s\n' "\${MOCK_RELEASE_VERSION_OVERRIDE:-$build_version}"
+    ;;
+  init)
+    mkdir -p .agent-layer
+    printf '%s\n' "\${MOCK_RELEASE_PIN_OVERRIDE:-${build_version#v}}" > .agent-layer/al.version
+    ;;
+  upgrade)
+    [[ "\${2:-}" == "plan" ]]
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+MOCK_BINARY
 chmod +x "$output"
 MOCK_GO
   chmod +x "$mock_bin/go"
@@ -60,6 +80,7 @@ MOCK_GO
   if (
     export PATH="$mock_bin:$PATH"
     export MOCK_GO_LOG="$go_log"
+    export MOCK_RELEASE_BINARY_LOG="$tmp_dir/release-binary.log"
     cd "$ROOT_DIR"
     # Override AL_VERSION and DIST_DIR for testing
     AL_VERSION="$expected_version" DIST_DIR="$dist_dir" ./scripts/build-release.sh
@@ -72,6 +93,70 @@ MOCK_GO
     echo "--- Build Log ---"
     cat "$tmp_dir/build.log"
     echo "-----------------"
+  fi
+}
+
+run_release_smoke_rejection_tests() {
+  section "Release Artifact Smoke Rejection Tests"
+
+  local wrong_version_dist="$tmp_dir/wrong-version-dist"
+  local wrong_version_log="$tmp_dir/wrong-version.log"
+  if (
+    export PATH="$mock_bin:$PATH"
+    export MOCK_GO_LOG="$tmp_dir/wrong-version-go.log"
+    export MOCK_RELEASE_VERSION_OVERRIDE="v0.0.0"
+    cd "$ROOT_DIR"
+    AL_VERSION="$expected_version" DIST_DIR="$wrong_version_dist" ./scripts/build-release.sh
+  ) > "$wrong_version_log" 2>&1; then
+    fail "release build should reject an artifact reporting the wrong version"
+  elif grep -Fq "release binary version is v0.0.0; expected $expected_version" "$wrong_version_log"; then
+    pass "release build rejects an artifact reporting the wrong version"
+  else
+    fail "wrong-version artifact failure was not actionable"
+    cat "$wrong_version_log"
+  fi
+
+  local wrong_pin_dist="$tmp_dir/wrong-pin-dist"
+  local wrong_pin_log="$tmp_dir/wrong-pin.log"
+  if (
+    export PATH="$mock_bin:$PATH"
+    export MOCK_GO_LOG="$tmp_dir/wrong-pin-go.log"
+    export MOCK_RELEASE_PIN_OVERRIDE="0.0.0"
+    cd "$ROOT_DIR"
+    AL_VERSION="$expected_version" DIST_DIR="$wrong_pin_dist" ./scripts/build-release.sh
+  ) > "$wrong_pin_log" 2>&1; then
+    fail "release build should reject an artifact initializing the wrong pin"
+  elif grep -Fq "release binary initialized pin 0.0.0; expected $expected_version_no_v" "$wrong_pin_log"; then
+    pass "release build rejects an artifact initializing the wrong pin"
+  else
+    fail "wrong-pin artifact failure was not actionable"
+    cat "$wrong_pin_log"
+  fi
+}
+
+run_missing_migration_manifest_test() {
+  section "Missing Migration Manifest Test"
+
+  local missing_dist="$tmp_dir/missing-migration-dist"
+  local missing_go_log="$tmp_dir/missing-migration-go.log"
+  local missing_log="$tmp_dir/missing-migration.log"
+  : > "$missing_go_log"
+
+  if (
+    export PATH="$mock_bin:$PATH"
+    export MOCK_GO_LOG="$missing_go_log"
+    export MOCK_RELEASE_BINARY_LOG="$tmp_dir/missing-release-binary.log"
+    cd "$ROOT_DIR"
+    AL_VERSION="v9.9.9" DIST_DIR="$missing_dist" ./scripts/build-release.sh
+  ) > "$missing_log" 2>&1; then
+    fail "stable release build should fail when its migration manifest is missing"
+  elif [[ -s "$missing_go_log" ]]; then
+    fail "stable release build compiled binaries before checking its migration manifest"
+  elif grep -Fq "stable release v9.9.9 is missing migration manifest internal/templates/migrations/9.9.9.json" "$missing_log"; then
+    pass "stable release build fails before compilation when its migration manifest is missing"
+  else
+    fail "missing migration manifest failure was not actionable"
+    cat "$missing_log"
   fi
 }
 
@@ -258,6 +343,14 @@ run_build_invocation_details() {
       pass "Build target present: linux/amd64"
     else
       fail "Missing build target: linux/amd64"
+    fi
+
+    if grep -Fxq -- "--version" "$tmp_dir/release-binary.log" &&
+       grep -Fxq -- "init --here --no-wizard" "$tmp_dir/release-binary.log" &&
+       grep -Fxq -- "upgrade plan" "$tmp_dir/release-binary.log"; then
+      pass "Stable release build smoke-tests the native artifact's version and upgrade path"
+    else
+      fail "Stable release build did not smoke-test the native artifact's version and upgrade path"
     fi
 
   fi


### PR DESCRIPTION
## Summary

- Prevent older Agent Layer executables from attempting upgrades that require newer embedded migration templates.
- Make recovery-only benchmark reporting use immutable completed-study state instead of restaging mutable current treatment inputs.
- Add artifact-level release checks so missing migrations and broken upgrade paths fail before publication.

## Changes

- Reject newer upgrade targets from older invoking CLIs with actionable `al update` guidance.
- Bind recovery-only runs to historical study manifests and content-addressed treatment pins, preserving complete report provenance without provider or verifier execution.
- Validate stable-release migration manifests before compilation and smoke-test the signed native artifact's version, initialized pin, and upgrade plan.
- Add regression and negative tests for upgrade dispatch, historical report regeneration, treatment provenance, and release artifact mismatches.
- Document both recovery-only operating modes.

## Verification

- `make ci` — passed: lint clean, 4,010 tests with one platform-specific skip, 76 release tests, and 842 end-to-end tests.
- Claude Opus/high independent review — all accepted correctness and robustness findings addressed; final review reported no blocking defects.

## Notes

- Release-versioned changelog, upgrade-row, migration-manifest, tag, and publication changes are intentionally excluded pending explicit approval of the exact follow-up version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recovery-only benchmark runs can now regenerate reports for compatible completed studies without rerunning providers or verifiers.
  - Historical treatment provenance is preserved during recovery.

- **Bug Fixes**
  - Upgrade and upgrade-plan commands now reject targets requiring a newer CLI and provide guidance for updating or prefetching a compatible version.
  - Development builds remain permitted to target newer releases.

- **Documentation**
  - Clarified recovery-only behavior, compatibility requirements, report regeneration, and concurrency limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->