### PR TITLE
feat: support OAuth MCP server configuration

### DIFF
--- a/cmd/al/doctor.go
+++ b/cmd/al/doctor.go
@@ -288,8 +288,11 @@ func renderSizeSummary(out io.Writer, w config.WarningsConfig, instTokens int, i
 			_, _ = fmt.Fprintf(out, messages.DoctorSizeMCPSchemaNoLimitFmt, mcp.TotalSchemaTokens)
 		}
 
-		if mcp.ReachableServers < mcp.EnabledServers {
-			_, _ = fmt.Fprintf(out, messages.DoctorSizeMCPPartialFmt, mcp.EnabledServers-mcp.ReachableServers, mcp.EnabledServers)
+		if unreachable := mcp.EnabledServers - mcp.ReachableServers - mcp.OAuthUnvalidatedServers; unreachable > 0 {
+			_, _ = fmt.Fprintf(out, messages.DoctorSizeMCPPartialFmt, unreachable, mcp.EnabledServers)
+		}
+		if mcp.OAuthUnvalidatedServers > 0 {
+			_, _ = fmt.Fprintf(out, messages.DoctorSizeMCPOAuthPartialFmt, mcp.OAuthUnvalidatedServers, mcp.EnabledServers)
 		}
 	}
 
@@ -519,6 +522,8 @@ func (r *mcpDiscoveryReporter) formatLineLocked(serverID string) string {
 	switch r.statusForLocked(serverID) {
 	case warnings.MCPDiscoveryStatusDone:
 		return fmt.Sprintf("  - %s: done", serverID)
+	case warnings.MCPDiscoveryStatusAuthNotValidated:
+		return fmt.Sprintf("  - %s: %s", serverID, messages.WarningsMCPOAuthNotValidated)
 	case warnings.MCPDiscoveryStatusError:
 		if err := r.errors[serverID]; err != nil {
 			return fmt.Sprintf("  - %s: error (%v)", serverID, err)
@@ -552,6 +557,8 @@ func formatMCPDiscoveryEvent(event warnings.MCPDiscoveryEvent) string {
 		return fmt.Sprintf("  - %s: starting", event.ServerID)
 	case warnings.MCPDiscoveryStatusDone:
 		return fmt.Sprintf("  - %s: done", event.ServerID)
+	case warnings.MCPDiscoveryStatusAuthNotValidated:
+		return fmt.Sprintf("  - %s: %s", event.ServerID, messages.WarningsMCPOAuthNotValidated)
 	case warnings.MCPDiscoveryStatusError:
 		if event.Err != nil {
 			return fmt.Sprintf("  - %s: error (%v)", event.ServerID, event.Err)

--- a/cmd/al/doctor_test.go
+++ b/cmd/al/doctor_test.go
@@ -91,6 +91,11 @@ func TestFormatMCPDiscoveryEvent(t *testing.T) {
 			want:  "  - srv: done",
 		},
 		{
+			name:  "auth not validated",
+			event: warnings.MCPDiscoveryEvent{ServerID: "figma", Status: warnings.MCPDiscoveryStatusAuthNotValidated},
+			want:  "  - figma: OAuth authentication not validated by doctor",
+		},
+		{
 			name:  "error without err",
 			event: warnings.MCPDiscoveryEvent{ServerID: "srv", Status: warnings.MCPDiscoveryStatusError},
 			want:  "  - srv: error",
@@ -121,19 +126,21 @@ type testError struct{ msg string }
 func (e *testError) Error() string { return e.msg }
 
 func TestMCPDiscoveryReporter_Report(t *testing.T) {
-	reporter := newMCPDiscoveryReporter([]string{"server1", "server2"}, false, io.Discard)
+	reporter := newMCPDiscoveryReporter([]string{"server1", "server2", "server3"}, false, io.Discard)
 	reporter.start()
 
 	// Send events
 	reporter.report(warnings.MCPDiscoveryEvent{ServerID: "server1", Status: warnings.MCPDiscoveryStatusDone})
 	reporter.report(warnings.MCPDiscoveryEvent{ServerID: "server2", Status: warnings.MCPDiscoveryStatusError, Err: &testError{"failed"}})
+	reporter.report(warnings.MCPDiscoveryEvent{ServerID: "server3", Status: warnings.MCPDiscoveryStatusAuthNotValidated})
 
 	// Wait for events to be processed
-	var s1, s2 warnings.MCPDiscoveryStatus
+	var s1, s2, s3 warnings.MCPDiscoveryStatus
 	require.Eventually(t, func() bool {
 		s1 = reporter.statusFor("server1")
 		s2 = reporter.statusFor("server2")
-		return s1 == warnings.MCPDiscoveryStatusDone && s2 == warnings.MCPDiscoveryStatusError
+		s3 = reporter.statusFor("server3")
+		return s1 == warnings.MCPDiscoveryStatusDone && s2 == warnings.MCPDiscoveryStatusError && s3 == warnings.MCPDiscoveryStatusAuthNotValidated
 	}, time.Second, 10*time.Millisecond)
 
 	reporter.stop()
@@ -144,6 +151,12 @@ func TestMCPDiscoveryReporter_Report(t *testing.T) {
 	}
 	if s2 != warnings.MCPDiscoveryStatusError {
 		t.Errorf("server2 status = %v, want error", s2)
+	}
+	if s3 != warnings.MCPDiscoveryStatusAuthNotValidated {
+		t.Errorf("server3 status = %v, want auth_not_validated", s3)
+	}
+	if line := reporter.formatLine("server3"); !strings.Contains(line, "OAuth authentication not validated by doctor") {
+		t.Errorf("expected formatLine to include OAuth not validated, got %q", line)
 	}
 }
 

--- a/cmd/al/root_doctor_test.go
+++ b/cmd/al/root_doctor_test.go
@@ -820,6 +820,30 @@ func TestRenderSizeSummary(t *testing.T) {
 		}
 	})
 
+	t.Run("partial note when some servers use oauth", func(t *testing.T) {
+		var out bytes.Buffer
+		mcp := warnings.MCPSummary{Available: true, EnabledServers: 2, ReachableServers: 1, OAuthUnvalidatedServers: 1, TotalTools: 5, TotalSchemaTokens: 1000}
+		renderSizeSummary(&out, config.WarningsConfig{}, 0, "AGENTS.md", nil, 0, true, mcp)
+		if !strings.Contains(out.String(), "1 of 2 enabled MCP server(s) use OAuth (not validated by doctor); tool and schema totals exclude them.") {
+			t.Fatalf("expected oauth partial note, got:\n%s", out.String())
+		}
+		if strings.Contains(out.String(), "unreachable") {
+			t.Fatalf("did not expect unreachable note when reachable, got:\n%s", out.String())
+		}
+	})
+
+	t.Run("oauth servers are not double-counted as unreachable", func(t *testing.T) {
+		var out bytes.Buffer
+		mcp := warnings.MCPSummary{Available: true, EnabledServers: 3, ReachableServers: 1, OAuthUnvalidatedServers: 1}
+		renderSizeSummary(&out, config.WarningsConfig{}, 0, "AGENTS.md", nil, 0, true, mcp)
+		if !strings.Contains(out.String(), "1 of 3 enabled MCP server(s) unreachable") {
+			t.Fatalf("expected one unreachable server, got:\n%s", out.String())
+		}
+		if !strings.Contains(out.String(), "1 of 3 enabled MCP server(s) use OAuth") {
+			t.Fatalf("expected one OAuth server, got:\n%s", out.String())
+		}
+	})
+
 	t.Run("skills unavailable excluded from total and named", func(t *testing.T) {
 		var out bytes.Buffer
 		mcp := warnings.MCPSummary{Available: true, EnabledServers: 1, ReachableServers: 1, TotalTools: 2, TotalSchemaTokens: 300}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -62,6 +62,13 @@ id = "local"
 enabled = false
 transport = "stdio"
 command = "tool"
+
+[[mcp.servers]]
+id = "oauth"
+enabled = true
+transport = "http"
+url = "https://example.com/mcp"
+auth = "oauth"
 `
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -88,6 +95,9 @@ command = "tool"
 	}
 	if !NotificationsChimeEnabled(*cfg) {
 		t.Fatal("expected notifications chime to be enabled")
+	}
+	if len(cfg.MCP.Servers) != 2 || cfg.MCP.Servers[1].Auth != MCPAuthOAuth {
+		t.Fatalf("expected OAuth MCP auth mode to load, got %#v", cfg.MCP.Servers)
 	}
 }
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -10,4 +10,7 @@ const (
 	skillManifestName    = "SKILL.md"
 	skillsDirName        = "skills"
 	agentLayerServerID   = "agent-layer"
+
+	// MCPAuthOAuth indicates OAuth authentication for an MCP server.
+	MCPAuthOAuth = "oauth"
 )

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -167,6 +167,7 @@ type MCPServer struct {
 	HTTPTransport string            `toml:"http_transport"`
 	URL           string            `toml:"url"`
 	Headers       map[string]string `toml:"headers"`
+	Auth          string            `toml:"auth,omitempty"`
 	Command       string            `toml:"command"`
 	Args          []string          `toml:"args"`
 	Env           map[string]string `toml:"env"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -12,6 +12,9 @@ import (
 const (
 	TransportHTTP  = "http"
 	TransportStdio = "stdio"
+
+	HTTPTransportSSE        = "sse"
+	HTTPTransportStreamable = "streamable"
 )
 
 // isValidApprovalMode checks the value against the config field catalog.
@@ -42,8 +45,8 @@ var validClients = map[string]struct{}{
 }
 
 var validHTTPTransports = map[string]struct{}{
-	"sse":        {},
-	"streamable": {},
+	HTTPTransportSSE:        {},
+	HTTPTransportStreamable: {},
 }
 
 var validWarningNoiseModes = map[string]struct{}{
@@ -137,11 +140,15 @@ func (c *Config) Validate(path string) error {
 					return fmt.Errorf(messages.ConfigMcpServerHTTPTransportInvalidFmt, path, i)
 				}
 			}
+			if server.Auth != "" && server.Auth != MCPAuthOAuth {
+				return fmt.Errorf(messages.ConfigMcpServerAuthInvalidFmt, path, i)
+			}
 		case TransportStdio:
 			// Silently strip HTTP-only fields; they are meaningless for stdio.
 			c.MCP.Servers[i].HTTPTransport = ""
 			c.MCP.Servers[i].URL = ""
 			c.MCP.Servers[i].Headers = nil
+			c.MCP.Servers[i].Auth = ""
 			if server.Command == "" {
 				return fmt.Errorf(messages.ConfigMcpServerCommandRequiredFmt, path, i)
 			}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -88,6 +88,13 @@ func TestValidateConfigErrors(t *testing.T) {
 			wantErr: "http_transport must be sse or streamable",
 		},
 		{
+			name: "http invalid auth",
+			cfg: withServers(valid, []MCPServer{
+				{ID: "x", Enabled: &trueVal, Transport: "http", URL: "https://example.com", Auth: "basic"},
+			}),
+			wantErr: "auth must be oauth",
+		},
+		{
 			name: "stdio missing command",
 			cfg: withServers(valid, []MCPServer{
 				{ID: "x", Enabled: &trueVal, Transport: "stdio"},
@@ -552,7 +559,7 @@ func TestValidateSanitizesTransportIncompatibleFields(t *testing.T) {
 		},
 	}
 
-	t.Run("stdio strips headers url and http_transport", func(t *testing.T) {
+	t.Run("stdio strips headers url http_transport and auth", func(t *testing.T) {
 		cfg := base
 		cfg.MCP.Servers = []MCPServer{{
 			ID:            "s1",
@@ -562,6 +569,7 @@ func TestValidateSanitizesTransportIncompatibleFields(t *testing.T) {
 			Headers:       map[string]string{"X-Key": "val"},
 			URL:           "https://leftover.example.com",
 			HTTPTransport: "sse",
+			Auth:          "oauth",
 		}}
 		if err := cfg.Validate("config.toml"); err != nil {
 			t.Fatalf("expected no error, got %v", err)
@@ -576,18 +584,22 @@ func TestValidateSanitizesTransportIncompatibleFields(t *testing.T) {
 		if srv.HTTPTransport != "" {
 			t.Errorf("expected http_transport to be empty, got %q", srv.HTTPTransport)
 		}
+		if srv.Auth != "" {
+			t.Errorf("expected auth to be empty, got %q", srv.Auth)
+		}
 		if srv.Command != "tool" {
 			t.Errorf("expected command to be preserved, got %q", srv.Command)
 		}
 	})
 
-	t.Run("http strips command args and env", func(t *testing.T) {
+	t.Run("http strips command args and env and preserves auth", func(t *testing.T) {
 		cfg := base
 		cfg.MCP.Servers = []MCPServer{{
 			ID:        "s1",
 			Enabled:   &enabled,
 			Transport: "http",
 			URL:       "https://example.com",
+			Auth:      "oauth",
 			Command:   "leftover",
 			Args:      []string{"--flag"},
 			Env:       map[string]string{"TOKEN": "x"},
@@ -607,6 +619,9 @@ func TestValidateSanitizesTransportIncompatibleFields(t *testing.T) {
 		}
 		if srv.URL != "https://example.com" {
 			t.Errorf("expected url to be preserved, got %q", srv.URL)
+		}
+		if srv.Auth != "oauth" {
+			t.Errorf("expected auth to be preserved, got %q", srv.Auth)
 		}
 	})
 }

--- a/internal/messages/config.go
+++ b/internal/messages/config.go
@@ -42,6 +42,7 @@ const (
 	ConfigMcpServerEnabledRequiredFmt             = "%s: mcp.servers[%d].enabled is required"
 	ConfigMcpServerURLRequiredFmt                 = "%s: mcp.servers[%d].url is required for http transport"
 	ConfigMcpServerHTTPTransportInvalidFmt        = "%s: mcp.servers[%d].http_transport must be sse or streamable"
+	ConfigMcpServerAuthInvalidFmt                 = "%s: mcp.servers[%d].auth must be oauth"
 	ConfigMcpServerCommandRequiredFmt             = "%s: mcp.servers[%d].command is required for stdio transport"
 	ConfigMcpServerTransportInvalidFmt            = "%s: mcp.servers[%d].transport must be http or stdio"
 	ConfigMcpServerClientInvalidFmt               = "%s: mcp.servers[%d].clients contains invalid client %q"

--- a/internal/messages/doctor.go
+++ b/internal/messages/doctor.go
@@ -98,6 +98,7 @@ const (
 	DoctorSizeMCPSchemaNoLimitFmt        = "  - MCP tool schemas (total): %d tokens (no limit set)\n"
 	DoctorSizeMCPUnavailable             = "  - MCP servers: size unavailable (server discovery failed)\n"
 	DoctorSizeMCPPartialFmt              = "  - Note: %d of %d enabled MCP server(s) unreachable; tool and schema totals exclude them.\n"
+	DoctorSizeMCPOAuthPartialFmt         = "  - Note: %d of %d enabled MCP server(s) use OAuth (not validated by doctor); tool and schema totals exclude them.\n"
 	DoctorSizeTotalFmt                   = "  - Total always-loaded (estimated): ~%d tokens\n"
 	DoctorSizeTotalExcludesFmt           = "  - Total always-loaded (estimated): ~%d tokens (excludes %s)\n"
 

--- a/internal/messages/system.go
+++ b/internal/messages/system.go
@@ -95,6 +95,7 @@ const (
 	WarningsTooManyServersFix               = "disable rarely used servers; consolidate."
 	WarningsMCPConnectFailedFmt             = "cannot connect, initialize, or list tools: %v"
 	WarningsMCPConnectFix                   = "correct URL/command/auth; or disable the server."
+	WarningsMCPOAuthNotValidated            = "OAuth authentication not validated by doctor"
 	WarningsMCPServerTooManyToolsFmt        = "server has > %d tools (%d > %d)"
 	WarningsMCPServerTooManyToolsFix        = "split the server by domain or reduce exported tools."
 	WarningsMCPSchemaBloatServerFmt         = "estimated tokens for tool definitions > %d (%d > %d)"

--- a/internal/projection/mcp.go
+++ b/internal/projection/mcp.go
@@ -16,6 +16,7 @@ type ResolvedMCPServer struct {
 	URL           string
 	Headers       map[string]string
 	HTTPTransport string
+	Auth          string
 	Command       string
 	Args          []string
 	Env           map[string]string

--- a/internal/projection/mcp_test.go
+++ b/internal/projection/mcp_test.go
@@ -17,6 +17,7 @@ func TestResolveMCPServers(t *testing.T) {
 			Clients:   []string{"antigravity"},
 			Transport: "http",
 			URL:       "https://example.com?token=${TOKEN}",
+			Auth:      config.MCPAuthOAuth,
 			Headers: map[string]string{
 				"Authorization": "Bearer ${TOKEN}",
 			},
@@ -50,6 +51,9 @@ func TestResolveMCPServers(t *testing.T) {
 	}
 	if resolved[0].Headers["Authorization"] != "Bearer abc123" {
 		t.Fatalf("unexpected header: %s", resolved[0].Headers["Authorization"])
+	}
+	if resolved[0].Auth != config.MCPAuthOAuth {
+		t.Fatalf("unexpected auth mode: %s", resolved[0].Auth)
 	}
 	if resolved[1].Args[1] != "abc123" {
 		t.Fatalf("unexpected arg substitution: %s", resolved[1].Args[1])

--- a/internal/projection/resolvers.go
+++ b/internal/projection/resolvers.go
@@ -67,6 +67,7 @@ func resolveSingleServer(server config.MCPServer, env map[string]string, resolve
 	entry := ResolvedMCPServer{
 		ID:        server.ID,
 		Transport: server.Transport,
+		Auth:      server.Auth,
 	}
 	repoRoot := env[config.BuiltinRepoRootEnvVar]
 

--- a/internal/warnings/mcp.go
+++ b/internal/warnings/mcp.go
@@ -21,9 +21,11 @@ type MCPSummary struct {
 	Available bool
 	// EnabledServers is the count of enabled, resolvable servers.
 	EnabledServers int
-	// ReachableServers is the count of servers discovery succeeded for. When it is less
-	// than EnabledServers, the tool/schema totals exclude the unreachable servers.
+	// ReachableServers is the count of servers whose tools were successfully discovered.
 	ReachableServers int
+	// OAuthUnvalidatedServers is the count of servers using client-managed OAuth, which
+	// doctor cannot authenticate. Tool and schema totals exclude them.
+	OAuthUnvalidatedServers int
 	// TotalTools is the number of tools discovered across reachable servers.
 	TotalTools int
 	// TotalSchemaTokens is the estimated tool-schema token count across reachable servers.
@@ -86,14 +88,21 @@ func CheckMCPServers(ctx context.Context, cfg *config.ProjectConfig, connector C
 	var totalTools int
 	var totalSchemaTokens int
 	var reachableServers int
+	var oauthUnvalidatedServers int
 	toolNames := make(map[string][]string) // name -> serverIDs
 
 	for _, res := range results {
+		if res.OAuthUnvalidated {
+			oauthUnvalidatedServers++
+			continue
+		}
+
 		if res.Error != nil {
 			source := SourceExternalDependency
 			if transportByServerID[res.ServerID] == config.TransportHTTP {
 				source = SourceNetwork
 			}
+
 			warnings = append(warnings, Warning{
 				Code:     CodeMCPServerUnreachable,
 				Subject:  res.ServerID,
@@ -207,11 +216,12 @@ func CheckMCPServers(ctx context.Context, cfg *config.ProjectConfig, connector C
 	}
 
 	summary := MCPSummary{
-		Available:         true,
-		EnabledServers:    len(enabledServers),
-		ReachableServers:  reachableServers,
-		TotalTools:        totalTools,
-		TotalSchemaTokens: totalSchemaTokens,
+		Available:               true,
+		EnabledServers:          len(enabledServers),
+		ReachableServers:        reachableServers,
+		OAuthUnvalidatedServers: oauthUnvalidatedServers,
+		TotalTools:              totalTools,
+		TotalSchemaTokens:       totalSchemaTokens,
 	}
 
 	return warnings, summary, nil
@@ -225,10 +235,11 @@ type ToolDef struct {
 
 // DiscoveryResult contains the results of discovering tools from an MCP server.
 type DiscoveryResult struct {
-	ServerID     string
-	Tools        []ToolDef
-	SchemaTokens int
-	Error        error
+	ServerID         string
+	Tools            []ToolDef
+	SchemaTokens     int
+	OAuthUnvalidated bool
+	Error            error
 }
 
 // MCPDiscoveryStatus is the status of a discovery event for an MCP server.
@@ -239,6 +250,8 @@ const (
 	MCPDiscoveryStatusStart MCPDiscoveryStatus = "start"
 	// MCPDiscoveryStatusDone indicates a server discovery completed successfully.
 	MCPDiscoveryStatusDone MCPDiscoveryStatus = "done"
+	// MCPDiscoveryStatusAuthNotValidated indicates that doctor skipped an OAuth server it cannot authenticate.
+	MCPDiscoveryStatusAuthNotValidated MCPDiscoveryStatus = "auth_not_validated"
 	// MCPDiscoveryStatusError indicates a server discovery completed with an error.
 	MCPDiscoveryStatusError MCPDiscoveryStatus = "error"
 )
@@ -282,7 +295,9 @@ func discoverTools(ctx context.Context, servers []projection.ResolvedMCPServer, 
 
 			if statusFn != nil {
 				status := MCPDiscoveryStatusDone
-				if res.Error != nil {
+				if res.OAuthUnvalidated {
+					status = MCPDiscoveryStatusAuthNotValidated
+				} else if res.Error != nil {
 					status = MCPDiscoveryStatusError
 				}
 				statusFn(MCPDiscoveryEvent{ServerID: s.ID, Status: status, Err: res.Error})

--- a/internal/warnings/mcp_connector.go
+++ b/internal/warnings/mcp_connector.go
@@ -91,7 +91,7 @@ type RealConnector struct{}
 // ConnectAndDiscover connects to an MCP server and discovers its tools.
 func (r *RealConnector) ConnectAndDiscover(ctx context.Context, server projection.ResolvedMCPServer) DiscoveryResult {
 	res := DiscoveryResult{ServerID: server.ID}
-	if server.Auth == config.MCPAuthOAuth {
+	if server.Transport == config.TransportHTTP && server.Auth == config.MCPAuthOAuth {
 		res.OAuthUnvalidated = true
 		return res
 	}

--- a/internal/warnings/mcp_connector.go
+++ b/internal/warnings/mcp_connector.go
@@ -91,6 +91,10 @@ type RealConnector struct{}
 // ConnectAndDiscover connects to an MCP server and discovers its tools.
 func (r *RealConnector) ConnectAndDiscover(ctx context.Context, server projection.ResolvedMCPServer) DiscoveryResult {
 	res := DiscoveryResult{ServerID: server.ID}
+	if server.Auth == config.MCPAuthOAuth {
+		res.OAuthUnvalidated = true
+		return res
+	}
 
 	// Create context with timeout for this server
 	ctx, cancel := context.WithTimeout(ctx, mcpDiscoveryTimeout)
@@ -118,7 +122,7 @@ func (r *RealConnector) ConnectAndDiscover(ctx context.Context, server projectio
 		}
 	case config.TransportHTTP:
 		switch server.HTTPTransport {
-		case "", "sse":
+		case "", config.HTTPTransportSSE:
 			t := &mcp.SSEClientTransport{
 				Endpoint: server.URL,
 			}
@@ -131,7 +135,7 @@ func (r *RealConnector) ConnectAndDiscover(ctx context.Context, server projectio
 				}
 			}
 			transport = t
-		case "streamable":
+		case config.HTTPTransportStreamable:
 			t := &mcp.StreamableClientTransport{
 				Endpoint: server.URL,
 			}

--- a/internal/warnings/mcp_test.go
+++ b/internal/warnings/mcp_test.go
@@ -1260,6 +1260,39 @@ func TestRealConnector_OAuthNotVerifiable(t *testing.T) {
 	assert.False(t, clientCreated, "OAuth discovery must not start a client that cannot use the client-managed credentials")
 }
 
+func TestRealConnector_StdioOAuthDoesNotSkipDiscovery(t *testing.T) {
+	// Doctor's lenient-config fallback skips validation, so a malformed stdio
+	// server can still carry auth = "oauth". Discovery must use the stdio path
+	// rather than treating leftover OAuth as unvalidated HTTP auth.
+	clientCreated := false
+	mockSession := &mockMCPSession{
+		tools: []*mcp.Tool{{Name: "tool1"}},
+	}
+	mockClient := &mockMCPClient{session: mockSession}
+
+	original := NewMCPClientFunc
+	NewMCPClientFunc = func(impl *mcp.Implementation, opts *mcp.ClientOptions) mcpClientInterface {
+		clientCreated = true
+		return mockClient
+	}
+	t.Cleanup(func() { NewMCPClientFunc = original })
+
+	connector := &RealConnector{}
+	server := projection.ResolvedMCPServer{
+		ID:        "malformed-stdio",
+		Transport: config.TransportStdio,
+		Command:   "echo",
+		Auth:      config.MCPAuthOAuth,
+	}
+
+	result := connector.ConnectAndDiscover(context.Background(), server)
+	assert.NoError(t, result.Error)
+	assert.False(t, result.OAuthUnvalidated)
+	assert.True(t, clientCreated, "stdio servers with leftover auth=oauth must still be discovered")
+	assert.Len(t, result.Tools, 1)
+	assert.Equal(t, "tool1", result.Tools[0].Name)
+}
+
 func TestCheckMCPServers_OAuthServerNotValidated(t *testing.T) {
 	trueVal := true
 	cfg := &config.ProjectConfig{

--- a/internal/warnings/mcp_test.go
+++ b/internal/warnings/mcp_test.go
@@ -1235,3 +1235,69 @@ func TestRealConnector_TooManyToolsGuard(t *testing.T) {
 	assert.Contains(t, result.Error.Error(), "too many tools or infinite loop")
 	assert.True(t, mockSession.closeCalled, "session.Close should be called")
 }
+
+func TestRealConnector_OAuthNotVerifiable(t *testing.T) {
+	clientCreated := false
+	original := NewMCPClientFunc
+	NewMCPClientFunc = func(impl *mcp.Implementation, opts *mcp.ClientOptions) mcpClientInterface {
+		clientCreated = true
+		return &mockMCPClient{}
+	}
+	t.Cleanup(func() { NewMCPClientFunc = original })
+
+	connector := &RealConnector{}
+	server := projection.ResolvedMCPServer{
+		ID:            "figma",
+		Transport:     config.TransportHTTP,
+		HTTPTransport: "streamable",
+		URL:           "https://mcp.figma.com/mcp",
+		Auth:          config.MCPAuthOAuth,
+	}
+
+	result := connector.ConnectAndDiscover(context.Background(), server)
+	assert.NoError(t, result.Error)
+	assert.True(t, result.OAuthUnvalidated)
+	assert.False(t, clientCreated, "OAuth discovery must not start a client that cannot use the client-managed credentials")
+}
+
+func TestCheckMCPServers_OAuthServerNotValidated(t *testing.T) {
+	trueVal := true
+	cfg := &config.ProjectConfig{
+		Config: config.Config{
+			MCP: config.MCPConfig{
+				Servers: []config.MCPServer{
+					{
+						ID:            "figma",
+						Enabled:       &trueVal,
+						Transport:     config.TransportHTTP,
+						HTTPTransport: "streamable",
+						URL:           "https://mcp.figma.com/mcp",
+						Auth:          config.MCPAuthOAuth,
+					},
+				},
+			},
+		},
+	}
+
+	var events []MCPDiscoveryEvent
+	statusFn := func(e MCPDiscoveryEvent) {
+		events = append(events, e)
+	}
+
+	warnings, summary, err := CheckMCPServers(context.Background(), cfg, &RealConnector{}, statusFn)
+	require.NoError(t, err)
+	assert.Empty(t, warnings, "OAuth server with AuthStatusNotVerifiable should not produce warnings")
+	assert.True(t, summary.Available)
+	assert.Equal(t, 1, summary.EnabledServers)
+	assert.Equal(t, 0, summary.ReachableServers)
+	assert.Equal(t, 1, summary.OAuthUnvalidatedServers)
+	assert.Equal(t, 0, summary.TotalTools)
+
+	var hasAuthNotValidatedEvent bool
+	for _, e := range events {
+		if e.ServerID == "figma" && e.Status == MCPDiscoveryStatusAuthNotValidated {
+			hasAuthNotValidatedEvent = true
+		}
+	}
+	assert.True(t, hasAuthNotValidatedEvent, "expected MCPDiscoveryStatusAuthNotValidated event")
+}

--- a/site/docs/reference.mdx
+++ b/site/docs/reference.mdx
@@ -227,6 +227,7 @@ Optional fields:
 - `clients` to restrict which clients receive a server (valid values: `antigravity`, `claude`, `vscode`, `codex`, `copilot`, `grok`; note that `claude_vscode` uses the `claude` client)
 - `http_transport` (`sse` or `streamable`) for HTTP servers
 - `headers` for HTTP auth and metadata
+- `auth = "oauth"` for HTTP servers that authenticate through each client's OAuth session (for example, Figma's remote MCP); this tells `al doctor` not to attempt an unauthenticated tool-discovery request
 - `command`, `args`, `env` for stdio servers
 
 When a local command already has useful `--help`, compare MCP against a CLI skill before adding a server. The [CLI Skill Design Guide](/cli-skill-design) explains when MCP is the right interface and when live `--help` is the better place to look up syntax.
@@ -267,6 +268,18 @@ enabled = true
 transport = "http"
 url = "https://example.com/mcp"
 headers = { Authorization = "Bearer ${AL_EXAMPLE_TOKEN}" }
+```
+
+For a server that relies on client-managed OAuth instead of static headers:
+
+```toml
+[[mcp.servers]]
+id = "figma"
+enabled = true
+transport = "http"
+http_transport = "streamable"
+url = "https://mcp.figma.com/mcp"
+auth = "oauth"
 ```
 
 #### Stdio example
@@ -357,8 +370,9 @@ Agent Layer validates `config.toml` on every run. Common validation rules:
 - `enabled` flags must be set for all agents and MCP servers
 - MCP transport must be `http` or `stdio`
 - `http_transport` (when set) must be `sse` or `streamable`
+- `auth` (when set) must be `oauth`
 - HTTP servers cannot set `command` or `args`
-- Stdio servers cannot set `url` or `headers`
+- Stdio servers cannot set `url`, `headers`, or `auth`
 - `skills.imports[].selectors` must include at least one positive selector, and every selector must be a normalized repository-relative path
 - `skills.imports[].tracking` must be `tracked` or `pinned`; `write_policy` must be `none`, `branch`, or `direct`
 - `write_policy = "branch"` requires an explicit non-primary `push_branch`; other policies must not set one. Configuration validation rejects the conventional primary names; `al skills push` additionally rejects the destination's actual default branch

--- a/site/docs/reference.mdx
+++ b/site/docs/reference.mdx
@@ -372,7 +372,7 @@ Agent Layer validates `config.toml` on every run. Common validation rules:
 - `http_transport` (when set) must be `sse` or `streamable`
 - `auth` (when set) must be `oauth`
 - HTTP servers cannot set `command` or `args`
-- Stdio servers cannot set `url`, `headers`, or `auth`
+- Stdio servers silently strip `url`, `headers`, and `auth` instead of failing validation
 - `skills.imports[].selectors` must include at least one positive selector, and every selector must be a normalized repository-relative path
 - `skills.imports[].tracking` must be `tracked` or `pinned`; `write_policy` must be `none`, `branch`, or `direct`
 - `write_policy = "branch"` requires an explicit non-primary `push_branch`; other policies must not set one. Configuration validation rejects the conventional primary names; `al skills push` additionally rejects the destination's actual default branch


### PR DESCRIPTION
## Summary

- Add `auth = "oauth"` for HTTP MCP server configuration.
- Let `al doctor` identify OAuth servers as intentionally unvalidated instead of reporting them unreachable.

## Changes

- Validate and project the OAuth authentication mode, and exclude client-managed OAuth servers from doctor discovery totals.
- Report OAuth discovery status and size-summary context distinctly, with unit coverage and reference documentation.

## Verification

- `make ci` — passed (including lint, coverage, race, release, and 842 end-to-end tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring OAuth-authenticated HTTP MCP servers with `auth = "oauth"`.
  - MCP discovery now identifies OAuth servers whose authentication could not be validated.

- **Bug Fixes**
  - `al doctor` excludes OAuth-unvalidated servers from unreachable counts and tool/schema totals.
  - Added clearer status messages and warnings for partially validated OAuth servers.
  - Invalid authentication settings are rejected, and authentication is cleared for stdio servers.

- **Documentation**
  - Added OAuth configuration guidance and examples, including discovery limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->