### PR TITLE
fix: preserve dispatch handoff safety

### DIFF
--- a/docs/AGENT-DISPATCH.md
+++ b/docs/AGENT-DISPATCH.md
@@ -254,10 +254,15 @@ conversation ID, successful provider exit, and proof that its process group
 has stopped. After terminal evidence, stdout closure, or provider exit, shutdown
 and output draining have a five-second bound; expiry fails the invocation and
 terminates its owned process group. Surviving descendants are also terminated
-after normal leader exit. Output is drained independently of process waiting
-so inherited pipes cannot hide that exit. Failure to prove termination retains
-the active claim rather than permitting overlapping work. The group-termination
-grace and proof windows are separate from the process/I/O shutdown deadline.
+after normal leader exit. Termination signals a group only while the captured
+leader identity still matches or, after that leader is a zombie, descendants
+still reserve the ID; a reused leader is never signalled. The worker reaps the
+leader with a non-blocking wait rather than a background `cmd.Wait` goroutine,
+so unproven termination cannot leak a blocked waiter. Output is drained
+independently of process waiting so inherited pipes cannot hide that exit.
+Failure to prove termination retains the active claim rather than permitting
+overlapping work. The group-termination grace and proof windows are separate
+from the process/I/O shutdown deadline.
 
 If the worker and leader have died but descendants survive, automatic recovery
 retains the claim and reports the group ID. Inspect the saved run evidence and

--- a/docs/AGENT-DISPATCH.md
+++ b/docs/AGENT-DISPATCH.md
@@ -30,7 +30,9 @@ Agent-facing tool and parameter descriptions are maintained in
 and `skill`, and exactly one of `prompt` or `prompt_file`. `dispatch_continue`
 accepts `handle` and exactly one prompt source. `dispatch_wait` and
 `dispatch_cancel` accept `handle`. Results carry the same `handle`, `state`,
-`result_path`, and `error` fields as the CLI.
+`result_path`, and `error` fields as the CLI. A wait that returns `running`
+also includes recorded `last_activity_at` and `last_output_at` timestamps when
+available.
 
 Successful results are returned as `structuredContent`; the SDK also emits the
 serialized text fallback required for compatibility with older clients. The
@@ -188,9 +190,13 @@ must omit those flags.
 }
 ```
 
-`wait` returns the same `running` object when its bounded interval expires
+`wait` returns a `running` object when its bounded interval expires
 before the invocation reaches a terminal state. The CLI waits eight minutes;
 `dispatch_wait` waits `dispatch.mcp_wait_timeout_minutes` (30 by default).
+When available, `last_activity_at` is the UTC timestamp of provider startup or
+the most recent normalized stream event, and `last_output_at` is the UTC
+timestamp of the most recent answer event. These are observations, not a health
+check: absence of new events does not prove a provider has stopped working.
 
 `wait` on a completed invocation returns:
 
@@ -234,6 +240,41 @@ interval — eight minutes on the CLI, `dispatch.mcp_wait_timeout_minutes` for
 Repeating it after termination immediately returns the same state and, for a
 completed invocation, the same `result_path` until a successful `continue`
 starts the next invocation.
+
+Continuation requires the recorded provider conversation ID. If a failed or
+cancelled invocation may have reached the provider but no ID was captured,
+`continue` fails rather than silently starting a fresh conversation. Inspect
+the previous run before explicitly choosing `start`. Only a proven pre-start
+failure permits a fresh retry through `continue`. Antigravity's `init` event
+persists its conversation ID before the terminal result, preserving identity
+when a later handoff fails.
+
+Dispatch requires a structured terminal result, a final answer, a consistent
+conversation ID, successful provider exit, and proof that its process group
+has stopped. After terminal evidence, stdout closure, or provider exit, shutdown
+and output draining have a five-second bound; expiry fails the invocation and
+terminates its owned process group. Surviving descendants are also terminated
+after normal leader exit. Output is drained independently of process waiting
+so inherited pipes cannot hide that exit. Failure to prove termination retains
+the active claim rather than permitting overlapping work. The group-termination
+grace and proof windows are separate from the process/I/O shutdown deadline.
+
+If the worker and leader have died but descendants survive, automatic recovery
+retains the claim and reports the group ID. Inspect the saved run evidence and
+the surviving processes to establish ownership before manually stopping any of
+them; never signal a group based solely on its numeric ID. Once the owned group
+is gone, another `wait` reconciles the abandoned run. A verified different start
+identity for a replacement group leader proves ID reuse, allowing recovery
+without signalling the unrelated group. This relies on the
+[POSIX process-ID reuse guarantee](https://pubs.opengroup.org/onlinepubs/009696699/basedefs/xbd_chap04.html#tag_04_12).
+
+This shutdown bound is not an idle-work timeout. In particular, Antigravity may
+save a planner response while withholding its structured terminal result until
+managed background tasks end. A saved transcript is not a completed dispatch.
+The `ship-pr` skill stops its own watcher through its managed task before handing
+control back for authorization or a blocker, and restarts it when monitoring
+resumes. Existing invocations retain their already-loaded instructions; updating
+the skill does not repair them in place.
 
 `cancel` is idempotent only after successful cancellation. Repeating it for a
 cancelled invocation succeeds. It cannot change a completed or failed

--- a/internal/agentdispatch/async.go
+++ b/internal/agentdispatch/async.go
@@ -143,6 +143,9 @@ func Continue(opts ContinueOptions) error {
 	if !terminalDispatchState(current.State) {
 		return exitError(ExitUnavailable, fmt.Sprintf("dispatch conversation %q is running", session.Name))
 	}
+	if session.ProviderSessionID == "" && current.RecoveryState != recoveryRetrySafe {
+		return exitError(ExitUnavailable, fmt.Sprintf("cannot continue dispatch conversation %q: provider acceptance is unknown and no provider session ID was recorded; inspect the previous run before explicitly starting a new conversation", session.Name))
+	}
 	if current.State == dispatchStateCompleted {
 		if _, err := completedResultPath(current); err != nil {
 			return err

--- a/internal/agentdispatch/dispatch.go
+++ b/internal/agentdispatch/dispatch.go
@@ -217,8 +217,9 @@ func finishDispatchFailure(request dispatchExecution, cause error) error {
 	var terminationFailure *unprovenProviderTerminationError
 	if errors.As(cause, &terminationFailure) {
 		// The provider group may still be live. Keep both the nonterminal run
-		// evidence and active claim so no replacement can overlap it.
-		return cause
+		// evidence and active claim so no replacement can overlap it. Startup
+		// may have failed before publishing the acquired process identity.
+		return errors.Join(cause, retainUnprovenProviderOwnership(request))
 	}
 	if current, err := loadRunRecord(request.Root, request.Run.Record.ID); err == nil && current.State == dispatchStateCancelled {
 		return finishDispatchCancellation(request)
@@ -254,6 +255,36 @@ func finishDispatchFailure(request dispatchExecution, cause error) error {
 		}
 	}
 	return cause
+}
+
+func retainUnprovenProviderOwnership(request dispatchExecution) error {
+	owned := request.Run.Record
+	if owned.PID == 0 {
+		return nil
+	}
+	return withRunLock(request.Run.Dir, func() error {
+		current, err := loadRunRecord(request.Root, owned.ID)
+		if err != nil {
+			return err
+		}
+		if current.PID != 0 {
+			if current.PID != owned.PID || current.ProcessGroupID != owned.ProcessGroupID || current.ProcessStartIdentity != owned.ProcessStartIdentity {
+				return exitError(ExitUnavailable, "cannot retain unproven provider ownership: recorded process identity conflicts with the started provider")
+			}
+			return nil
+		}
+		// Preserve concurrent cancellation and all newer state. Only add the
+		// owned identity; a stale revision must not erase this safety evidence.
+		current.PID = owned.PID
+		current.ProcessGroupID = owned.ProcessGroupID
+		current.ProcessStartIdentity = owned.ProcessStartIdentity
+		current.Revision++
+		current.UpdatedAt = time.Now().UTC()
+		if err := writeJSONAtomic(filepath.Join(request.Run.Dir, dispatchRunFile), current); err != nil {
+			return wrapExitError(ExitConfig, "retain unproven provider ownership", err)
+		}
+		return nil
+	})
 }
 
 // finishDispatchCancellation is called only by the owning execution after no

--- a/internal/agentdispatch/dispatch_lifecycle_test.go
+++ b/internal/agentdispatch/dispatch_lifecycle_test.go
@@ -124,6 +124,15 @@ func TestUnprovenProviderTerminationRetainsRunAndActiveClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 	cause := &unprovenProviderTerminationError{err: exitError(ExitTargetFailure, "provider process group death was not proven")}
+	// Simulate ownership captured by Start but not yet published, including
+	// a stale revision from a concurrent running-state update.
+	current := run.Record
+	if err := writeRunRecord(run.Dir, &current); err != nil {
+		t.Fatal(err)
+	}
+	run.Record.PID = os.Getpid()
+	run.Record.ProcessGroupID = os.Getpid()
+	run.Record.ProcessStartIdentity = processStartIdentity(os.Getpid())
 	if err := finishDispatchFailure(dispatchExecution{Root: root, Run: run, Session: session, Mode: dispatchModeFresh}, cause); !errors.Is(err, cause) {
 		t.Fatalf("finishDispatchFailure error = %v, want unproven termination failure", err)
 	}
@@ -140,6 +149,18 @@ func TestUnprovenProviderTerminationRetainsRunAndActiveClaim(t *testing.T) {
 	}
 	if durable.State != dispatchStateRunning || durable.CompletedAt != nil || durable.TerminalReason != "" {
 		t.Fatalf("unproven termination terminalized run evidence: %#v", durable)
+	}
+	if durable.PID != run.Record.PID || durable.ProcessGroupID != run.Record.ProcessGroupID || durable.ProcessStartIdentity != run.Record.ProcessStartIdentity {
+		t.Fatalf("unproven termination lost unpublished process ownership: %#v", durable)
+	}
+	run.Record.ProcessStartIdentity = "conflicting-owner"
+	err = finishDispatchFailure(dispatchExecution{Root: root, Run: run, Session: session, Mode: dispatchModeFresh}, cause)
+	if !errors.Is(err, cause) || !strings.Contains(err.Error(), "recorded process identity conflicts") {
+		t.Fatalf("conflicting ownership was not reported: %v", err)
+	}
+	unchanged, err := loadRunRecord(root, run.Record.ID)
+	if err != nil || unchanged.ProcessStartIdentity != durable.ProcessStartIdentity || unchanged.Revision != durable.Revision {
+		t.Fatalf("conflicting ownership overwrote durable evidence: %#v, %v", unchanged, err)
 	}
 }
 

--- a/internal/agentdispatch/handoff_test.go
+++ b/internal/agentdispatch/handoff_test.go
@@ -1,0 +1,263 @@
+package agentdispatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Exercise the published worker and public wait/continue boundary, including
+// failure before a final result. A reducer-only test cannot prove resumability.
+func TestAntigravityHandoffRetainsConversation(t *testing.T) {
+	const id = "22222222-2222-4222-8222-222222222222"
+	for _, tc := range []struct {
+		name, script, reason string
+	}{
+		{"init then exit", `printf '{"event":"init","conversation_id":"` + id + `"}\n'; exit 1`, "exited"},
+		{"failed result identity", `printf '{"event":"result","result":{"status":"ERROR","conversation_id":"` + id + `","error":"handoff failed"}}\n'; exit 1`, "handoff failed"},
+		{"conflicting result", `printf '{"event":"init","conversation_id":"` + id + `"}\n{"event":"result","result":{"status":"SUCCESS","conversation_id":"wrong","response":"wrong answer","usage":{}}}\n'`, "conflicting session IDs"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := writeDispatchRepo(t, dispatchRepoConfig{})
+			binDir := t.TempDir()
+			writeDispatchStub(t, binDir, "agy", tc.script)
+			t.Setenv("PATH", testPath(binDir))
+			t.Setenv("AL_TEST_LOG", filepath.Join(root, "provider-args"))
+			var gate *os.File
+			launcher := func(string, string, string) (launchedWorker, error) {
+				read, write, err := os.Pipe()
+				if err != nil {
+					return launchedWorker{}, err
+				}
+				gate = read
+				t.Cleanup(func() { _ = read.Close() })
+				return launchedWorker{gate: write, pid: os.Getpid(), startIdentity: processStartIdentity(os.Getpid())}, nil
+			}
+			var out bytes.Buffer
+			if err := Start(StartOptions{
+				Root: root, WorkDir: root, Agent: AgentAntigravity, Prompt: "handoff", Stdout: &out,
+				Env: os.Environ(), LookPath: mockLookPath(binDir), launchWorker: launcher,
+				VersionLookup: func(string, string) (string, error) { return supportedProviderVersions[AgentAntigravity], nil },
+			}); err != nil {
+				t.Fatal(err)
+			}
+			var response Result
+			if err := json.Unmarshal(out.Bytes(), &response); err != nil {
+				t.Fatal(err)
+			}
+			session, err := loadSession(root, response.Handle)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := RunWorker(root, session.RunID, gate); err == nil || !strings.Contains(err.Error(), tc.reason) {
+				t.Fatalf("worker failure = %v, want %q", err, tc.reason)
+			}
+			out.Reset()
+			requireDispatchExitCode(t, Wait(WaitRequest{Root: root, ID: session.Name, Stdout: &out}), ExitTargetFailure)
+			if err := json.Unmarshal(out.Bytes(), &response); err != nil || response.State != dispatchStateFailed || response.ResultPath != "" {
+				t.Fatalf("failed handoff published a result: %s, %v", out.String(), err)
+			}
+			session, err = loadSession(root, session.Name)
+			if err != nil || session.ProviderSessionID != id || session.ActiveRunID != "" {
+				t.Fatalf("lost conversation after failure: %#v, %v", session, err)
+			}
+			// Continuation must send the captured identity to the provider, not
+			// merely keep the same Agent Layer handle around a fresh conversation.
+			writeDispatchStub(t, binDir, "agy", `printf '{"event":"init","conversation_id":"`+id+`"}\n{"event":"result","result":{"status":"SUCCESS","conversation_id":"`+id+`","response":"continued","usage":{"input_tokens":1}}}\n'`)
+			if err := Continue(ContinueOptions{
+				Root: root, WorkDir: root, Handle: session.Name, Prompt: "continue", Env: os.Environ(),
+				LookPath: mockLookPath(binDir), launchWorker: launcher,
+				VersionLookup: func(string, string) (string, error) { return supportedProviderVersions[AgentAntigravity], nil },
+			}); err != nil {
+				t.Fatal(err)
+			}
+			session, err = loadSession(root, session.Name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := RunWorker(root, session.RunID, gate); err != nil {
+				t.Fatal(err)
+			}
+			assertFileContains(t, filepath.Join(root, "provider-args"), "=--conversation\n")
+			assertFileContains(t, filepath.Join(root, "provider-args"), "="+id+"\n")
+			out.Reset()
+			if err := Wait(WaitRequest{Root: root, ID: session.Name, Stdout: &out}); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal(out.Bytes(), &response); err != nil || response.State != dispatchStateCompleted {
+				t.Fatalf("continued handoff = %s, %v", out.String(), err)
+			}
+			answer, err := os.ReadFile(response.ResultPath) // #nosec G304 -- test-owned dispatch result.
+			if err != nil || string(answer) != "continued" {
+				t.Fatalf("continued answer = %q, %v", answer, err)
+			}
+		})
+	}
+}
+
+func TestContinueWithoutIdentityRequiresProvenSafeRetry(t *testing.T) {
+	for _, recovery := range []string{recoveryAcceptanceUnknown, recoveryResumeRequired, recoveryRetrySafe} {
+		t.Run(recovery, func(t *testing.T) {
+			root := writeDispatchRepo(t, dispatchRepoConfig{})
+			run, session := newWaitTestRun(t, root)
+			session.ProviderSessionID = ""
+			session.State = sessionStatePending
+			if err := persistSession(root, session); err != nil {
+				t.Fatal(err)
+			}
+			run.Record.State = dispatchStateFailed
+			run.Record.RecoveryState = recovery
+			now := time.Now().UTC()
+			run.Record.CompletedAt = &now
+			if err := writeRunRecord(run.Dir, &run.Record); err != nil {
+				t.Fatal(err)
+			}
+			if err := releaseConversation(root, session.Name, run.Record.ID); err != nil {
+				t.Fatal(err)
+			}
+			launched := false
+			err := Continue(ContinueOptions{
+				Root: root, WorkDir: root, Handle: session.Name, Prompt: "retry", Env: []string{}, LookPath: alwaysFound,
+				VersionLookup: func(string, string) (string, error) { return supportedProviderVersions[AgentCodex], nil },
+				launchWorker: func(string, string, string) (launchedWorker, error) {
+					launched = true
+					return launchedWorker{}, fmt.Errorf("test launcher reached")
+				},
+			})
+			if recovery == recoveryRetrySafe {
+				if !launched {
+					t.Fatalf("safe retry rejected: %v", err)
+				}
+			} else {
+				requireDispatchExitCode(t, err, ExitUnavailable)
+				if launched || !strings.Contains(err.Error(), "no provider session ID") {
+					t.Fatalf("unsafe continuation: launched=%t, err=%v", launched, err)
+				}
+				current, err := loadSession(root, session.Name)
+				if err != nil || current.RunID != run.Record.ID {
+					t.Fatalf("rejected continuation changed current invocation: %#v, %v", current, err)
+				}
+			}
+		})
+	}
+}
+
+func TestRunnerBoundsHandoffAndCleansDescendants(t *testing.T) {
+	const answer = `printf '{"type":"thread.started","thread_id":"` + runtimeSessionID + `"}\n{"type":"agent_message","message":"final"}\n{"type":"turn.completed"}\n'; `
+	for _, tc := range []struct {
+		name, script string
+		wantFailure  bool
+	}{
+		{"terminal but live", answer + `trap '' TERM; while :; do sleep 1; done`, true},
+		{"failure after terminal", answer + `sleep 0.05; printf '{"type":"turn.failed","message":"late failure"}\n'`, true},
+		{"stdout closed but live", `exec 1>&-; trap '' TERM; while :; do sleep 1; done`, true},
+		{"inherited output", answer + `sleep 60 &`, false},
+		{"detached output", answer + `sleep 60 >/dev/null 2>&1 &`, false},
+		{"exit near deadline with slow descendant cleanup", answer + `(trap '' TERM; exec sleep 60) >/dev/null 2>&1 & sleep 4.2`, false},
+		{"exit without terminal with inherited output", `sleep 60 & exit 1`, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
+			if err != nil {
+				t.Fatal(err)
+			}
+			started := time.Now()
+			result, err := executeProvider(providerCommand{
+				Path: "/bin/sh", Args: []string{"-c", tc.script}, Env: os.Environ(), Provider: AgentCodex,
+			}, nil, run, root, nil, func(string) error { return nil })
+			if time.Since(started) > providerShutdownGrace+4*providerTerminationGrace {
+				t.Fatalf("handoff did not finish within shutdown bounds: %v", err)
+			}
+			if tc.wantFailure {
+				requireDispatchExitCode(t, err, ExitTargetFailure)
+				var unproven *unprovenProviderTerminationError
+				if errors.As(err, &unproven) {
+					t.Fatalf("test provider termination was unproven: %v", err)
+				}
+				if result.Answer != "" {
+					t.Fatalf("failed shutdown returned final answer: %#v", result)
+				}
+			} else if err != nil || result.Answer != "final" {
+				t.Fatalf("clean handoff = %#v, %v", result, err)
+			}
+			if !providerProcessGroupDead(run.Record.ProcessGroupID) {
+				t.Fatalf("handoff left live descendants in group %d (recorded identity %q, current identity %q, reused %t): %v", run.Record.ProcessGroupID, run.Record.ProcessStartIdentity, processStartIdentity(run.Record.PID), providerProcessGroupReused(run.Record), err)
+			}
+		})
+	}
+}
+
+func TestRunnerLargePromptWithInheritedStdin(t *testing.T) {
+	root := t.TempDir()
+	run, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeFresh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt := bytes.Repeat([]byte("prompt bytes\n"), 32*1024)
+	// The child deliberately holds stdin without reading it. The leader
+	// reads only a prefix; a pipe-backed prompt would leave exec's copy
+	// goroutine blocked after its successful exit.
+	script := `read -r first; [ "$first" = "prompt bytes" ] || exit 2
+exec 3<&0
+sleep 60 <&3 >/dev/null 2>&1 &
+printf '{"type":"thread.started","thread_id":"` + runtimeSessionID + `"}\n{"type":"agent_message","message":"final"}\n{"type":"turn.completed"}\n'
+`
+	result, err := executeProvider(providerCommand{
+		Path: "/bin/sh", Args: []string{"-c", script}, Env: os.Environ(), Provider: AgentCodex,
+	}, prompt, run, root, nil, func(string) error { return nil })
+	if err != nil || result.Answer != "final" {
+		t.Fatalf("completed provider with inherited stdin = %#v, %v", result, err)
+	}
+	if !providerProcessGroupDead(run.Record.ProcessGroupID) {
+		t.Fatal("provider left an stdin-holding descendant alive")
+	}
+	files, err := filepath.Glob(filepath.Join(run.Dir, "provider-stdin-*"))
+	if err != nil || len(files) != 0 {
+		t.Fatalf("private prompt was left on disk: %v, %v", files, err)
+	}
+}
+
+func TestAntigravityIdentityEvidenceSurvivesPersistenceFailure(t *testing.T) {
+	for _, expected := range []string{"", runtimeSessionID} {
+		t.Run("expected="+expected, func(t *testing.T) {
+			root := t.TempDir()
+			run, err := newDispatchRun(root, AgentAntigravity, supportedProviderVersions[AgentAntigravity], dispatchModeFresh)
+			if err != nil {
+				t.Fatal(err)
+			}
+			session, err := reserveSession(root, run)
+			if err != nil {
+				t.Fatal(err)
+			}
+			const observed = "22222222-2222-4222-8222-222222222222"
+			persistCalled := false
+			_, err = executeProvider(providerCommand{
+				Path: "/bin/sh", Args: []string{"-c", `printf '{"event":"init","conversation_id":"` + observed + `"}\n'`},
+				Env: os.Environ(), Provider: AgentAntigravity, SessionID: expected,
+			}, nil, run, root, nil, func(string) error {
+				persistCalled = true
+				return errors.New("session store unavailable")
+			})
+			requireDispatchExitCode(t, err, ExitTargetFailure)
+			_ = finishDispatchFailure(dispatchExecution{Root: root, Run: run, Session: session, Mode: dispatchModeFresh}, err)
+			record, loadErr := loadRunRecord(root, run.Record.ID)
+			if loadErr != nil {
+				t.Fatal(loadErr)
+			}
+			if expected == "" {
+				if !persistCalled || record.ProviderSessionID != observed || !strings.Contains(record.TerminalReason, "session store unavailable") {
+					t.Fatalf("lost observed identity on persistence failure: %#v", record)
+				}
+			} else if persistCalled || record.ProviderSessionID != "" || !strings.Contains(record.TerminalReason, "requested conversation") {
+				t.Fatalf("accepted mismatched resume identity: %#v", record)
+			}
+		})
+	}
+}

--- a/internal/agentdispatch/handoff_test.go
+++ b/internal/agentdispatch/handoff_test.go
@@ -159,7 +159,7 @@ func TestRunnerBoundsHandoffAndCleansDescendants(t *testing.T) {
 		{"stdout closed but live", `exec 1>&-; trap '' TERM; while :; do sleep 1; done`, true},
 		{"inherited output", answer + `sleep 60 &`, false},
 		{"detached output", answer + `sleep 60 >/dev/null 2>&1 &`, false},
-		{"exit near deadline with slow descendant cleanup", answer + `(trap '' TERM; exec sleep 60) >/dev/null 2>&1 & sleep 4.2`, false},
+		{"exit near deadline with slow descendant cleanup", answer + `(trap '' TERM; exec sleep 60) >/dev/null 2>&1 & sleep 3`, false},
 		{"exit without terminal with inherited output", `sleep 60 & exit 1`, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/agentdispatch/mcp_test.go
+++ b/internal/agentdispatch/mcp_test.go
@@ -344,6 +344,11 @@ func TestMCPWaitRejectsUnknownHandleAsToolError(t *testing.T) {
 func TestMCPContinueStartsTheNextInvocation(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{})
 	run, dispatchSession := newWaitTestRun(t, root)
+	dispatchSession.ProviderSessionID = runtimeSessionID
+	dispatchSession.State = sessionStateDurable
+	if err := persistSession(root, dispatchSession); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(run.Record.AnswerPath, []byte("first"), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agentdispatch/mcp_tool_descriptions.toml
+++ b/internal/agentdispatch/mcp_tool_descriptions.toml
@@ -18,7 +18,7 @@ prompt = "Prompt text. Provide exactly one of prompt or prompt_file."
 prompt_file = "Path to a prompt file. Provide exactly one of prompt or prompt_file."
 
 [tools.dispatch_wait]
-description = "Wait up to {{wait_minutes}} minutes for one conversation. Returns running while active; completed returns result_path for the Markdown output, failed returns error, and cancelled is terminal. Ending this wait does not stop provider work."
+description = "Wait up to {{wait_minutes}} minutes for one conversation. Returns running with recorded last_activity_at/last_output_at timestamps when available; completed returns result_path for the Markdown output, failed returns error, and cancelled is terminal. Ending this wait does not stop provider work."
 
 [tools.dispatch_wait.parameters]
 handle = "Conversation handle returned by dispatch_start or dispatch_continue."

--- a/internal/agentdispatch/operations.go
+++ b/internal/agentdispatch/operations.go
@@ -29,6 +29,12 @@ func reconcileOrphan(root string, record RunRecord) (RunRecord, error) {
 	if invocationOwnership(record) != ownershipDead {
 		return record, nil
 	}
+	if !providerProcessGroupDead(record.ProcessGroupID) && !providerProcessGroupReused(record) {
+		// The worker's latched ownership capability is gone. A dead leader
+		// does not authorize signalling a possibly reused group or releasing
+		// the claim while orphaned descendants may still be doing work.
+		return RunRecord{}, exitError(ExitUnavailable, fmt.Sprintf("dispatch run %s lost its worker and provider leader but process group %d remains; cannot prove termination, so the active claim is retained; inspect surviving processes and verify their ownership before manual recovery (do not signal a group by ID alone)", record.ID, record.ProcessGroupID))
+	}
 	now := time.Now().UTC()
 	record.State = dispatchStateFailed
 	record.RecoveryState = recoveryAcceptanceUnknown

--- a/internal/agentdispatch/provider.go
+++ b/internal/agentdispatch/provider.go
@@ -70,6 +70,7 @@ const (
 	antigravityEffortLow          = "low"
 	antigravityEffortMedium       = "medium"
 	antigravityEffortHigh         = "high"
+	antigravityInitEvent          = "init"
 )
 
 // codexDispatchSandboxMode resolves the Codex sandbox for a non-YOLO dispatch.
@@ -651,10 +652,12 @@ func reduceGrokEvent(expected string, value map[string]any, textAccumulator *str
 
 func reduceAntigravityEvent(value map[string]any, terminalSeen *bool) []providerEvent {
 	eventType, _ := value[jsonEventKey].(string)
-	if eventType == "init" {
+	if eventType == antigravityInitEvent {
 		id, _ := firstStringV013(value, "conversation_id")
 		if id == "" {
-			return []providerEvent{{Kind: eventFailure, Reason: "Antigravity init event has no conversation ID"}}
+			// Ignore an incomplete lifecycle notification. The terminal
+			// result invariant still rejects a run without an identity.
+			return []providerEvent{{Kind: eventProgress, Activity: eventType}}
 		}
 		return []providerEvent{{Kind: eventSession, SessionID: id}}
 	}

--- a/internal/agentdispatch/provider.go
+++ b/internal/agentdispatch/provider.go
@@ -651,6 +651,13 @@ func reduceGrokEvent(expected string, value map[string]any, textAccumulator *str
 
 func reduceAntigravityEvent(value map[string]any, terminalSeen *bool) []providerEvent {
 	eventType, _ := value[jsonEventKey].(string)
+	if eventType == "init" {
+		id, _ := firstStringV013(value, "conversation_id")
+		if id == "" {
+			return []providerEvent{{Kind: eventFailure, Reason: "Antigravity init event has no conversation ID"}}
+		}
+		return []providerEvent{{Kind: eventSession, SessionID: id}}
+	}
 	if eventType != "result" {
 		if eventType == "" {
 			return nil
@@ -667,24 +674,28 @@ func reduceAntigravityEvent(value map[string]any, terminalSeen *bool) []provider
 	if result == nil {
 		return []providerEvent{{Kind: eventFailure, Reason: "Antigravity terminal result is not an object"}}
 	}
+	id, _ := firstStringV013(result, "conversation_id")
+	var events []providerEvent
+	if id != "" {
+		events = append(events, providerEvent{Kind: eventSession, SessionID: id})
+	}
 	status, _ := result[jsonStatusKey].(string)
 	if status != "SUCCESS" {
 		reason := "Antigravity terminal result was unsuccessful"
 		if providerError, _ := firstStringV013(result, "error"); providerError != "" {
 			reason += ": " + providerError
 		}
-		return []providerEvent{{Kind: eventFailure, Reason: reason}}
+		return append(events, providerEvent{Kind: eventFailure, Reason: reason})
 	}
-	id, _ := firstStringV013(result, "conversation_id")
 	answer, _ := firstStringV013(result, jsonResponseKey)
 	if id == "" || answer == "" {
-		return []providerEvent{{Kind: eventFailure, Reason: "Antigravity terminal result has no conversation ID or final answer"}}
+		return append(events, providerEvent{Kind: eventFailure, Reason: "Antigravity terminal result has no conversation ID or final answer"})
 	}
 	usage, _ := result[grokUsageEventType].(map[string]any)
 	if usage == nil {
-		return []providerEvent{{Kind: eventFailure, Reason: "Antigravity terminal result has no usage object"}}
+		return append(events, providerEvent{Kind: eventFailure, Reason: "Antigravity terminal result has no usage object"})
 	}
-	return []providerEvent{{Kind: eventSession, SessionID: id}, {Kind: eventAnswer, Answer: answer}, {Kind: eventProgress, Activity: "usage", Usage: usage}, {Kind: eventComplete}}
+	return append(events, providerEvent{Kind: eventAnswer, Answer: answer}, providerEvent{Kind: eventProgress, Activity: "usage", Usage: usage}, providerEvent{Kind: eventComplete})
 }
 
 func readStructuredEventsWithLineage(reader io.Reader, rawWriter io.Writer, agent string, expectedSession string, claudeLineage bool, consume func(providerEvent) error, consumeLineage func(claudeLineageEvidence) error) error {

--- a/internal/agentdispatch/provider_runner_test.go
+++ b/internal/agentdispatch/provider_runner_test.go
@@ -923,6 +923,29 @@ func TestStructuredProviderStreamsRejectDuplicateTerminalEvents(t *testing.T) {
 	}
 }
 
+func TestAntigravityIncompleteInitIsProgressAndTerminalStillAuthoritative(t *testing.T) {
+	progress, err := reduceStructuredTestEvent(AgentAntigravity, "", []byte(`{"event":"init"}`))
+	if err != nil || len(progress) != 1 || progress[0].Kind != eventProgress || progress[0].Activity != antigravityInitEvent {
+		t.Fatalf("incomplete init = %#v, %v", progress, err)
+	}
+	session, err := reduceStructuredTestEvent(AgentAntigravity, "", []byte(`{"event":"init","conversation_id":"conversation"}`))
+	if err != nil || len(session) != 1 || session[0].Kind != eventSession || session[0].SessionID != "conversation" {
+		t.Fatalf("valid init = %#v, %v", session, err)
+	}
+	stream := `{"event":"init"}` + "\n" +
+		`{"event":"result","result":{"status":"SUCCESS","conversation_id":"conversation","response":"answer","usage":{"input_tokens":1,"output_tokens":2,"thinking_tokens":1,"cache_read_tokens":0}}}` + "\n"
+	var events []providerEvent
+	if err := readStructuredEventsWithLineage(strings.NewReader(stream), io.Discard, AgentAntigravity, "", false, func(event providerEvent) error {
+		events = append(events, event)
+		return nil
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 5 || events[0].Kind != eventProgress || events[0].Activity != antigravityInitEvent || events[1].Kind != eventSession || events[1].SessionID != "conversation" || events[2].Kind != eventAnswer || events[2].Answer != "answer" || events[3].Kind != eventProgress || events[4].Kind != eventComplete {
+		t.Fatalf("incomplete init plus terminal = %#v", events)
+	}
+}
+
 func TestAntigravityStructuredEventsRequireSuccessfulUsageBearingTerminal(t *testing.T) {
 	events, err := reduceStructuredTestEvent(AgentAntigravity, "", []byte(`{"event":"result","result":{"status":"SUCCESS","conversation_id":"conversation","response":"answer","usage":{"input_tokens":1,"output_tokens":2,"thinking_tokens":1,"cache_read_tokens":0}}}`))
 	if err != nil {

--- a/internal/agentdispatch/provider_runner_test.go
+++ b/internal/agentdispatch/provider_runner_test.go
@@ -937,8 +937,13 @@ func TestAntigravityStructuredEventsRequireSuccessfulUsageBearingTerminal(t *tes
 		`{"event":"result","result":{"status":"SUCCESS","conversation_id":"conversation","response":"answer"}}`,
 	} {
 		events, err = reduceStructuredTestEvent(AgentAntigravity, "", []byte(raw))
-		if err != nil || len(events) != 1 || events[0].Kind != eventFailure {
+		if err != nil || len(events) == 0 || events[len(events)-1].Kind != eventFailure {
 			t.Fatalf("Antigravity invalid terminal %s = %#v, %v", raw, events, err)
+		}
+		for _, event := range events {
+			if event.Kind == eventAnswer || event.Kind == eventComplete {
+				t.Fatalf("invalid terminal published an answer or completion: %#v", events)
+			}
 		}
 	}
 	events, err = reduceStructuredTestEvent(AgentAntigravity, "", []byte(`{"event":"result","result":{"status":"ERROR","error":"invalid model selection","conversation_id":"","response":"","usage":{}}}`))

--- a/internal/agentdispatch/runner.go
+++ b/internal/agentdispatch/runner.go
@@ -426,10 +426,16 @@ func awaitProviderCompletion(
 			wait.shutdownTimer.Stop()
 		}
 	}()
-	waitPoll := time.NewTicker(providerTerminationPollInterval)
+	observeInterval := providerObservePollInterval()
+	waitPoll := time.NewTicker(observeInterval)
 	defer waitPoll.Stop()
+	terminationPolling := observeInterval == providerTerminationPollInterval
 	for {
 		wait.observeLeader(startShutdownDeadline)
+		if !terminationPolling && (wait.termination.hasRequested() || wait.shutdownTimer != nil) {
+			waitPoll.Reset(providerTerminationPollInterval)
+			terminationPolling = true
+		}
 		needReap := !wait.reaped && wait.terminationErr == nil && wait.cmd.Process != nil && wait.cmd.Process.Pid > 0
 		if streamErr == nil && stderrErr == nil && !needReap && wait.terminationDone == nil {
 			break

--- a/internal/agentdispatch/runner.go
+++ b/internal/agentdispatch/runner.go
@@ -52,6 +52,10 @@ type executionResult struct {
 	Answer     string
 }
 
+// After terminal evidence or process exit, only shutdown and output draining
+// remain. This is not an idle timeout for an actively working provider.
+const providerShutdownGrace = 5 * time.Second
+
 // unprovenProviderTerminationError marks a provider failure whose process
 // group may still be live. Failure finalization must preserve the active claim
 // and nonterminal run evidence until a later cancellation or recovery proves
@@ -67,7 +71,7 @@ func (e *unprovenProviderTerminationError) Unwrap() error { return e.err }
 func newUnprovenProviderTerminationError(primary error, message string, proofErr error) *unprovenProviderTerminationError {
 	return &unprovenProviderTerminationError{err: errors.Join(
 		primary,
-		wrapExitError(ExitTargetFailure, message, proofErr),
+		wrapExitError(ExitTargetFailure, fmt.Sprintf("%s: %v", message, proofErr), proofErr),
 	)}
 }
 
@@ -118,19 +122,46 @@ func executeProvider(
 		cmd.Dir = root
 	}
 	cmd.Env = command.Env
-	cmd.Stdin = bytes.NewReader(prompt)
-	stdoutPipe, err := cmd.StdoutPipe()
+	// A file avoids exec's stdin-copy goroutine, which can outlive the leader
+	// when a descendant inherits an unread pipe. Unlink it while open so the
+	// prompt is not left behind as another durable artifact.
+	stdin, err := os.CreateTemp(run.Dir, "provider-stdin-*")
+	if err != nil {
+		return executionResult{}, wrapExitError(ExitConfig, "create dispatch provider stdin", err)
+	}
+	defer func() { _ = stdin.Close() }()
+	if err := os.Remove(stdin.Name()); err != nil {
+		return executionResult{}, wrapExitError(ExitConfig, "unlink dispatch provider stdin", err)
+	}
+	if _, err := stdin.Write(prompt); err != nil {
+		return executionResult{}, wrapExitError(ExitConfig, "write dispatch provider stdin", err)
+	}
+	if _, err := stdin.Seek(0, io.SeekStart); err != nil {
+		return executionResult{}, wrapExitError(ExitConfig, "rewind dispatch provider stdin", err)
+	}
+	cmd.Stdin = stdin
+	// Own the pipes so cmd.Wait can observe process exit independently without
+	// closing output that the structured reader has not consumed yet.
+	stdoutPipe, stdoutWrite, err := os.Pipe()
 	if err != nil {
 		return executionResult{}, wrapExitError(ExitTargetFailure, "open dispatch provider stdout", err)
 	}
-	stderrPipe, err := cmd.StderrPipe()
+	defer func() { _ = stdoutPipe.Close() }()
+	defer func() { _ = stdoutWrite.Close() }()
+	stderrPipe, stderrWrite, err := os.Pipe()
 	if err != nil {
 		return executionResult{}, wrapExitError(ExitTargetFailure, "open dispatch provider stderr", err)
 	}
+	defer func() { _ = stderrPipe.Close() }()
+	defer func() { _ = stderrWrite.Close() }()
+	cmd.Stdout = stdoutWrite
+	cmd.Stderr = stderrWrite
 	prepareProviderProcessGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		return executionResult{}, &preStartFailure{err: providerStartError(command.Provider, err)}
 	}
+	_ = stdoutWrite.Close()
+	_ = stderrWrite.Close()
 	run.Record.PID = cmd.Process.Pid
 	run.Record.ProcessGroupID = cmd.Process.Pid
 	run.Record.ProcessStartIdentity = processStartIdentity(cmd.Process.Pid)
@@ -167,10 +198,18 @@ func executeProvider(
 			close(stderrDrained)
 		}()
 		termination.request()
+		waited := make(chan error, 1)
+		go func() { waited <- cmd.Wait() }()
+		<-termination.done
+		_ = stdoutPipe.Close()
+		_ = stderrPipe.Close()
 		<-stdoutDrained
 		<-stderrDrained
-		_ = cmd.Wait()
-		terminationErr := termination.providerStopped()
+		terminationErr := termination.err
+		if terminationErr == nil {
+			<-waited
+			terminationErr = termination.providerStopped()
+		}
 		if terminationErr != nil {
 			return executionResult{}, newUnprovenProviderTerminationError(
 				err,
@@ -187,6 +226,7 @@ func executeProvider(
 	var pendingAnswer string
 	var resultMu sync.Mutex
 	var semanticErr error
+	terminal := make(chan struct{}, 1)
 	setFailure := func(err error) {
 		if err == nil {
 			return
@@ -217,6 +257,10 @@ func executeProvider(
 				semanticErr = errors.New("provider returned conflicting session IDs")
 				return semanticErr
 			}
+			if command.SessionID != "" && command.SessionID != event.SessionID {
+				semanticErr = errors.New("provider returned a session ID different from the requested conversation")
+				return semanticErr
+			}
 			result.SessionID = event.SessionID
 			run.Record.ProviderSessionID = event.SessionID
 			if err := persist(event.SessionID); err != nil {
@@ -229,6 +273,10 @@ func executeProvider(
 			run.Record.LastOutputAt = &now
 		case eventComplete:
 			result.Complete = true
+			select {
+			case terminal <- struct{}{}:
+			default:
+			}
 		case eventFailure:
 			semanticErr = errors.New(event.Reason)
 			return semanticErr
@@ -284,10 +332,64 @@ func executeProvider(
 		stderrErr <- err
 	}()
 
-	streamResult := <-streamErr
-	stderrResult := <-stderrErr
-	waitErr := cmd.Wait()
-	terminationErr := termination.providerStopped()
+	waited := make(chan error, 1)
+	go func(done chan<- error) { done <- cmd.Wait() }(waited)
+	var streamResult, stderrResult, waitErr, terminationErr error
+	var shutdownTimer *time.Timer
+	var shutdownDeadline <-chan time.Time
+	startShutdownDeadline := func() {
+		if shutdownTimer == nil && (streamErr != nil || stderrErr != nil || waited != nil) {
+			shutdownTimer = time.NewTimer(providerShutdownGrace)
+			shutdownDeadline = shutdownTimer.C
+		}
+	}
+	defer func() {
+		if shutdownTimer != nil {
+			shutdownTimer.Stop()
+		}
+	}()
+	terminationDone := termination.done
+	for streamErr != nil || stderrErr != nil || waited != nil || terminationDone != nil {
+		if streamErr == nil && stderrErr == nil && waited == nil && shutdownTimer != nil {
+			// Process exit and I/O met their deadline. Group termination has
+			// its own bounded grace/proof windows; do not spend this deadline
+			// a second time on that independent cleanup phase.
+			shutdownTimer.Stop()
+			shutdownDeadline = nil
+		}
+		select {
+		case <-terminal:
+			startShutdownDeadline()
+		case streamResult = <-streamErr:
+			streamErr = nil
+			startShutdownDeadline()
+		case stderrResult = <-stderrErr:
+			stderrErr = nil
+		case waitErr = <-waited:
+			waited = nil
+			startShutdownDeadline()
+			termination.request()
+		case <-terminationDone:
+			terminationDone = nil
+			terminationErr = termination.err
+			startShutdownDeadline()
+			if terminationErr != nil {
+				// Do not hang on an unkillable provider. Retain its active claim
+				// through the unproven-termination error below.
+				waited = nil
+				_ = stdoutPipe.Close()
+				_ = stderrPipe.Close()
+			}
+		case <-shutdownDeadline:
+			shutdownDeadline = nil
+			setFailure(fmt.Errorf("provider did not exit and close output streams within %s of terminal evidence or shutdown", providerShutdownGrace))
+			_ = stdoutPipe.Close()
+			_ = stderrPipe.Close()
+		}
+	}
+	if terminationErr == nil {
+		terminationErr = termination.providerStopped()
+	}
 	signal := caughtSignal()
 	resultMu.Lock()
 	currentSemanticErr := semanticErr
@@ -300,12 +402,12 @@ func executeProvider(
 		} else {
 			primaryErr = exitError(ExitSigterm, fmt.Sprintf("%s interrupted by signal SIGTERM", command.Provider))
 		}
+	case currentSemanticErr != nil:
+		primaryErr = exitError(ExitTargetFailure, fmt.Sprintf("%s dispatch did not complete: %v", command.Provider, currentSemanticErr))
 	case streamResult != nil:
 		primaryErr = wrapExitError(ExitTargetFailure, fmt.Sprintf("capture dispatch provider output: %v", streamResult), streamResult)
 	case stderrResult != nil:
 		primaryErr = wrapExitError(ExitTargetFailure, fmt.Sprintf("capture dispatch provider diagnostics: %v", stderrResult), stderrResult)
-	case currentSemanticErr != nil:
-		primaryErr = exitError(ExitTargetFailure, fmt.Sprintf("%s dispatch did not complete: %v", command.Provider, currentSemanticErr))
 	case waitErr != nil:
 		primaryErr = providerWaitError(command.Provider, waitErr)
 	}

--- a/internal/agentdispatch/runner.go
+++ b/internal/agentdispatch/runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync"
 	"time"
@@ -165,6 +166,9 @@ func executeProvider(
 	run.Record.PID = cmd.Process.Pid
 	run.Record.ProcessGroupID = cmd.Process.Pid
 	run.Record.ProcessStartIdentity = processStartIdentity(cmd.Process.Pid)
+	leaderPID := run.Record.PID
+	leaderGroupID := run.Record.ProcessGroupID
+	leaderStart := run.Record.ProcessStartIdentity
 	termination, err := newStartedProviderTermination(cmd, run.Record, providerTerminationGrace)
 	if err != nil {
 		// The exec.Cmd is direct proof that this leader is ours, but without a
@@ -198,16 +202,13 @@ func executeProvider(
 			close(stderrDrained)
 		}()
 		termination.request()
-		waited := make(chan error, 1)
-		go func() { waited <- cmd.Wait() }()
-		<-termination.done
+		_, _ = reapDuringTermination(cmd, leaderStart, termination)
 		_ = stdoutPipe.Close()
 		_ = stderrPipe.Close()
 		<-stdoutDrained
 		<-stderrDrained
 		terminationErr := termination.err
 		if terminationErr == nil {
-			<-waited
 			terminationErr = termination.providerStopped()
 		}
 		if terminationErr != nil {
@@ -332,64 +333,10 @@ func executeProvider(
 		stderrErr <- err
 	}()
 
-	waited := make(chan error, 1)
-	go func(done chan<- error) { done <- cmd.Wait() }(waited)
-	var streamResult, stderrResult, waitErr, terminationErr error
-	var shutdownTimer *time.Timer
-	var shutdownDeadline <-chan time.Time
-	startShutdownDeadline := func() {
-		if shutdownTimer == nil && (streamErr != nil || stderrErr != nil || waited != nil) {
-			shutdownTimer = time.NewTimer(providerShutdownGrace)
-			shutdownDeadline = shutdownTimer.C
-		}
-	}
-	defer func() {
-		if shutdownTimer != nil {
-			shutdownTimer.Stop()
-		}
-	}()
-	terminationDone := termination.done
-	for streamErr != nil || stderrErr != nil || waited != nil || terminationDone != nil {
-		if streamErr == nil && stderrErr == nil && waited == nil && shutdownTimer != nil {
-			// Process exit and I/O met their deadline. Group termination has
-			// its own bounded grace/proof windows; do not spend this deadline
-			// a second time on that independent cleanup phase.
-			shutdownTimer.Stop()
-			shutdownDeadline = nil
-		}
-		select {
-		case <-terminal:
-			startShutdownDeadline()
-		case streamResult = <-streamErr:
-			streamErr = nil
-			startShutdownDeadline()
-		case stderrResult = <-stderrErr:
-			stderrErr = nil
-		case waitErr = <-waited:
-			waited = nil
-			startShutdownDeadline()
-			termination.request()
-		case <-terminationDone:
-			terminationDone = nil
-			terminationErr = termination.err
-			startShutdownDeadline()
-			if terminationErr != nil {
-				// Do not hang on an unkillable provider. Retain its active claim
-				// through the unproven-termination error below.
-				waited = nil
-				_ = stdoutPipe.Close()
-				_ = stderrPipe.Close()
-			}
-		case <-shutdownDeadline:
-			shutdownDeadline = nil
-			setFailure(fmt.Errorf("provider did not exit and close output streams within %s of terminal evidence or shutdown", providerShutdownGrace))
-			_ = stdoutPipe.Close()
-			_ = stderrPipe.Close()
-		}
-	}
-	if terminationErr == nil {
-		terminationErr = termination.providerStopped()
-	}
+	streamResult, stderrResult, waitErr, terminationErr := awaitProviderCompletion(
+		cmd, termination, leaderPID, leaderGroupID, leaderStart,
+		stdoutPipe, stderrPipe, streamErr, stderrErr, terminal, setFailure,
+	)
 	signal := caughtSignal()
 	resultMu.Lock()
 	currentSemanticErr := semanticErr
@@ -434,6 +381,160 @@ func executeProvider(
 	resultMu.Unlock()
 	result.Answer = terminalAnswer
 	return result, nil
+}
+
+type providerWaitState struct {
+	cmd              *exec.Cmd
+	termination      *providerTermination
+	leader           RunRecord
+	stdoutPipe       *os.File
+	stderrPipe       *os.File
+	reaped           bool
+	waitErr          error
+	terminationErr   error
+	terminationDone  <-chan struct{}
+	shutdownTimer    *time.Timer
+	shutdownDeadline <-chan time.Time
+}
+
+func awaitProviderCompletion(
+	cmd *exec.Cmd,
+	termination *providerTermination,
+	leaderPID, leaderGroupID int,
+	leaderStart string,
+	stdoutPipe, stderrPipe *os.File,
+	streamErr, stderrErr chan error,
+	terminal <-chan struct{},
+	setFailure func(error),
+) (streamResult, stderrResult, waitErr, terminationErr error) {
+	wait := &providerWaitState{
+		cmd:             cmd,
+		termination:     termination,
+		leader:          RunRecord{PID: leaderPID, ProcessGroupID: leaderGroupID, ProcessStartIdentity: leaderStart},
+		stdoutPipe:      stdoutPipe,
+		stderrPipe:      stderrPipe,
+		terminationDone: termination.done,
+	}
+	startShutdownDeadline := func() {
+		if wait.shutdownTimer == nil && (streamErr != nil || stderrErr != nil || !wait.reaped) {
+			wait.shutdownTimer = time.NewTimer(providerShutdownGrace)
+			wait.shutdownDeadline = wait.shutdownTimer.C
+		}
+	}
+	defer func() {
+		if wait.shutdownTimer != nil {
+			wait.shutdownTimer.Stop()
+		}
+	}()
+	waitPoll := time.NewTicker(providerTerminationPollInterval)
+	defer waitPoll.Stop()
+	for {
+		wait.observeLeader(startShutdownDeadline)
+		needReap := !wait.reaped && wait.terminationErr == nil && wait.cmd.Process != nil && wait.cmd.Process.Pid > 0
+		if streamErr == nil && stderrErr == nil && !needReap && wait.terminationDone == nil {
+			break
+		}
+		if streamErr == nil && stderrErr == nil && wait.reaped && wait.shutdownTimer != nil {
+			// Process exit and I/O met their deadline. Group termination has
+			// its own bounded grace/proof windows; do not spend this deadline
+			// a second time on that independent cleanup phase.
+			wait.shutdownTimer.Stop()
+			wait.shutdownDeadline = nil
+		}
+		select {
+		case <-terminal:
+			startShutdownDeadline()
+		case streamResult = <-streamErr:
+			streamErr = nil
+			startShutdownDeadline()
+		case stderrResult = <-stderrErr:
+			stderrErr = nil
+		case <-wait.terminationDone:
+			wait.terminationDone = nil
+			wait.terminationErr = wait.termination.err
+			startShutdownDeadline()
+			if wait.terminationErr != nil {
+				// Do not hang on an unkillable provider. Retain its active claim
+				// through the unproven-termination error below.
+				wait.abandonUnproven()
+			}
+		case <-wait.shutdownDeadline:
+			wait.shutdownDeadline = nil
+			setFailure(fmt.Errorf("provider did not exit and close output streams within %s of terminal evidence or shutdown", providerShutdownGrace))
+			_ = wait.stdoutPipe.Close()
+			_ = wait.stderrPipe.Close()
+		case <-waitPoll.C:
+		}
+	}
+	if wait.terminationErr == nil {
+		wait.terminationErr = wait.termination.providerStopped()
+	}
+	return streamResult, stderrResult, wait.waitErr, wait.terminationErr
+}
+
+func (wait *providerWaitState) observeLeader(startShutdown func()) {
+	if wait.reaped || wait.cmd.Process == nil || wait.cmd.Process.Pid <= 0 {
+		return
+	}
+	if providerProcessGroupReused(wait.leader) {
+		if wait.terminationErr == nil {
+			wait.terminationErr = errProviderGroupIdentityMismatch
+		}
+		wait.terminationDone = nil
+		releaseUnreapedProvider(wait.cmd)
+		return
+	}
+	zombie := processIsZombie(wait.cmd.Process.Pid)
+	groupDead := providerProcessGroupDead(wait.leader.ProcessGroupID)
+	if !wait.termination.hasRequested() {
+		switch {
+		case zombie && !groupDead:
+			wait.termination.request()
+		case zombie || groupDead:
+			wait.noteReap(reapOwnedProviderLeader(wait.cmd, wait.leader.ProcessStartIdentity))
+			if wait.reaped {
+				startShutdown()
+			}
+			if providerProcessGroupDead(wait.leader.ProcessGroupID) {
+				wait.terminationDone = nil
+			}
+			return
+		default:
+			return
+		}
+	}
+	wait.noteReap(reapOwnedProviderLeader(wait.cmd, wait.leader.ProcessStartIdentity))
+	if wait.reaped {
+		startShutdown()
+	}
+}
+
+func (wait *providerWaitState) noteReap(done bool, err error) {
+	if done {
+		wait.reaped = true
+		wait.waitErr = err
+		return
+	}
+	if err != nil && wait.waitErr == nil {
+		wait.waitErr = err
+	}
+}
+
+func (wait *providerWaitState) abandonUnproven() {
+	if !wait.reaped {
+		done, err := reapOwnedProviderLeader(wait.cmd, wait.leader.ProcessStartIdentity)
+		if done {
+			wait.reaped = true
+			wait.waitErr = err
+		} else {
+			if err != nil && wait.waitErr == nil {
+				wait.waitErr = err
+			}
+			releaseUnreapedProvider(wait.cmd)
+		}
+	}
+	_ = wait.stdoutPipe.Close()
+	_ = wait.stderrPipe.Close()
 }
 
 func antigravityTimeoutReported(stderrPath string, logPath string) (bool, error) {

--- a/internal/agentdispatch/runtime_helpers.go
+++ b/internal/agentdispatch/runtime_helpers.go
@@ -108,15 +108,34 @@ func providerProcessGroupDead(pgid int) bool {
 	return errors.Is(syscall.Kill(-pgid, 0), syscall.ESRCH)
 }
 
+// providerProcessGroupReused proves that a live group leader is a different
+// process. A PID cannot be allocated again while its original process group
+// still reserves that ID. Never signal the new owner's group.
+func providerProcessGroupReused(record RunRecord) bool {
+	if record.PID <= 0 || record.PID != record.ProcessGroupID || record.ProcessStartIdentity == "" {
+		return false
+	}
+	current := processStartIdentity(record.PID)
+	if current == "" || current == record.ProcessStartIdentity {
+		return false
+	}
+	pgid, err := syscall.Getpgid(record.PID)
+	return err == nil && pgid == record.PID
+}
+
 // terminate sends SIGTERM to one verified Agent Layer-owned process group,
 // escalates to SIGKILL after the bounded grace period, and returns only after
 // group death is proven or a second bounded proof window expires.
 func (group ownedProviderProcessGroup) terminate(grace time.Duration) error {
+	var signalErr error
 	if err := syscall.Kill(-group.pgid, syscall.SIGTERM); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
 			return nil
 		}
-		return fmt.Errorf("send SIGTERM to provider process group: %w", err)
+		// Darwin can report EPERM for a group containing only zombies.
+		// Reaping runs concurrently, so retain the error but still allow the
+		// bounded death-proof window. A signal error alone is not that proof.
+		signalErr = fmt.Errorf("send SIGTERM to provider process group: %w", err)
 	}
 	if grace <= 0 {
 		grace = providerTerminationGrace
@@ -133,7 +152,7 @@ func (group ownedProviderProcessGroup) terminate(grace time.Duration) error {
 			}
 		case <-timer.C:
 			if err := syscall.Kill(-group.pgid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
-				return fmt.Errorf("send SIGKILL to provider process group after %s grace: %w", grace, err)
+				signalErr = errors.Join(signalErr, fmt.Errorf("send SIGKILL to provider process group after %s grace: %w", grace, err))
 			}
 			proofTimer := time.NewTimer(grace)
 			defer proofTimer.Stop()
@@ -145,7 +164,7 @@ func (group ownedProviderProcessGroup) terminate(grace time.Duration) error {
 						return nil
 					}
 				case <-proofTimer.C:
-					return fmt.Errorf("provider process group %d remained live %s after SIGKILL", group.pgid, grace)
+					return errors.Join(signalErr, fmt.Errorf("provider process group %d remained live %s after SIGKILL", group.pgid, grace))
 				}
 			}
 		}
@@ -162,10 +181,10 @@ func (group ownedProviderProcessGroup) terminateReverified(grace time.Duration) 
 type providerTermination struct {
 	group     ownedProviderProcessGroup
 	grace     time.Duration
-	done      chan error
+	done      chan struct{}
+	err       error
 	mu        sync.Mutex
 	requested bool
-	completed bool
 }
 
 // newStartedProviderTermination latches process-group ownership after cmd.Start
@@ -192,19 +211,19 @@ func newStartedProviderTermination(cmd *exec.Cmd, record RunRecord, grace time.D
 		return nil, fmt.Errorf("read started provider process group: %w", err)
 	}
 	group := ownedProviderProcessGroup{pid: record.PID, pgid: record.ProcessGroupID, start: record.ProcessStartIdentity}
-	return &providerTermination{group: group, grace: grace, done: make(chan error, 1)}, nil
+	return &providerTermination{group: group, grace: grace, done: make(chan struct{})}, nil
 }
 
 func (termination *providerTermination) request() {
 	termination.mu.Lock()
-	if termination.requested || termination.completed {
+	if termination.requested {
 		termination.mu.Unlock()
 		return
 	}
 	termination.requested = true
 	termination.mu.Unlock()
 	go func() {
-		termination.done <- termination.group.terminate(termination.grace)
+		termination.err = termination.group.terminate(termination.grace)
 		close(termination.done)
 	}()
 }
@@ -212,18 +231,10 @@ func (termination *providerTermination) request() {
 // providerStopped completes the controller after cmd.Wait has reaped the
 // provider leader. It also joins any in-flight escalation before claim release.
 func (termination *providerTermination) providerStopped() error {
-	termination.mu.Lock()
-	if termination.completed {
-		termination.mu.Unlock()
-		return nil
-	}
-	termination.completed = true
-	requested := termination.requested
-	termination.mu.Unlock()
-	if !requested {
-		return nil
-	}
-	return <-termination.done
+	// A reaped leader does not prove that its descendants have exited.
+	termination.request()
+	<-termination.done
+	return termination.err
 }
 
 func installProviderSignalForwarder(requestTermination func()) (caught func() os.Signal, stop func()) {

--- a/internal/agentdispatch/runtime_helpers.go
+++ b/internal/agentdispatch/runtime_helpers.go
@@ -44,25 +44,61 @@ func processStartIdentity(pid int) string {
 	return "ps:" + strings.TrimSpace(string(out))
 }
 
+func procStatFields(content string) []string {
+	closeParen := strings.LastIndex(content, ")")
+	if closeParen == -1 {
+		return nil
+	}
+	return strings.Fields(content[closeParen+1:])
+}
+
+// procStatState extracts state (field 3) from /proc/<pid>/stat. The
+// parenthesized comm field may itself contain spaces or parentheses, so
+// fields are indexed after the last ")": the remainder starts at field 3.
+func procStatState(content string) string {
+	fields := procStatFields(content)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
 // procStatStartTime extracts starttime (field 22) from /proc/<pid>/stat. The
 // parenthesized comm field may itself contain spaces or parentheses, so
 // fields are indexed after the last ")": the remainder starts at field 3
 // (state), putting starttime at remainder index 19.
 func procStatStartTime(content string) string {
-	closeParen := strings.LastIndex(content, ")")
-	if closeParen == -1 {
-		return ""
-	}
-	fields := strings.Fields(content[closeParen+1:])
+	fields := procStatFields(content)
 	if len(fields) <= 19 {
 		return ""
 	}
 	return fields[19]
 }
 
+func processIsZombie(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	if data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid)); err == nil {
+		return procStatState(string(data)) == "Z"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ps", "-o", "stat=", "-p", strconv.Itoa(pid)).Output() // #nosec G204 -- pid is an Agent Layer-owned integer.
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(string(out)), "Z")
+}
+
 const (
 	providerTerminationGrace        = time.Second
 	providerTerminationPollInterval = 10 * time.Millisecond
+)
+
+var (
+	errProviderGroupDead             = errors.New("provider process group is already dead")
+	errProviderGroupIdentityMismatch = errors.New("provider process group ownership identity no longer matches")
 )
 
 type ownedProviderProcessGroup struct {
@@ -123,14 +159,63 @@ func providerProcessGroupReused(record RunRecord) bool {
 	return err == nil && pgid == record.PID
 }
 
+// prepareSignal proves it is still safe to signal this process group.
+// A live leader must match the captured start identity. After that leader
+// becomes a zombie or is reaped, descendants keep the process-group ID
+// reserved until they exit, so a still-live group is safe to signal. A live
+// replacement leader with a different start identity must not be signalled.
+func (group ownedProviderProcessGroup) prepareSignal() error {
+	record := RunRecord{PID: group.pid, ProcessGroupID: group.pgid, ProcessStartIdentity: group.start}
+	if providerProcessGroupReused(record) {
+		return errProviderGroupIdentityMismatch
+	}
+	if providerProcessGroupDead(group.pgid) {
+		return errProviderGroupDead
+	}
+	current := processStartIdentity(group.pid)
+	switch {
+	case current == group.start && current != "":
+		if processIsZombie(group.pid) {
+			return nil
+		}
+		return group.verifyLiveIdentity()
+	case current != "":
+		return errProviderGroupIdentityMismatch
+	default:
+		if providerProcessGroupDead(group.pgid) {
+			return errProviderGroupDead
+		}
+		if current := processStartIdentity(group.pid); current != "" && current != group.start {
+			return errProviderGroupIdentityMismatch
+		}
+		return nil
+	}
+}
+
+func (group ownedProviderProcessGroup) signal(sig syscall.Signal) error {
+	if err := group.prepareSignal(); err != nil {
+		if errors.Is(err, errProviderGroupDead) {
+			return nil
+		}
+		return err
+	}
+	if err := syscall.Kill(-group.pgid, sig); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 // terminate sends SIGTERM to one verified Agent Layer-owned process group,
 // escalates to SIGKILL after the bounded grace period, and returns only after
 // group death is proven or a second bounded proof window expires.
 func (group ownedProviderProcessGroup) terminate(grace time.Duration) error {
 	var signalErr error
-	if err := syscall.Kill(-group.pgid, syscall.SIGTERM); err != nil {
-		if errors.Is(err, syscall.ESRCH) {
-			return nil
+	if err := group.signal(syscall.SIGTERM); err != nil {
+		if errors.Is(err, errProviderGroupIdentityMismatch) {
+			return err
 		}
 		// Darwin can report EPERM for a group containing only zombies.
 		// Reaping runs concurrently, so retain the error but still allow the
@@ -151,7 +236,10 @@ func (group ownedProviderProcessGroup) terminate(grace time.Duration) error {
 				return nil
 			}
 		case <-timer.C:
-			if err := syscall.Kill(-group.pgid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			if err := group.signal(syscall.SIGKILL); err != nil {
+				if errors.Is(err, errProviderGroupIdentityMismatch) {
+					return errors.Join(signalErr, err)
+				}
 				signalErr = errors.Join(signalErr, fmt.Errorf("send SIGKILL to provider process group after %s grace: %w", grace, err))
 			}
 			proofTimer := time.NewTimer(grace)
@@ -228,13 +316,134 @@ func (termination *providerTermination) request() {
 	}()
 }
 
-// providerStopped completes the controller after cmd.Wait has reaped the
-// provider leader. It also joins any in-flight escalation before claim release.
+func (termination *providerTermination) hasRequested() bool {
+	termination.mu.Lock()
+	defer termination.mu.Unlock()
+	return termination.requested
+}
+
+// providerStopped joins any in-flight escalation. If termination was not
+// started while the leader identity was still reserved, it signals only when
+// ownership can still be proven; a reused or unprovable group is not signalled.
 func (termination *providerTermination) providerStopped() error {
-	// A reaped leader does not prove that its descendants have exited.
+	if termination.hasRequested() {
+		<-termination.done
+		return termination.err
+	}
+	if err := termination.group.prepareSignal(); err != nil {
+		if errors.Is(err, errProviderGroupDead) {
+			return nil
+		}
+		return err
+	}
 	termination.request()
 	<-termination.done
 	return termination.err
+}
+
+type providerWaitStatusError struct {
+	status syscall.WaitStatus
+}
+
+func (e *providerWaitStatusError) Error() string {
+	if e.status.Exited() {
+		return fmt.Sprintf("exit status %d", e.status.ExitStatus())
+	}
+	if e.status.Signaled() {
+		return fmt.Sprintf("signal: %s", e.status.Signal())
+	}
+	return "process wait failed"
+}
+
+func (e *providerWaitStatusError) ExitCode() int {
+	if e.status.Exited() {
+		return e.status.ExitStatus()
+	}
+	return -1
+}
+
+func waitStatusToError(status syscall.WaitStatus) error {
+	if status.Exited() && status.ExitStatus() == 0 {
+		return nil
+	}
+	return &providerWaitStatusError{status: status}
+}
+
+// reapOwnedProviderLeader reaps the started leader without blocking. It never
+// waits on a PID whose start identity no longer matches, so a reused process
+// is not collected as if it were the provider.
+func reapOwnedProviderLeader(cmd *exec.Cmd, start string) (bool, error) {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return true, nil
+	}
+	pid := cmd.Process.Pid
+	if providerProcessGroupReused(RunRecord{PID: pid, ProcessGroupID: pid, ProcessStartIdentity: start}) {
+		return false, errProviderGroupIdentityMismatch
+	}
+	if current := processStartIdentity(pid); current != "" && start != "" && current != start {
+		return false, errProviderGroupIdentityMismatch
+	}
+	var status syscall.WaitStatus
+	var rusage syscall.Rusage
+	wpid, err := syscall.Wait4(pid, &status, syscall.WNOHANG, &rusage)
+	if err != nil {
+		if errors.Is(err, syscall.ECHILD) {
+			_ = cmd.Process.Release()
+			return true, nil
+		}
+		return false, err
+	}
+	if wpid == 0 {
+		return false, nil
+	}
+	_ = cmd.Process.Release()
+	return true, waitStatusToError(status)
+}
+
+func releaseUnreapedProvider(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return
+	}
+	_ = cmd.Process.Release()
+}
+
+// reapDuringTermination reaps the owned leader concurrently with group
+// termination so a zombie can release the process-group ID. It never starts a
+// blocking cmd.Wait goroutine; if the leader remains live after termination
+// fails, the process handle is released instead of leaking a waiter.
+func reapDuringTermination(cmd *exec.Cmd, start string, termination *providerTermination) (error, bool) {
+	ticker := time.NewTicker(providerTerminationPollInterval)
+	defer ticker.Stop()
+	var waitErr error
+	reaped := false
+	for {
+		if !reaped {
+			done, err := reapOwnedProviderLeader(cmd, start)
+			if done {
+				reaped = true
+				waitErr = err
+			} else if err != nil && waitErr == nil {
+				waitErr = err
+			}
+		}
+		select {
+		case <-termination.done:
+			if !reaped {
+				done, err := reapOwnedProviderLeader(cmd, start)
+				if done {
+					reaped = true
+					waitErr = err
+				} else if err != nil && waitErr == nil {
+					waitErr = err
+				}
+			}
+			if !reaped {
+				releaseUnreapedProvider(cmd)
+			}
+			return waitErr, reaped
+		case <-ticker.C:
+		}
+	}
 }
 
 func installProviderSignalForwarder(requestTermination func()) (caught func() os.Signal, stop func()) {
@@ -285,13 +494,17 @@ func providerStartError(target string, err error) error {
 	return wrapExitError(ExitTargetFailure, fmt.Sprintf("start %s: %v", target, err), err)
 }
 
+type waitExitCoder interface {
+	ExitCode() int
+}
+
 func providerWaitError(target string, err error) error {
 	if err == nil {
 		return nil
 	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		code := exitErr.ExitCode()
+	var coder waitExitCoder
+	if errors.As(err, &coder) {
+		code := coder.ExitCode()
 		if code <= 0 {
 			code = 1
 		}

--- a/internal/agentdispatch/runtime_helpers.go
+++ b/internal/agentdispatch/runtime_helpers.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -94,7 +95,17 @@ func processIsZombie(pid int) bool {
 const (
 	providerTerminationGrace        = time.Second
 	providerTerminationPollInterval = 10 * time.Millisecond
+	// Darwin has no /proc, so identity and zombie probes exec ps. Pre-terminal
+	// observation is much slower there; termination still uses the 10ms poll.
+	darwinProviderObserveInterval = 250 * time.Millisecond
 )
+
+func providerObservePollInterval() time.Duration {
+	if runtime.GOOS == "darwin" {
+		return darwinProviderObserveInterval
+	}
+	return providerTerminationPollInterval
+}
 
 var (
 	errProviderGroupDead             = errors.New("provider process group is already dead")

--- a/internal/agentdispatch/runtime_helpers_test.go
+++ b/internal/agentdispatch/runtime_helpers_test.go
@@ -49,6 +49,56 @@ func TestProviderTerminationAllowsGracefulProcessGroupExit(t *testing.T) {
 	}
 }
 
+func TestProviderTerminationWaitsForZombieReaping(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	prepareProviderProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	reaped := false
+	t.Cleanup(func() {
+		if !reaped {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+	record := RunRecord{PID: cmd.Process.Pid, ProcessGroupID: cmd.Process.Pid, ProcessStartIdentity: processStartIdentity(cmd.Process.Pid)}
+	termination, err := newStartedProviderTermination(cmd, record, 500*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		out, err := exec.Command("ps", "-o", "stat=", "-p", strconv.Itoa(cmd.Process.Pid)).Output() // #nosec G204 -- test-owned PID.
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.HasPrefix(strings.TrimSpace(string(out)), "Z") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("test process did not become a zombie")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	termination.request()
+	select {
+	case <-termination.done:
+		t.Fatalf("termination returned before zombie reaping could prove group death: %v", termination.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	reaped = true
+	if err := termination.providerStopped(); err != nil {
+		t.Fatalf("reaped zombie group failed termination: %v", err)
+	}
+	if !providerProcessGroupDead(cmd.Process.Pid) {
+		t.Fatal("reaped test process retained a live group")
+	}
+}
+
 func TestProviderTerminationEscalatesAndUnblocksDescendantPipesAndWait(t *testing.T) {
 	childPIDPath := filepath.Join(t.TempDir(), "child.pid")
 	cmd := exec.Command("/bin/sh", "-c", `trap 'exit 0' TERM; (trap '' TERM; while :; do sleep 1; done) & child=$!; printf '%s\n' "$child" > "$1"; wait "$child"`, "sh", childPIDPath) // #nosec G204 -- fixed test-only shell command.

--- a/internal/agentdispatch/runtime_helpers_test.go
+++ b/internal/agentdispatch/runtime_helpers_test.go
@@ -6,12 +6,26 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
 )
+
+func TestProviderObservePollIntervalIsSlowerOnDarwin(t *testing.T) {
+	got := providerObservePollInterval()
+	if runtime.GOOS == "darwin" {
+		if got <= providerTerminationPollInterval {
+			t.Fatalf("darwin observe interval %s is not slower than termination poll %s", got, providerTerminationPollInterval)
+		}
+		return
+	}
+	if got != providerTerminationPollInterval {
+		t.Fatalf("observe interval = %s, want %s", got, providerTerminationPollInterval)
+	}
+}
 
 func TestProviderTerminationAllowsGracefulProcessGroupExit(t *testing.T) {
 	readyPath := filepath.Join(t.TempDir(), "ready")
@@ -284,8 +298,8 @@ func TestReapDuringTerminationReleasesUnreapedLeader(t *testing.T) {
 	if !errors.Is(termination.err, errProviderGroupIdentityMismatch) && !errors.Is(waitErr, errProviderGroupIdentityMismatch) {
 		t.Fatalf("unproven reused termination = wait %v terminate %v", waitErr, termination.err)
 	}
-	if unrelated.Process.Pid > 0 {
-		t.Fatal("unreaped reused leader was not released")
+	if err := unrelated.Process.Signal(syscall.Signal(0)); err == nil || !strings.Contains(err.Error(), "already released") {
+		t.Fatalf("unreaped reused leader was not released: %v", err)
 	}
 	if err := syscall.Kill(pid, 0); err != nil {
 		t.Fatalf("released reused leader was signalled: %v", err)

--- a/internal/agentdispatch/runtime_helpers_test.go
+++ b/internal/agentdispatch/runtime_helpers_test.go
@@ -158,6 +158,140 @@ func TestProviderTerminationEscalatesAndUnblocksDescendantPipesAndWait(t *testin
 	stopped = true
 }
 
+func TestTerminateDoesNotSignalReusedProcessGroup(t *testing.T) {
+	unrelated := exec.Command("/bin/sh", "-c", `trap '' TERM; while :; do sleep 1; done`) // #nosec G204 -- fixed test-only shell command.
+	prepareProviderProcessGroup(unrelated)
+	if err := unrelated.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := unrelated.Process.Pid
+	defer func() {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		_ = unrelated.Wait()
+	}()
+	current := processStartIdentity(pid)
+	if current == "" {
+		t.Fatal("process start identity is required for reuse tests")
+	}
+	group := ownedProviderProcessGroup{pid: pid, pgid: pid, start: current + "-other"}
+	if err := group.terminate(50 * time.Millisecond); !errors.Is(err, errProviderGroupIdentityMismatch) {
+		t.Fatalf("reused group terminate = %v, want identity mismatch", err)
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("reused process group was signalled: %v", err)
+	}
+}
+
+func TestProviderStoppedAfterReapDoesNotSignalWhenGroupDead(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	prepareProviderProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	record := RunRecord{PID: cmd.Process.Pid, ProcessGroupID: cmd.Process.Pid, ProcessStartIdentity: processStartIdentity(cmd.Process.Pid)}
+	termination, err := newStartedProviderTermination(cmd, record, 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	if err := termination.providerStopped(); err != nil {
+		t.Fatalf("dead group after reap: %v", err)
+	}
+	if termination.hasRequested() {
+		t.Fatal("providerStopped signalled a reaped group with no descendants")
+	}
+}
+
+func TestProviderStoppedAfterReapTerminatesDescendants(t *testing.T) {
+	childPIDPath := filepath.Join(t.TempDir(), "child.pid")
+	cmd := exec.Command("/bin/sh", "-c", `(trap '' TERM; while :; do sleep 1; done) & child=$!; printf '%s\n' "$child" > "$1"; exit 0`, "sh", childPIDPath) // #nosec G204 -- fixed test-only shell command.
+	prepareProviderProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	stopped := false
+	t.Cleanup(func() {
+		if !stopped {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+	})
+	childPID := waitForProviderChildPID(t, childPIDPath)
+	record := RunRecord{PID: cmd.Process.Pid, ProcessGroupID: cmd.Process.Pid, ProcessStartIdentity: processStartIdentity(cmd.Process.Pid)}
+	termination, err := newStartedProviderTermination(cmd, record, 75*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("leader exit: %v", err)
+	}
+	if err := termination.providerStopped(); err != nil {
+		t.Fatal(err)
+	}
+	waitForProviderProcessExit(t, childPID)
+	waitForProviderProcessGroupExit(t, cmd.Process.Pid)
+	stopped = true
+}
+
+func TestReapOwnedProviderLeaderDoesNotWaitOnReusedPID(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", `trap '' TERM; while :; do sleep 1; done`) // #nosec G204 -- fixed test-only shell command.
+	prepareProviderProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := cmd.Process.Pid
+	defer func() {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	}()
+	current := processStartIdentity(pid)
+	if current == "" {
+		t.Fatal("process start identity is required for reuse tests")
+	}
+	reaped, err := reapOwnedProviderLeader(cmd, current+"-other")
+	if reaped || !errors.Is(err, errProviderGroupIdentityMismatch) {
+		t.Fatalf("reap reused pid = %t, %v", reaped, err)
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("reap collected a reused process: %v", err)
+	}
+}
+
+func TestReapDuringTerminationReleasesUnreapedLeader(t *testing.T) {
+	unrelated := exec.Command("/bin/sh", "-c", `trap '' TERM; while :; do sleep 1; done`) // #nosec G204 -- fixed test-only shell command.
+	prepareProviderProcessGroup(unrelated)
+	if err := unrelated.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := unrelated.Process.Pid
+	current := processStartIdentity(pid)
+	if current == "" {
+		t.Fatal("process start identity is required for reuse tests")
+	}
+	defer func() {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		var status syscall.WaitStatus
+		_, _ = syscall.Wait4(pid, &status, 0, nil)
+	}()
+	group := ownedProviderProcessGroup{pid: pid, pgid: pid, start: current + "-other"}
+	termination := &providerTermination{group: group, grace: 50 * time.Millisecond, done: make(chan struct{})}
+	termination.request()
+	waitErr, reaped := reapDuringTermination(unrelated, current+"-other", termination)
+	if reaped {
+		t.Fatal("reaped a reused process group leader")
+	}
+	if !errors.Is(termination.err, errProviderGroupIdentityMismatch) && !errors.Is(waitErr, errProviderGroupIdentityMismatch) {
+		t.Fatalf("unproven reused termination = wait %v terminate %v", waitErr, termination.err)
+	}
+	if unrelated.Process.Pid > 0 {
+		t.Fatal("unreaped reused leader was not released")
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("released reused leader was signalled: %v", err)
+	}
+}
+
 func TestProviderTerminationRejectsMismatchedProcessIdentityWithoutSignalling(t *testing.T) {
 	cmd := exec.Command("/bin/sh", "-c", `trap '' TERM; while :; do sleep 1; done`) // #nosec G204 -- fixed test-only shell command.
 	prepareProviderProcessGroup(cmd)

--- a/internal/agentdispatch/runtime_test.go
+++ b/internal/agentdispatch/runtime_test.go
@@ -21,9 +21,15 @@ func TestProcStatStartTimeSurvivesCommWithSpacesAndParens(t *testing.T) {
 		if got := procStatStartTime(content); got != "777" {
 			t.Fatalf("comm %q shifted starttime: got %q", comm, got)
 		}
+		if got := procStatState(content); got != "S" {
+			t.Fatalf("comm %q shifted state: got %q", comm, got)
+		}
 	}
 	if got := procStatStartTime("no stat shape"); got != "" {
 		t.Fatalf("malformed stat produced identity %q", got)
+	}
+	if got := procStatState("no stat shape"); got != "" {
+		t.Fatalf("malformed stat produced state %q", got)
 	}
 }
 

--- a/internal/agentdispatch/state.go
+++ b/internal/agentdispatch/state.go
@@ -400,7 +400,7 @@ func cancelledClaimReleasable(record RunRecord) bool {
 	if record.PID == 0 && record.ProcessGroupID == 0 && record.ProcessStartIdentity == "" {
 		return true
 	}
-	return processOwnership(record) == ownershipDead && providerProcessGroupDead(record.ProcessGroupID)
+	return processOwnership(record) == ownershipDead && (providerProcessGroupDead(record.ProcessGroupID) || providerProcessGroupReused(record))
 }
 
 // sessionOwnerRunID resolves the explicit active claim and the compatibility

--- a/internal/agentdispatch/types.go
+++ b/internal/agentdispatch/types.go
@@ -129,10 +129,12 @@ type ContinueOptions struct {
 // tools decode that same rendering from a private buffer, so both surfaces
 // report identical handles, states, result paths, and failure text.
 type Result struct {
-	Handle     string `json:"handle"`
-	State      string `json:"state"`
-	ResultPath string `json:"result_path,omitempty"`
-	Error      string `json:"error,omitempty"`
+	Handle         string     `json:"handle"`
+	State          string     `json:"state"`
+	ResultPath     string     `json:"result_path,omitempty"`
+	Error          string     `json:"error,omitempty"`
+	LastActivityAt *time.Time `json:"last_activity_at,omitempty"`
+	LastOutputAt   *time.Time `json:"last_output_at,omitempty"`
 }
 
 // WaitRequest identifies one existing dispatch conversation, by handle, to

--- a/internal/agentdispatch/wait.go
+++ b/internal/agentdispatch/wait.go
@@ -55,7 +55,10 @@ func Wait(request WaitRequest) error {
 		}
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
-			return writePublicResult(writerOrDiscard(request.Stdout), Result{Handle: session.Name, State: dispatchStateRunning})
+			return writePublicResult(writerOrDiscard(request.Stdout), Result{
+				Handle: session.Name, State: dispatchStateRunning,
+				LastActivityAt: record.LastActivityAt, LastOutputAt: record.LastOutputAt,
+			})
 		}
 		pollDelay := min(interval, remaining)
 		select {

--- a/internal/agentdispatch/wait_test.go
+++ b/internal/agentdispatch/wait_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -110,6 +112,10 @@ func TestWaitYieldsRunningWithoutChangingInvocation(t *testing.T) {
 	run.Record.State = dispatchStateRunning
 	run.Record.SupervisorPID = os.Getpid()
 	run.Record.SupervisorStartIdentity = processStartIdentity(os.Getpid())
+	activity := time.Now().UTC().Add(-time.Minute)
+	output := activity.Add(-time.Minute)
+	run.Record.LastActivityAt = &activity
+	run.Record.LastOutputAt = &output
 	if err := writeRunRecord(run.Dir, &run.Record); err != nil {
 		t.Fatal(err)
 	}
@@ -128,6 +134,9 @@ func TestWaitYieldsRunningWithoutChangingInvocation(t *testing.T) {
 	}
 	if got.Handle != session.Name || got.State != dispatchStateRunning {
 		t.Fatalf("wait result = %#v", got)
+	}
+	if got.LastActivityAt == nil || !got.LastActivityAt.Equal(activity) || got.LastOutputAt == nil || !got.LastOutputAt.Equal(output) {
+		t.Fatalf("wait lost recorded activity timestamps: %#v", got)
 	}
 	current, err := loadRunRecord(root, run.Record.ID)
 	if err != nil {
@@ -228,6 +237,96 @@ func TestWaitFailsInvocationAbandonedBeforeWorkerLaunch(t *testing.T) {
 	}
 	if got.State != dispatchStateFailed || got.Error != "dispatch was interrupted before launching its worker" {
 		t.Fatalf("wait result = %#v", got)
+	}
+}
+
+func TestWaitRetainsOrphanClaimWhileDescendantsSurvive(t *testing.T) {
+	root := t.TempDir()
+	run, session := newWaitTestRun(t, root)
+	childPath := filepath.Join(root, "child.pid")
+	cmd := exec.Command("/bin/sh", "-c", `sleep 60 & echo $! > "$1"`, "sh", childPath) // #nosec G204 -- fixed test command and test-owned path.
+	prepareProviderProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) })
+	waitForProviderChildPID(t, childPath)
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	run.Record.State = dispatchStateRunning
+	run.Record.PID = cmd.Process.Pid
+	run.Record.ProcessGroupID = cmd.Process.Pid
+	run.Record.ProcessStartIdentity = "reaped-leader"
+	if err := writeRunRecord(run.Dir, &run.Record); err != nil {
+		t.Fatal(err)
+	}
+	err := Wait(WaitRequest{Root: root, ID: session.Name, Timeout: time.Millisecond})
+	requireDispatchExitCode(t, err, ExitUnavailable)
+	current, err := loadSession(root, session.Name)
+	if err != nil || current.ActiveRunID != run.Record.ID {
+		t.Fatalf("orphan recovery released a live descendant claim: %#v, %v", current, err)
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		t.Fatal(err)
+	}
+	waitForProviderProcessGroupExit(t, cmd.Process.Pid)
+	requireDispatchExitCode(t, Wait(WaitRequest{Root: root, ID: session.Name}), ExitTargetFailure)
+	current, err = loadSession(root, session.Name)
+	if err != nil || current.ActiveRunID != "" {
+		t.Fatalf("dead orphan claim was not released: %#v, %v", current, err)
+	}
+}
+
+func TestWaitRecoversReusedProcessGroupWithoutSignallingIt(t *testing.T) {
+	for _, state := range []string{dispatchStateRunning, dispatchStateCancelled} {
+		t.Run(state, func(t *testing.T) {
+			root := t.TempDir()
+			run, session := newWaitTestRun(t, root)
+			unrelated := exec.Command("sleep", "60")
+			prepareProviderProcessGroup(unrelated)
+			if err := unrelated.Start(); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = unrelated.Process.Kill(); _ = unrelated.Wait() })
+			run.Record.State = state
+			run.Record.PID = unrelated.Process.Pid
+			run.Record.ProcessGroupID = unrelated.Process.Pid
+			run.Record.ProcessStartIdentity = "previous-owner"
+			if state == dispatchStateCancelled {
+				now := time.Now().UTC()
+				run.Record.CompletedAt = &now
+			}
+			if err := writeRunRecord(run.Dir, &run.Record); err != nil {
+				t.Fatal(err)
+			}
+			err := Wait(WaitRequest{Root: root, ID: session.Name, Timeout: time.Millisecond})
+			if state == dispatchStateRunning {
+				requireDispatchExitCode(t, err, ExitTargetFailure)
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			wantActive := ""
+			if state == dispatchStateCancelled {
+				// Cancelled waits are idempotent reads. A replacement claim is
+				// the boundary that checks whether cancelled work still lives.
+				replacement, err := newDispatchRun(root, AgentCodex, supportedProviderVersions[AgentCodex], dispatchModeResume)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := claimConversation(root, session.Name, replacement.Record.ID); err != nil {
+					t.Fatal(err)
+				}
+				wantActive = replacement.Record.ID
+			}
+			current, err := loadSession(root, session.Name)
+			if err != nil || current.ActiveRunID != wantActive {
+				t.Fatalf("reused group prevented claim recovery: %#v, %v", current, err)
+			}
+			if err := unrelated.Process.Signal(syscall.Signal(0)); err != nil {
+				t.Fatalf("recovery signalled an unrelated process: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/templates/skills/ship-pr/SKILL.md
+++ b/internal/templates/skills/ship-pr/SKILL.md
@@ -28,10 +28,14 @@ Unless the user narrows the scope, include the entire current working tree.
    and fill `assets/pr-body-template.md`, removing unused sections and
    placeholders.
 
-2. Start one watcher in a managed background session. Keep it running until the
-   PR merges or the workflow stops, then stop it. If it exits after a transient
-   transport failure, refetch authoritative state and restart it with the same
-   append-only log.
+2. Start one watcher in a managed background session and retain its task/session
+   ID. Keep it running while actively monitoring the PR. Before returning to the
+   caller for authorization, a blocker, or any other handoff, stop this watcher
+   through its managed session and verify it has stopped. Antigravity print mode
+   can withhold a saved final response while a managed background task is running.
+   If monitoring resumes, restart the watcher with the same append-only log;
+   refetch authoritative state first, including after a transient transport
+   failure. Stop the watcher when the PR merges or the workflow ends.
 
    ```bash
    bash <skill_dir>/scripts/watch-pr-events.sh \
@@ -81,14 +85,15 @@ Unless the user narrows the scope, include the entire current working tree.
    reply. Return to step 3 until ready. If only checks or reviews are pending,
    wait for the watcher.
 
-5. Request single-use merge authorization for the exact PR and head. Report any
-   substantive findings, a concise comment disposition summary, and readiness
-   evidence.
+5. Stop the watcher and verify it has stopped before returning the single-use
+   merge authorization request for the exact PR and head. Report any substantive
+   findings, a concise comment disposition summary, and readiness evidence.
 
 6. After authorization, refetch the head, checks, mergeability, and comments.
    Confirm the local tree is complete and every eligible comment has a supported
-   posted reply. If anything changed, return to step 3 and obtain new
-   authorization for the resulting PR head; otherwise merge.
+   posted reply. If anything changed, restart the watcher as described in step 2,
+   return to step 3, and obtain new authorization for the resulting PR head;
+   otherwise merge.
 
 7. Confirm the checkout is clean, switch to the default branch, fast-forward it,
    and delete branches or worktrees created by this workflow. Preserve state and


### PR DESCRIPTION
## Summary

- Preserve provider conversation identity across failed Antigravity handoffs and safe continuation.
- Bound provider shutdown and descendant cleanup so terminal evidence cannot leave overlapping work or hidden live pipes.
- Retain active claims when orphaned descendants or process-ID reuse make ownership unprovable.

## Changes

- Persist Antigravity `init` conversation IDs, expose running wait activity/output timestamps, and reject continuation without proven provider acceptance unless recovery marked a retry safe.
- Separate provider shutdown/output-drain deadlines from process-group termination proof, use unlinked temporary stdin files, and guard process-group recovery against reused identities.
- Add lifecycle, handoff, runner, orphan recovery, MCP, and documentation/template coverage.

## Verification

- `make fmt-check` — passed
- `make lint` — passed
- `make test-race` — passed
- `make test` — passed: 4,043 tests, 1 environment-dependent skip
- Pre-commit hooks — passed, including `go test ./...`

## Notes

- The environment-dependent skipped test could not create a symlink containing invalid UTF-8 on macOS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Running dispatch results now include the latest activity and output timestamps.
  - Conversation session identity is retained across handoffs and certain unsuccessful runs.

- **Bug Fixes**
  - Improved process shutdown, descendant cleanup, and orphan recovery to avoid disrupting unrelated processes.
  - Continuation now prevents unsafe retries when provider session identity is unknown.
  - Provider progress, output, and completion states are handled more reliably during failures and timeouts.

- **Documentation**
  - Expanded guidance for timestamps, continuation, recovery, shutdown, and managed task workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->