### PR TITLE
fix: suppress update warnings in dispatched child output

### DIFF
--- a/internal/agentdispatch/dispatch_test.go
+++ b/internal/agentdispatch/dispatch_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/conn-castle/agent-layer/internal/gitenv"
 	"github.com/conn-castle/agent-layer/internal/sync"
 	"github.com/conn-castle/agent-layer/internal/templates"
+	"github.com/conn-castle/agent-layer/internal/updatewarn"
 )
 
 const antigravityStructuredOK = `printf '{"event":"result","result":{"status":"SUCCESS","conversation_id":"22222222-2222-4222-8222-222222222222","response":"agy ok","usage":{"input_tokens":1,"output_tokens":2,"thinking_tokens":1,"cache_read_tokens":0}}}\n'`
@@ -231,6 +232,7 @@ func TestDispatchAllowsNestedDispatchWithinDefaultDepth(t *testing.T) {
 	// via run.Create and exports AL_RUN_DIR / AL_RUN_ID via BuildEnv.
 	assertFileContains(t, logPath, "AL_RUN_DIR=")
 	assertFileContains(t, logPath, "AL_RUN_ID=")
+	assertFileContains(t, logPath, updatewarn.EnvSuppress+"=1")
 	// Negative env-passthrough contract: BuildEnv strips AL_SHIM_ACTIVE so the
 	// shim marker does not leak into the dispatched child env.
 	assertFileDoesNotContain(t, logPath, "AL_SHIM_ACTIVE=")

--- a/internal/agentdispatch/provider.go
+++ b/internal/agentdispatch/provider.go
@@ -20,6 +20,7 @@ import (
 	"github.com/conn-castle/agent-layer/internal/config"
 	"github.com/conn-castle/agent-layer/internal/projection"
 	"github.com/conn-castle/agent-layer/internal/run"
+	"github.com/conn-castle/agent-layer/internal/updatewarn"
 	"github.com/conn-castle/agent-layer/internal/version"
 )
 
@@ -860,5 +861,6 @@ func compatibleTargetVersion(path string, target targetMeta, lookup func(string,
 func dispatchEnvironment(base []string, project *config.ProjectConfig, dispatchRun *dispatchRun, depth int) []string {
 	info := &run.Info{ID: dispatchRun.Record.ID, Dir: dispatchRun.Dir}
 	env := clients.BuildEnv(base, project.Env, info)
-	return clients.SetEnv(env, clients.EnvDispatchActive, fmt.Sprintf("%d", depth))
+	env = clients.SetEnv(env, clients.EnvDispatchActive, fmt.Sprintf("%d", depth))
+	return clients.SetEnv(env, updatewarn.EnvSuppress, "1")
 }

--- a/internal/clients/runner_test.go
+++ b/internal/clients/runner_test.go
@@ -182,6 +182,7 @@ func TestRunLaunchError(t *testing.T) {
 }
 
 func TestRunWarnsOnUpdateWhenEnabled(t *testing.T) {
+	t.Setenv(updatewarn.EnvSuppress, "")
 	root := t.TempDir()
 	writeMinimalRepo(t, root)
 
@@ -248,6 +249,7 @@ mcp_server_threshold = 5
 }
 
 func TestRunWithStderr_QuietSuppressesOutput(t *testing.T) {
+	t.Setenv(updatewarn.EnvSuppress, "")
 	root := t.TempDir()
 	writeMinimalRepo(t, root)
 
@@ -318,6 +320,7 @@ mcp_server_threshold = 5
 }
 
 func TestRunWithStderr_QuietFromConfigSuppressesOutput(t *testing.T) {
+	t.Setenv(updatewarn.EnvSuppress, "")
 	root := t.TempDir()
 	writeMinimalRepo(t, root)
 

--- a/internal/updatewarn/warn.go
+++ b/internal/updatewarn/warn.go
@@ -13,12 +13,19 @@ import (
 	"github.com/conn-castle/agent-layer/internal/versiondispatch"
 )
 
+// EnvSuppress disables the best-effort update notice for machine-oriented
+// execution contexts whose output must stay focused on the requested work.
+const EnvSuppress = "AL_SUPPRESS_UPDATE_WARNING"
+
 // CheckForUpdate is a seam for tests.
 var CheckForUpdate = update.Check
 
 // WarnIfOutdated emits update warnings to stderr when a newer release is available.
 // It is a best-effort warning and never returns an error.
 func WarnIfOutdated(ctx context.Context, currentVersion string, stderr io.Writer) {
+	if strings.TrimSpace(os.Getenv(EnvSuppress)) != "" {
+		return
+	}
 	if strings.TrimSpace(os.Getenv(versiondispatch.EnvVersionOverride)) != "" {
 		return
 	}

--- a/internal/updatewarn/warn_test.go
+++ b/internal/updatewarn/warn_test.go
@@ -4,12 +4,25 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/conn-castle/agent-layer/internal/update"
 	"github.com/conn-castle/agent-layer/internal/versiondispatch"
 )
+
+// TestMain keeps warning tests independent of a dispatched child's
+// AL_SUPPRESS_UPDATE_WARNING inheritance. Tests that exercise suppression
+// set the variable themselves.
+func TestMain(m *testing.M) {
+	if err := os.Unsetenv(EnvSuppress); err != nil {
+		fmt.Fprintf(os.Stderr, "clear %s: %v\n", EnvSuppress, err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
 
 func TestWarnIfOutdated_SkipsWhenVersionOverrideSet(t *testing.T) {
 	t.Setenv(versiondispatch.EnvVersionOverride, "1")

--- a/internal/updatewarn/warn_test.go
+++ b/internal/updatewarn/warn_test.go
@@ -31,6 +31,26 @@ func TestWarnIfOutdated_SkipsWhenVersionOverrideSet(t *testing.T) {
 	}
 }
 
+func TestWarnIfOutdated_SkipsWhenSuppressed(t *testing.T) {
+	t.Setenv(EnvSuppress, "1")
+	orig := CheckForUpdate
+	called := 0
+	CheckForUpdate = func(context.Context, string) (update.CheckResult, error) {
+		called++
+		return update.CheckResult{}, nil
+	}
+	t.Cleanup(func() { CheckForUpdate = orig })
+
+	var stderr bytes.Buffer
+	WarnIfOutdated(context.Background(), "v1.0.0", &stderr)
+	if called != 0 {
+		t.Fatalf("expected update check to be skipped, got %d calls", called)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no output, got %q", stderr.String())
+	}
+}
+
 func TestWarnIfOutdated_SkipsWhenNoNetworkSet(t *testing.T) {
 	t.Setenv(versiondispatch.EnvNoNetwork, "1")
 	orig := CheckForUpdate


### PR DESCRIPTION
## Summary

- Prevent dispatched child processes from emitting best-effort update notices into machine-oriented output.
- Preserve the existing warning behavior for ordinary interactive execution.

## Changes

- Add an environment-controlled suppression guard to update-warning checks.
- Set the guard in dispatched child environments.
- Add focused coverage for suppression and environment propagation.

## Verification

- `go test ./internal/agentdispatch ./internal/updatewarn` — passed.
- `make test` — passed via the pre-commit hook.
- `git diff --check` — passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed update warnings during provider dispatches to prevent unnecessary warning output.
  * Added support for disabling update checks when the suppression setting is enabled.
* **Tests**
  * Added coverage verifying that suppressed update checks perform no checks and produce no stderr output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->