### PR TITLE
feat: discover harness models for Claude, Codex, Grok, and Antigravity

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Run `al wizard` any time to interactively configure the most important settings:
 
 - **Approvals Mode** (all, mcp, commands, none, yolo)
 - **Agent Enablement** (Antigravity, Claude, Codex, VS Code, Copilot CLI, Grok)
-- **Model Selection** (optional; leave blank to use client defaults. Antigravity model names include reasoning level in the `agy models` display string; Claude, Codex, and Grok expose reasoning effort separately where supported)
+- **Model Selection** (optional; leave blank to use client defaults. Claude, Codex, Grok, and Antigravity suggestions come exclusively from the installed harnesses, queried concurrently without sync. Discovery failure stops the interactive picker; there are no bundled model lists or fallbacks. Scripted answers supply explicit values without discovery. Copilot CLI offers manual model entry only. Antigravity exposes native slugs and display names; Claude, Codex, and Grok expose reasoning effort separately where supported)
 - **Feature toggles** — folded into the model step as three per-agent multi-selects (Claude, Codex, and Grok). Each feature is a checkbox where **checked = keep enabled** and unchecking disables it; checkboxes are pre-checked to match your current config, so re-running the wizard without changes makes no edits.
     - *Claude:* IDE open-file reading, auto-memory, claude.ai connectors, the AskUserQuestion tool, and the Claude status line.
     - *Codex:* built-in apps (GitHub, Gmail, etc.), browser/computer-use, and the Codex status line.

--- a/cmd/al/dispatch.go
+++ b/cmd/al/dispatch.go
@@ -83,7 +83,7 @@ func newDispatchOptionsCmd() *cobra.Command {
 				return err
 			}
 			return dispatchCommandError(cmd, agentdispatch.WriteOptions(agentdispatch.OptionsRequest{
-				Root: root, Env: os.Environ(), Stdout: cmd.OutOrStdout(),
+				Context: cmd.Context(), Root: root, Env: os.Environ(), Stdout: cmd.OutOrStdout(),
 			}))
 		},
 	}

--- a/cmd/al/doctor.go
+++ b/cmd/al/doctor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
+	"github.com/conn-castle/agent-layer/internal/agentoptions"
 	"github.com/conn-castle/agent-layer/internal/config"
 	"github.com/conn-castle/agent-layer/internal/doctor"
 	"github.com/conn-castle/agent-layer/internal/messages"
@@ -25,6 +26,7 @@ var (
 	measureInstructions = warnings.MeasureInstructions
 	checkMCPServers     = warnings.CheckMCPServers
 	checkPolicy         = warnings.CheckPolicy
+	checkModels         = doctor.CheckModels
 )
 
 func newDoctorCmd() *cobra.Command {
@@ -50,6 +52,15 @@ func newDoctorCmd() *cobra.Command {
 			// 2. Check Config
 			configResults, cfg := doctor.CheckConfig(root)
 			allResults = append(allResults, configResults...)
+			// Start discovery alongside the remaining checks; no sync is needed.
+			modelsDone := make(chan []doctor.Result, 1)
+			if cfg != nil {
+				go func() {
+					req := agentoptions.DefaultDiscoveryRequest()
+					req.Context = cmd.Context()
+					modelsDone <- checkModels(cfg, req)
+				}()
+			}
 
 			updateResult := doctor.Result{CheckName: messages.DoctorCheckNameUpdate}
 			if strings.TrimSpace(os.Getenv(versiondispatch.EnvNoNetwork)) != "" {
@@ -109,6 +120,7 @@ func newDoctorCmd() *cobra.Command {
 
 				// 7. Check CLI Skills (catalog-installed skills' binaries on PATH).
 				allResults = append(allResults, doctor.CheckCLISkills(cfg)...)
+				allResults = append(allResults, <-modelsDone...)
 			}
 
 			hasFail := false

--- a/docs/AGENT-DISPATCH.md
+++ b/docs/AGENT-DISPATCH.md
@@ -114,6 +114,33 @@ al dispatch cancel <handle-or-invocation-id>
 `options` returns the known dispatch agents, their current availability, configured
 defaults, and supported model and reasoning-effort overrides.
 
+Model suggestions are discovered from the installed Claude, Codex, Grok, and
+Antigravity harnesses, concurrently and without sync or an inference prompt.
+Discovery uses the same project environment and provider configuration helpers
+as launching an agent. Each lookup has a ten-second timeout. Model fields report
+`source: "harness"` on success; when discovery fails, they report
+`source: "unavailable"`, `discovery_error`, and an empty suggestions list.
+Skipped lookups report `source: "not_requested"`. No model catalog or fallback
+is shipped. The `catalog` source is reserved for non-model option metadata.
+Suggestions are not an exhaustive account-access guarantee: custom model IDs
+and aliases remain accepted. Starting or continuing a dispatch does not repeat
+model discovery. `AL_NO_NETWORK` disables live model discovery.
+
+Wizard starts concurrent discovery only on entering model selection and reuses
+results through back navigation. A discovery error stops the interactive picker.
+Scripted model answers are explicit inputs and do not trigger discovery. Copilot
+CLI offers manual entry, not static suggestions. Doctor checks only enabled
+harnesses with configured model overrides and reports discovery
+failures or configured models absent from their lists as warnings. Neither
+operation syncs as part of model discovery. Discovery may create the normal
+repo-local `.agy` and `.grok-config` directories when absent; it does not sync
+configuration or create dispatch runs.
+
+Each explicit dispatch-options request obtains fresh results; no persistent
+model cache is used. Provider-version queries also run concurrently. Launch,
+sync, and dispatch start/continue do not run model queries just to pass through
+an explicit configuration value or use the harness default.
+
 `start` requires an agent and exactly one prompt source. Model and reasoning
 effort are optional overrides. When omitted, Agent Layer uses its configured
 value; when that is also empty, it omits the provider flag so the provider uses

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -13,6 +13,20 @@ You need:
 
 Run all commands from the project root.
 
+New experiment model identities may use `<provider>/<model>` (for example,
+`codex/<native-model-id>`), with `reasoning` supplied separately. The provider
+is `claude`, `codex`, `grok`, or `antigravity`. This avoids a maintained runtime
+model allowlist. Historical short names remain readable solely to preserve old
+study identities; parsing an identity does not verify current model support.
+Published comparison evidence must still correspond to the selected identity.
+
+Antigravity and Grok runtime preflights capture model lists from the pinned
+harness inside the benchmark container. The host validates those bytes using
+the same Go parsers as Wizard, Doctor, and Dispatch, including authentication
+failure detection. Container transport does not maintain a separate model
+parser or fallback list. These checks run during runtime preflight, not on
+every paid task invocation.
+
 ## Recommended workflow
 
 ### 1. Create the study

--- a/docs/agent-layer/BACKLOG.md
+++ b/docs/agent-layer/BACKLOG.md
@@ -33,29 +33,23 @@ Unscheduled user-visible features and tasks (distinct from issues; not refactors
     Acceptance criteria: Dispatch cleanup removes stale zero-byte `.lock` files without affecting active work, retains a documented useful window of completed results/history, and automatically caps or archives older records so `.agent-layer/state/dispatch` and related state/log storage cannot grow without bound.
     Notes: Observed cleanup found 212 JSON dispatch records paired with 212 zero-byte `.lock` files under `.agent-layer/state/dispatch`, plus dispatch capability-cache state; make retention recoverable and safe for in-flight dispatches. Confirmed evidence expiry exists; lock-file unlinking while flocked is unsafe and is not part of that policy.
 
-- Backlog 2026-08-17 grok-live-models: Use `grok models` for wizard and dispatch suggestions
-    Priority: Medium. Area: providers / grok / dispatch / wizard
-    Description: Replace the hardcoded Grok model catalog (`grok-4.6`, `grok-4.5`) with live `grok models` output so wizard and dispatch suggestions stay current.
-    Acceptance criteria: Wizard discovery and `al dispatch start` validation share one provider-backed Grok model path with catalog fallback; custom values remain allowed.
-    Notes: Fits the existing `shared-live-options` backlog; Grok is the remaining live-source gap after Antigravity.
-
 - Backlog 2026-08-17 grok-dispatch-usage: Keep Grok dispatch usage/cost events
     Priority: Low. Area: providers / grok / dispatch
     Description: Record Grok streaming `usage` events instead of dropping them in `reduceGrokEvent`, so dispatch results can report cost like Claude/Codex.
     Acceptance criteria: A completed Grok dispatch retains observed usage when the stream includes it; missing usage stays explicitly absent rather than inferred.
     Notes: Current reducer returns nil for `usage` events.
 
-- Backlog 2026-07-09 copilot-cli-gpt-5.6-models: Advertise GPT-5.6 models for GitHub Copilot CLI
-    Priority: Medium. Area: providers / copilot-cli / dispatch / wizard
-    Description: Add Sol, Terra, and Luna to the separate Copilot CLI model catalog after verifying the exact provider-native identifiers, so wizard and dispatch users do not need custom values.
-    Acceptance criteria: Provider-specific CLI evidence confirms the identifiers; the shared Copilot CLI catalog, exact catalog test, wizard, and dispatch validation accept all three models while preserving custom values.
-    Notes: GitHub's 2026-07-09 changelog confirms gradual Copilot CLI availability; deferred from PR #135 because that reviewed plan is scoped to the Codex provider catalog.
+- Backlog 2026-07-09 copilot-cli-model-discovery: Discover GitHub Copilot CLI models
+    Priority: Medium. Area: providers / copilot-cli / wizard
+    Description: Add a verified native discovery adapter for Copilot CLI to replace manual-only model entry.
+    Acceptance criteria: Suggestions come exclusively from the installed harness through the shared Go discovery boundary; no static catalog or fallback is introduced.
+    Notes: Static Copilot model suggestions were removed. Explicit model values remain supported; Copilot CLI is not a dispatch provider.
 
-- Backlog 2026-06-30 shared-live-options: Use shared live option providers for wizard and dispatch validation
+- Backlog 2026-06-30 shared-live-options: Discover reasoning-effort suggestions from harnesses
     Priority: Medium. Area: providers / dispatch / wizard
-    Description: Replace hard-coded model/reasoning suggestions with provider-backed discovery where a client exposes an authoritative source: Codex model and reasoning suggestions from `codex debug models`, Claude reasoning-effort choices from CLI help where available, and Antigravity models from `agy models`.
-    Acceptance criteria: Wizard discovery and `al dispatch start` validation share one provider-backed option path with catalog fallbacks; no agent gets a one-off wizard or dispatch special case; Codex models/efforts come from the local CLI catalog; Antigravity models come from `agy models`; Claude efforts come from local help; Claude model suggestions remain catalog-backed or custom-only unless Claude exposes an authoritative model list.
-    Notes: Wizard and dispatch now share `internal/agentoptions` for provider-backed options; remaining work is adding Codex/Claude live sources. Keep custom overrides allowed, and do not parse Claude model examples as a complete catalog.
+    Description: Replace hard-coded reasoning-effort suggestions with provider-backed discovery where an authoritative source is available.
+    Acceptance criteria: Wizard and dispatch share reasoning metadata from harness discovery, retain explicit fallback diagnostics, and preserve custom overrides.
+    Notes: Model discovery is implemented for Claude, Codex, Grok, and Antigravity. Remaining work is reasoning metadata and its model-dependent presentation; Claude initialization and Codex model/list already expose candidate capability fields.
 
 - Backlog 2026-06-15 interactive-html-review-skill: Skill to make any HTML output file browser-commentable
     Priority: High. Area: skills / UX

--- a/docs/agent-layer/COMMANDS.md
+++ b/docs/agent-layer/COMMANDS.md
@@ -118,6 +118,16 @@ Notes: Runs `deadcode -test` from `./cmd/al` and `./cmd/publish-site` roots; use
 
 ### Test
 
+- Benchmark live harness model discovery through the production Go no-sync path
+```bash
+AL_MODEL_DISCOVERY_BENCHMARK_ROOT="$PWD" go test ./internal/agentoptions -run '^$' -bench BenchmarkLiveModelDiscovery -benchtime=3x -count=1
+```
+Run from: repo root
+Prerequisites: Installed, authenticated harnesses and an initialized project.
+Notes: Uses project launch configuration without sync or inference. Each iteration
+starts a harness; upstream caches are not cleared. Authentication/discovery
+failures fail the affected benchmark instead of timing bundled fallback results.
+
 - Run all tests
 ```bash
 make test

--- a/internal/agentdispatch/dispatch_behavior_test.go
+++ b/internal/agentdispatch/dispatch_behavior_test.go
@@ -2,17 +2,42 @@ package agentdispatch
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/conn-castle/agent-layer/internal/agentoptions"
 )
+
+func TestOptionsCancellationStopsVersionProbes(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	binary := filepath.Join(t.TempDir(), "slow-provider")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nexec sleep 30\n"), 0o700); err != nil { // #nosec G306 -- executable provider fixture.
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	options, err := BuildOptions(OptionsRequest{
+		Root: root, Context: ctx, Env: []string{},
+		LookPath: func(string) (string, error) { return binary, nil },
+	})
+	if !errors.Is(err, context.DeadlineExceeded) || options != nil {
+		t.Fatalf("cancelled options request returned options=%+v err=%v", options, err)
+	}
+	if elapsed := time.Since(started); elapsed > 3*time.Second {
+		t.Fatalf("version probes outlived request cancellation: %v", elapsed)
+	}
+}
 
 func TestOptionsExposeOnlyStartSelectionFacts(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{})
@@ -155,11 +180,15 @@ func TestNewerProviderVersionDispatchWarnsOnStderrOnly(t *testing.T) {
 
 func TestBuildOptionsResolvesEachProviderBinaryOnce(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	replaceDispatchConfigText(t, root, "[agents.grok]\nenabled = false", "[agents.grok]\nenabled = true")
 	lookups := map[string]int{}
+	var mu sync.Mutex
 	_, err := BuildOptions(OptionsRequest{
 		Root: root,
 		Env:  []string{},
 		LookPath: func(binary string) (string, error) {
+			mu.Lock()
+			defer mu.Unlock()
 			lookups[binary]++
 			return "/mock/" + binary, nil
 		},
@@ -174,6 +203,51 @@ func TestBuildOptionsResolvesEachProviderBinaryOnce(t *testing.T) {
 		binary := target.Binary
 		if lookups[binary] != 1 {
 			t.Fatalf("LookPath(%q) calls = %d, want 1", binary, lookups[binary])
+		}
+	}
+}
+
+func TestOptionsVersionQueriesRunConcurrently(t *testing.T) {
+	root := writeDispatchRepo(t, dispatchRepoConfig{})
+	replaceDispatchConfigText(t, root, "[agents.grok]\nenabled = false", "[agents.grok]\nenabled = true")
+	started := make(chan string, 4)
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		_, err := BuildOptions(OptionsRequest{Root: root, Env: []string{"AL_NO_NETWORK=1"}, LookPath: alwaysFound,
+			VersionLookup: func(_ string, agent string) (string, error) {
+				started <- agent
+				<-release
+				return supportedProviderVersions[agent], nil
+			}})
+		done <- err
+	}()
+	for range 4 {
+		select {
+		case <-started:
+		case <-time.After(5 * time.Second):
+			close(release)
+			<-done
+			t.Fatal("provider version queries were serialized")
+		}
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOptionsSkipsDisabledProviderQueries(t *testing.T) {
+	options := buildTargetOptions(dispatchTestConfig(AgentCodex), agentoptions.DiscoveryRequest{Live: true,
+		LookPath: func(binary string) (string, error) {
+			if binary != AgentCodex {
+				t.Errorf("queried disabled provider %s", binary)
+			}
+			return "", os.ErrNotExist
+		}})
+	for _, option := range options {
+		if option.Agent != AgentCodex && (option.Available || option.Model.Source != "not_requested" || len(option.Model.Suggestions) != 0) {
+			t.Errorf("unexpected disabled provider metadata: %+v", option)
 		}
 	}
 }

--- a/internal/agentdispatch/dispatch_test.go
+++ b/internal/agentdispatch/dispatch_test.go
@@ -113,11 +113,8 @@ func TestBuildOptionsJSONShape(t *testing.T) {
 			claude = target
 		}
 	}
-	if !claude.Model.OverrideSupported || len(claude.Model.Suggestions) == 0 || !claude.Model.AllowCustom {
+	if !claude.Model.OverrideSupported || len(claude.Model.Suggestions) != 0 || !claude.Model.AllowCustom || claude.Model.DiscoveryError == "" || claude.Model.Source != "unavailable" {
 		t.Fatalf("unexpected claude model metadata: %#v", claude.Model)
-	}
-	if want := config.FieldOptionValues(config.ClaudeModelFieldKey); !slices.Equal(claude.Model.Suggestions, want) {
-		t.Fatalf("claude model suggestions = %v, want shared catalog %v", claude.Model.Suggestions, want)
 	}
 	var codex AgentOption
 	for _, target := range options.Agents {
@@ -125,11 +122,8 @@ func TestBuildOptionsJSONShape(t *testing.T) {
 			codex = target
 		}
 	}
-	if !codex.Model.OverrideSupported || !codex.Model.AllowCustom {
+	if !codex.Model.OverrideSupported || len(codex.Model.Suggestions) != 0 || !codex.Model.AllowCustom || codex.Model.DiscoveryError == "" || codex.Model.Source != "unavailable" {
 		t.Fatalf("unexpected codex model metadata: %#v", codex.Model)
-	}
-	if want := config.FieldOptionValues(config.CodexModelFieldKey); !slices.Equal(codex.Model.Suggestions, want) {
-		t.Fatalf("codex model suggestions = %v, want shared catalog %v", codex.Model.Suggestions, want)
 	}
 	if !codex.ReasoningEffort.OverrideSupported || !codex.ReasoningEffort.AllowCustom {
 		t.Fatalf("unexpected codex reasoning effort metadata: %#v", codex.ReasoningEffort)
@@ -146,7 +140,7 @@ func TestBuildOptionsJSONShape(t *testing.T) {
 	if !agy.Model.OverrideSupported || agy.Model.Configured != "Gemini 3.1 Pro (High)" || !agy.Model.AllowCustom {
 		t.Fatalf("unexpected antigravity model metadata: %#v", agy.Model)
 	}
-	if !slices.Contains(agy.Model.Suggestions, "Gemini 3.1 Pro (High)") {
+	if len(agy.Model.Suggestions) != 0 || agy.Model.DiscoveryError == "" {
 		t.Fatalf("unexpected antigravity model suggestions: %#v", agy.Model.Suggestions)
 	}
 	if agy.ReasoningEffort.OverrideSupported {
@@ -158,8 +152,8 @@ func TestBuildOptionsUsesTargetModelSuggestionProvider(t *testing.T) {
 	root := writeDispatchRepo(t, dispatchRepoConfig{})
 	binDir := t.TempDir()
 	logPath := filepath.Join(t.TempDir(), "agy.log")
-	writeDispatchStub(t, binDir, "agy", `if [ "$1" = "models" ]; then
-  printf 'Live Antigravity Model\nBackup Antigravity Model\n'
+	writeDispatchStub(t, binDir, "agy", `if [ "$2" = "models" ]; then
+  printf 'live\tLive Antigravity Model\nbackup\tBackup Antigravity Model\n'
 fi`)
 
 	options, err := BuildOptions(OptionsRequest{
@@ -180,10 +174,11 @@ fi`)
 		}
 	}
 	got := strings.Join(agy.Model.Suggestions, ",")
-	if got != "Live Antigravity Model,Backup Antigravity Model" {
+	if got != "live,Live Antigravity Model,backup,Backup Antigravity Model" {
 		t.Fatalf("antigravity suggestions = %q", got)
 	}
-	assertFileContains(t, logPath, "ARG_0=models")
+	assertFileContains(t, logPath, "ARG_0=--gemini_dir="+filepath.Join(root, ".agy"))
+	assertFileContains(t, logPath, "ARG_1=models")
 	assertFileContains(t, logPath, "AGY_CLI_DISABLE_AUTO_UPDATE=1")
 }
 

--- a/internal/agentdispatch/mcp.go
+++ b/internal/agentdispatch/mcp.go
@@ -300,7 +300,7 @@ func (s *dispatchToolServer) handleOptions(ctx context.Context, _ *mcp.CallToolR
 	if err := ctx.Err(); err != nil {
 		return nil, nil, err
 	}
-	options, err := BuildOptions(OptionsRequest{Root: s.root, Env: s.env})
+	options, err := BuildOptions(OptionsRequest{Context: ctx, Root: s.root, Env: s.env})
 	if err != nil {
 		return nil, nil, toolError(err)
 	}

--- a/internal/agentdispatch/options.go
+++ b/internal/agentdispatch/options.go
@@ -1,10 +1,12 @@
 package agentdispatch
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/conn-castle/agent-layer/internal/agentoptions"
 	"github.com/conn-castle/agent-layer/internal/config"
@@ -36,6 +38,8 @@ type FieldOption struct {
 	Configured        string   `json:"configured"`
 	Suggestions       []string `json:"suggestions"`
 	AllowCustom       bool     `json:"allow_custom"`
+	Source            string   `json:"source,omitempty"`
+	DiscoveryError    string   `json:"discovery_error,omitempty"`
 }
 
 type targetDiscovery struct {
@@ -68,11 +72,19 @@ func BuildOptions(req OptionsRequest) (*OptionsResponse, error) {
 		return nil, exitError(ExitConfig, err.Error())
 	}
 	versionLookup := req.VersionLookup
-	return &OptionsResponse{Agents: buildTargetOptions(
+	ctx := req.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	options := &OptionsResponse{Agents: buildTargetOptions(
 		project.Config,
-		agentoptions.DiscoveryRequest{Env: env, LookPath: lookPath, Live: true},
+		agentoptions.DiscoveryRequest{Context: ctx, Project: project, Env: env, LookPath: lookPath, Live: true},
 		versionLookup,
-	)}, nil
+	)}
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return options, nil
 }
 
 // WriteOptions renders the discovery contract as one JSON object.
@@ -91,37 +103,49 @@ func buildTargetOptions(cfg config.Config, discovery agentoptions.DiscoveryReque
 		lookup = lookups[0]
 	}
 	targets := targetRegistry()
-	result := make([]AgentOption, 0, len(targets))
-	for _, target := range targets {
-		facts := discoverTarget(cfg, target, discovery.LookPath, rawTargetVersionDiscovery(lookup))
-		fieldDiscovery := discovery
-		if !facts.Fresh.Supported {
-			fieldDiscovery.Live = false
-		} else {
-			resolvedPath := facts.Target.Binary
-			fieldDiscovery.LookPath = func(binary string) (string, error) {
-				if binary == target.Binary {
-					return resolvedPath, nil
-				}
-				return discovery.LookPath(binary)
+	result := make([]AgentOption, len(targets))
+	var workers sync.WaitGroup
+	for i, target := range targets {
+		workers.Go(func() {
+			facts := targetDiscovery{Target: target, Fresh: CapabilityOption{Reason: "disabled in config"}}
+			if targetEnabled(cfg, target.Name) {
+				facts = discoverTarget(cfg, target, discovery.LookPath, rawTargetVersionDiscovery(discovery.Context, lookup))
 			}
-		}
-		result = append(result, AgentOption{
-			Agent:             target.Name,
-			Available:         facts.Fresh.Supported,
-			UnavailableReason: facts.Fresh.Reason,
-			Model:             fieldOptionWithDiscovery(cfg, target, agentoptions.KindModel, fieldDiscovery),
-			ReasoningEffort:   fieldOptionWithDiscovery(cfg, target, agentoptions.KindReasoningEffort, fieldDiscovery),
+			fieldDiscovery := discovery
+			if !facts.Fresh.Supported {
+				fieldDiscovery.Live = false
+			} else {
+				resolvedPath := facts.Target.Binary
+				fieldDiscovery.LookPath = func(binary string) (string, error) {
+					if binary == target.Binary {
+						return resolvedPath, nil
+					}
+					return discovery.LookPath(binary)
+				}
+			}
+			result[i] = AgentOption{
+				Agent:             target.Name,
+				Available:         facts.Fresh.Supported,
+				UnavailableReason: facts.Fresh.Reason,
+				Model:             fieldOptionWithDiscovery(cfg, target, agentoptions.KindModel, fieldDiscovery),
+				ReasoningEffort:   fieldOptionWithDiscovery(cfg, target, agentoptions.KindReasoningEffort, fieldDiscovery),
+			}
 		})
 	}
+	workers.Wait()
 	return result
 }
 
-func rawTargetVersionDiscovery(lookup func(string, string) (string, error)) targetVersionDiscovery {
+func rawTargetVersionDiscovery(ctx context.Context, lookup func(string, string) (string, error)) targetVersionDiscovery {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	return func(path string, target targetMeta) (string, string, error) {
 		readVersion := lookup
 		if readVersion == nil {
-			readVersion = providerVersion
+			readVersion = func(path, agent string) (string, error) {
+				return providerVersionWithContext(ctx, path, agent)
+			}
 		}
 		installed, err := readVersion(path, target.Name)
 		if err != nil {
@@ -162,5 +186,5 @@ func discoverTarget(cfg config.Config, target targetMeta, lookPath func(string) 
 
 func fieldOptionWithDiscovery(cfg config.Config, target targetMeta, kind agentoptions.Kind, discovery agentoptions.DiscoveryRequest) FieldOption {
 	resolved := agentoptions.Resolve(cfg, target.Name, kind, discovery)
-	return FieldOption{OverrideSupported: resolved.OverrideSupported, Configured: resolved.Configured, Suggestions: resolved.Suggestions, AllowCustom: resolved.AllowCustom}
+	return FieldOption{OverrideSupported: resolved.OverrideSupported, Configured: resolved.Configured, Suggestions: resolved.Suggestions, AllowCustom: resolved.AllowCustom, Source: resolved.Source, DiscoveryError: resolved.DiscoveryError}
 }

--- a/internal/agentdispatch/provider.go
+++ b/internal/agentdispatch/provider.go
@@ -170,10 +170,18 @@ func claudeLineageSupported(providerVersion string) (bool, error) {
 }
 
 func providerVersion(path string, agent string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), providerVersionTimeout)
+	return providerVersionWithContext(context.Background(), path, agent)
+}
+
+func providerVersionWithContext(parent context.Context, path string, agent string) (string, error) {
+	ctx, cancel := context.WithTimeout(parent, providerVersionTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, path, "--version") // #nosec G204 -- path is resolved from the static provider registry.
+	cmd.WaitDelay = time.Second
 	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return "", fmt.Errorf("read %s version: %w", agent, ctx.Err())
+	}
 	if err != nil {
 		return "", fmt.Errorf("read %s version: %w", agent, err)
 	}

--- a/internal/agentdispatch/types.go
+++ b/internal/agentdispatch/types.go
@@ -209,6 +209,8 @@ type CancelRequest struct {
 
 // OptionsRequest configures an Agent Dispatch options response.
 type OptionsRequest struct {
+	// Lookup callbacks may be invoked concurrently across providers.
+	Context       context.Context
 	Root          string
 	Env           []string
 	Stdout        io.Writer

--- a/internal/agentoptions/discovery.go
+++ b/internal/agentoptions/discovery.go
@@ -1,0 +1,339 @@
+package agentoptions
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/conn-castle/agent-layer/internal/clients"
+	"github.com/conn-castle/agent-layer/internal/clients/antigravity"
+	"github.com/conn-castle/agent-layer/internal/clients/claude"
+	"github.com/conn-castle/agent-layer/internal/clients/codex"
+	"github.com/conn-castle/agent-layer/internal/clients/grok"
+	"github.com/conn-castle/agent-layer/internal/versiondispatch"
+)
+
+const discoveryTimeout = 10 * time.Second
+const maxDiscoveryBytes = 2 * 1024 * 1024
+const agentAntigravity = "antigravity"
+const modelsCommand = "models"
+const initializeMethod = "initialize"
+const methodKey = "method"
+
+// HasModelDiscovery reports whether the installed harness can supply a catalog.
+func HasModelDiscovery(agent string) bool {
+	return slices.Contains([]string{agentAntigravity, agentClaude, agentCodex, agentGrok}, agent)
+}
+
+// DiscoverModels queries the harness without sync or inference. It uses the same
+// project environment and provider configuration helpers as launch and dispatch.
+// A returned catalog describes selectable models, not guaranteed account access.
+func DiscoverModels(agent string, req DiscoveryRequest) ([]string, error) {
+	if !HasModelDiscovery(agent) {
+		return nil, fmt.Errorf("model discovery is not supported for %s", agent)
+	}
+	if req.Env == nil {
+		req.Env = os.Environ()
+	}
+	req.Env = slices.Clone(req.Env)
+	effectiveEnv := req.Env
+	if req.Project != nil {
+		effectiveEnv = clients.BuildEnv(effectiveEnv, req.Project.Env, nil)
+	}
+	if offline, _ := clients.GetEnv(effectiveEnv, versiondispatch.EnvNoNetwork); strings.TrimSpace(offline) != "" {
+		return nil, fmt.Errorf("model discovery disabled by %s", versiondispatch.EnvNoNetwork)
+	}
+	if req.LookPath == nil {
+		req.LookPath = exec.LookPath
+	}
+	if req.Context == nil {
+		req.Context = context.Background()
+	}
+	if req.Timeout <= 0 {
+		req.Timeout = discoveryTimeout
+	}
+	ctx, cancel := context.WithTimeout(req.Context, req.Timeout)
+	defer cancel()
+	req.Context = ctx
+	var models []string
+	var err error
+	if agent == agentAntigravity {
+		models, err = antigravity.DiscoverModels(antigravity.ModelOptionsRequest{
+			Context: ctx, Project: req.Project, Env: req.Env, LookPath: req.LookPath, Timeout: req.Timeout,
+		})
+	} else {
+		models, err = discoverCommandModels(agent, req)
+	}
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("%s model discovery: %w", agent, ctx.Err())
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s model discovery: %w", agent, err)
+	}
+	return normalizeModels(agent, models)
+}
+
+// ParseModelCommandOutput validates native non-protocol model output. Remote
+// executors can transport the bytes without maintaining a second model parser.
+func ParseModelCommandOutput(agent string, output []byte) ([]string, error) {
+	if len(output) > maxDiscoveryBytes {
+		return nil, errors.New("model discovery output exceeded size limit")
+	}
+	var models []string
+	var err error
+	switch agent {
+	case agentAntigravity:
+		models, err = antigravity.ParseModelOutput(output)
+	case agentGrok:
+		models, err = readGrokModels(bytes.NewReader(output))
+	default:
+		return nil, fmt.Errorf("%s requires protocol model discovery", agent)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s model discovery: %w", agent, err)
+	}
+	return normalizeModels(agent, models)
+}
+
+func normalizeModels(agent string, models []string) ([]string, error) {
+	result := make([]string, 0, len(models))
+	for _, model := range models {
+		model = strings.TrimSpace(model)
+		if model == "" || strings.ContainsAny(model, "\r\n\t") {
+			return nil, fmt.Errorf("%s model discovery returned an invalid model", agent)
+		}
+		if !slices.Contains(result, model) {
+			result = append(result, model)
+		}
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("%s model discovery returned no models", agent)
+	}
+	return result, nil
+}
+
+func discoveryCommand(agent string, req DiscoveryRequest) (*exec.Cmd, error) {
+	path, err := req.LookPath(agent)
+	if err != nil {
+		return nil, err
+	}
+	env := slices.Clone(req.Env)
+	if project := req.Project; project != nil {
+		env = clients.BuildEnv(env, project.Env, nil)
+		switch agent {
+		case agentClaude:
+			env = claude.ConfigureEnvironment(project.Root, env, project.Config.Agents.Claude, nil)
+		case agentCodex:
+			env = codex.ConfigureEnvironment(project.Root, env, project.Config.Agents.Codex, nil)
+		case agentGrok:
+			if err := grok.EnsureHome(project.Root); err != nil {
+				return nil, err
+			}
+			env = grok.ConfigureEnvironment(project.Root, env, project.Config.Agents.Grok, nil)
+		}
+	}
+	args := []string{modelsCommand}
+	switch agent {
+	case agentClaude:
+		args = []string{"-p", "--input-format", "stream-json", "--output-format", "stream-json", "--verbose",
+			"--no-session-persistence", "--strict-mcp-config", "--mcp-config", `{"mcpServers":{}}`,
+			"--settings", `{"disableAllHooks":true}`, "--tools", ""}
+	case agentCodex:
+		args = []string{"app-server"}
+	}
+	// #nosec G204 -- PATH-resolved harness; fixed discovery arguments, no prompt.
+	cmd := exec.CommandContext(req.Context, path, args...)
+	cmd.Env = env
+	cmd.WaitDelay = time.Second
+	if req.Project != nil {
+		cmd.Dir = req.Project.Root
+	}
+	return cmd, nil
+}
+
+func discoverCommandModels(agent string, req DiscoveryRequest) ([]string, error) {
+	// Give protocol completion its own cancellation scope to reap the harness
+	// immediately after the reply, without waiting for the discovery deadline.
+	ctx, cancel := context.WithCancel(req.Context)
+	defer cancel()
+	req.Context = ctx
+	cmd, err := discoveryCommand(agent, req)
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	stopClose := context.AfterFunc(ctx, func() {
+		_ = stdout.Close()
+		_ = stdin.Close()
+	})
+	defer stopClose()
+	waited := false
+	defer func() {
+		_ = stdin.Close()
+		cancel()
+		if !waited {
+			_ = cmd.Wait()
+		}
+	}()
+	reader := &io.LimitedReader{R: stdout, N: maxDiscoveryBytes + 1}
+	if agent == agentGrok {
+		models, err := readGrokModels(reader)
+		if err != nil {
+			return nil, err
+		}
+		if reader.N == 0 {
+			return nil, errors.New("model discovery output exceeded size limit")
+		}
+		err = cmd.Wait()
+		waited = true
+		if err != nil {
+			return nil, err
+		}
+		return models, nil
+	}
+	decoder, encoder := json.NewDecoder(reader), json.NewEncoder(stdin)
+	if agent == agentClaude {
+		return readClaudeModels(decoder, encoder)
+	}
+	return readCodexModels(decoder, encoder)
+}
+
+func readGrokModels(reader io.Reader) ([]string, error) {
+	scanner := bufio.NewScanner(reader)
+	var models []string
+	inModels := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.Contains(strings.ToLower(line), "not authenticated") {
+			return nil, errors.New("harness is not authenticated; sign in using al grok")
+		}
+		if line == "Available models:" {
+			inModels = true
+			continue
+		}
+		if !inModels || line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "* ") && !strings.HasPrefix(line, "- ") {
+			return nil, errors.New("unrecognized grok models output")
+		}
+		value := strings.TrimSpace(strings.TrimSuffix(line[2:], " (default)"))
+		models = append(models, value)
+	}
+	return models, scanner.Err()
+}
+
+func readClaudeModels(decoder *json.Decoder, encoder *json.Encoder) ([]string, error) {
+	if err := encoder.Encode(map[string]any{"type": "control_request", "request_id": modelsCommand, "request": map[string]any{"subtype": initializeMethod}}); err != nil {
+		return nil, err
+	}
+	for {
+		var msg struct {
+			Type     string `json:"type"`
+			Response struct {
+				ID       string `json:"request_id"`
+				Subtype  string `json:"subtype"`
+				Response struct {
+					Models []struct {
+						Value string `json:"value"`
+					} `json:"models"`
+				} `json:"response"`
+			} `json:"response"`
+		}
+		if err := decoder.Decode(&msg); err != nil {
+			return nil, fmt.Errorf("read initialization response: %w", err)
+		}
+		if msg.Type != "control_response" || msg.Response.ID != modelsCommand {
+			continue
+		}
+		if msg.Response.Subtype != "success" {
+			return nil, errors.New("harness rejected initialization; check Claude authentication and configuration")
+		}
+		models := make([]string, 0, len(msg.Response.Response.Models))
+		for _, model := range msg.Response.Response.Models {
+			models = append(models, model.Value)
+		}
+		return models, nil
+	}
+}
+
+func codexRequest(decoder *json.Decoder, encoder *json.Encoder, id int, method string, params any, result any) error {
+	if err := encoder.Encode(map[string]any{"id": id, methodKey: method, "params": params}); err != nil {
+		return err
+	}
+	for {
+		var msg struct {
+			ID     *int            `json:"id"`
+			Result json.RawMessage `json:"result"`
+			Error  json.RawMessage `json:"error"`
+		}
+		if err := decoder.Decode(&msg); err != nil {
+			return fmt.Errorf("read %s response: %w", method, err)
+		}
+		if msg.ID == nil || *msg.ID != id {
+			continue
+		}
+		if len(msg.Error) > 0 && string(msg.Error) != "null" {
+			return fmt.Errorf("harness rejected %s; check Codex authentication and configuration", method)
+		}
+		return json.Unmarshal(msg.Result, result)
+	}
+}
+
+func readCodexModels(decoder *json.Decoder, encoder *json.Encoder) ([]string, error) {
+	var initialized map[string]any
+	if err := codexRequest(decoder, encoder, 1, initializeMethod, map[string]any{"clientInfo": map[string]string{"name": "agent_layer", "version": "1"}}, &initialized); err != nil {
+		return nil, err
+	}
+	if err := encoder.Encode(map[string]any{methodKey: "initialized", "params": map[string]any{}}); err != nil {
+		return nil, err
+	}
+	var models []string
+	cursor := ""
+	seen := map[string]bool{}
+	for id := 2; ; id++ {
+		params := map[string]any{"includeHidden": false}
+		if cursor != "" {
+			params["cursor"] = cursor
+		}
+		var page struct {
+			Data []struct {
+				Model string `json:"model"`
+			} `json:"data"`
+			NextCursor *string `json:"nextCursor"`
+		}
+		if err := codexRequest(decoder, encoder, id, "model/list", params, &page); err != nil {
+			return nil, err
+		}
+		for _, model := range page.Data {
+			models = append(models, model.Model)
+		}
+		if page.NextCursor == nil || *page.NextCursor == "" {
+			return models, nil
+		}
+		cursor = *page.NextCursor
+		if seen[cursor] {
+			return nil, errors.New("model/list repeated a pagination cursor")
+		}
+		seen[cursor] = true
+	}
+}

--- a/internal/agentoptions/discovery_test.go
+++ b/internal/agentoptions/discovery_test.go
@@ -1,0 +1,249 @@
+package agentoptions
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/conn-castle/agent-layer/internal/config"
+)
+
+// The test executable doubles as a harness so protocol, environment, working
+// directory, and cancellation checks exercise the production process boundary.
+func TestMain(m *testing.M) {
+	if mode := os.Getenv("AL_TEST_MODEL_HARNESS"); mode != "" {
+		runModelHarness(mode)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func runModelHarness(mode string) {
+	if mode == "environment" {
+		cwd, _ := os.Getwd()
+		if os.Getenv("GROK_HOME") != filepath.Join(cwd, ".grok-config") || os.Getenv("AL_TEST_PROJECT_VALUE") != "project-value" || os.Getenv("AL_DISPATCH_ACTIVE") != "" {
+			os.Exit(3)
+		}
+		fmt.Println("Available models:\n  * future-model (default)")
+		return
+	}
+	if mode == "grok" {
+		fmt.Println("Default model: future-model\n\nAvailable models:\n  * future-model (default)\n  - another-model")
+		return
+	}
+	if mode == "unauthenticated" {
+		fmt.Println("You are not authenticated.\nAvailable models:\n  * fallback")
+		return
+	}
+	if mode == "bad-output" {
+		fmt.Println("unexpected output")
+		return
+	}
+	if mode == "exit-error" {
+		fmt.Println("Available models:\n  - misleading-model")
+		os.Exit(2)
+	}
+	if mode == "hang" {
+		time.Sleep(time.Minute)
+		return
+	}
+	if mode == "oversized" {
+		fmt.Print(strings.Repeat("x", maxDiscoveryBytes+1))
+		return
+	}
+	if mode == "antigravity" {
+		cwd, _ := os.Getwd()
+		if !strings.Contains(strings.Join(os.Args[1:], " "), "--gemini_dir="+filepath.Join(cwd, ".agy")) || os.Getenv("AGY_CLI_DISABLE_AUTO_UPDATE") != "1" || os.Getenv("AL_TEST_PROJECT_VALUE") != "project-value" {
+			os.Exit(3)
+		}
+		fmt.Println("future-id\tFuture Display Name")
+		return
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	encoder := json.NewEncoder(os.Stdout)
+	for scanner.Scan() {
+		var msg map[string]any
+		if json.Unmarshal(scanner.Bytes(), &msg) != nil {
+			os.Exit(4)
+		}
+		if mode == "claude" || mode == "claude-error" {
+			request, _ := msg["request"].(map[string]any)
+			if msg["type"] != "control_request" || request["subtype"] != "initialize" {
+				os.Exit(5)
+			}
+			subtype := "success"
+			if mode == "claude-error" {
+				subtype = "error"
+			}
+			_ = encoder.Encode(map[string]any{"type": "control_response", "response": map[string]any{"request_id": msg["request_id"], "subtype": subtype, "response": map[string]any{"models": []map[string]string{{"value": "future-claude"}}}}})
+			continue
+		}
+		switch msg["method"] {
+		case "initialize":
+			_ = encoder.Encode(map[string]any{"id": msg["id"], "result": map[string]string{"userAgent": "fixture"}})
+		case "initialized":
+		case "model/list":
+			params := msg["params"].(map[string]any)
+			if mode == "codex-error" {
+				_ = encoder.Encode(map[string]any{"id": msg["id"], "error": map[string]any{"code": -32000}})
+				continue
+			}
+			var cursor any = "next-page"
+			model := "future-codex"
+			if params["cursor"] == "next-page" && mode != "codex-loop" {
+				cursor = nil
+				model = "another-codex"
+			}
+			_ = encoder.Encode(map[string]any{"method": "notification"})
+			_ = encoder.Encode(map[string]any{"id": msg["id"], "result": map[string]any{"data": []map[string]string{{"model": model}}, "nextCursor": cursor}})
+		default:
+			os.Exit(6)
+		}
+	}
+}
+
+func harnessRequest(t *testing.T, mode string) DiscoveryRequest {
+	t.Helper()
+	path, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return DiscoveryRequest{Env: []string{"AL_TEST_MODEL_HARNESS=" + mode}, LookPath: func(string) (string, error) { return path, nil }, Timeout: 3 * time.Second}
+}
+
+func TestDiscoverModelsThroughHarnessProtocols(t *testing.T) {
+	for _, tc := range []struct {
+		agent, mode string
+		want        []string
+	}{
+		{"claude", "claude", []string{"future-claude"}},
+		{"codex", "codex", []string{"future-codex", "another-codex"}},
+		{"grok", "grok", []string{"future-model", "another-model"}},
+	} {
+		t.Run(tc.agent, func(t *testing.T) {
+			got, err := DiscoverModels(tc.agent, harnessRequest(t, tc.mode))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("models=%v want=%v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiscoveryUsesProjectLaunchContextWithoutSync(t *testing.T) {
+	for _, agent := range []string{"grok", "antigravity"} {
+		t.Run(agent, func(t *testing.T) {
+			mode := agent
+			if agent == "grok" {
+				mode = "environment"
+			}
+			req := harnessRequest(t, mode)
+			req.Env = append(req.Env, "AL_DISPATCH_ACTIVE=1")
+			root, err := filepath.EvalSymlinks(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Project = &config.ProjectConfig{Root: root, Env: map[string]string{"AL_TEST_PROJECT_VALUE": "project-value"}}
+			// No config.toml or sync inputs exist. Discovery must still work from
+			// the supplied snapshot using normal provider launch preparation.
+			if _, err := DiscoverModels(agent, req); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(filepath.Join(req.Project.Root, ".agent-layer")); !os.IsNotExist(err) {
+				t.Fatalf("discovery created sync/run state: %v", err)
+			}
+		})
+	}
+}
+
+func TestDiscoveryFailuresRemainExplicit(t *testing.T) {
+	for _, tc := range []struct{ agent, mode string }{
+		{"claude", "claude-error"}, {"codex", "codex-error"}, {"codex", "codex-loop"},
+		{"grok", "unauthenticated"}, {"grok", "bad-output"}, {"grok", "exit-error"},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			req := harnessRequest(t, tc.mode)
+			req.Live = true
+			option := Resolve(config.Config{}, tc.agent, KindModel, req)
+			if option.DiscoveryError == "" || option.Source != "unavailable" || len(option.Suggestions) != 0 {
+				t.Fatalf("false discovery success: %+v", option)
+			}
+		})
+	}
+}
+
+func TestDiscoveryDeadlineAndOffline(t *testing.T) {
+	req := harnessRequest(t, "hang")
+	req.Timeout = 50 * time.Millisecond
+	for _, agent := range []string{"claude", "codex", "grok", "antigravity"} {
+		start := time.Now()
+		if _, err := DiscoverModels(agent, req); err == nil || !strings.Contains(err.Error(), "deadline exceeded") {
+			t.Fatalf("%s timeout error=%v", agent, err)
+		}
+		if time.Since(start) > 2*time.Second {
+			t.Fatalf("%s timeout did not stop the child", agent)
+		}
+	}
+	req.Env = append(req.Env, "AL_NO_NETWORK=1")
+	req.LookPath = func(string) (string, error) { t.Fatal("offline discovery launched a harness"); return "", nil }
+	if _, err := DiscoverModels("codex", req); err == nil {
+		t.Fatal("offline discovery claimed success")
+	}
+	req.Env = []string{}
+	req.Project = &config.ProjectConfig{Env: map[string]string{"AL_NO_NETWORK": "1"}}
+	if _, err := DiscoverModels("codex", req); err == nil {
+		t.Fatal("project-level offline discovery claimed success")
+	}
+	req = harnessRequest(t, "hang")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req.Context = ctx
+	if _, err := DiscoverModels("grok", req); err == nil {
+		t.Fatal("cancelled discovery claimed success")
+	}
+}
+
+func TestAntigravityDiscoveryBoundsOutput(t *testing.T) {
+	_, err := DiscoverModels("antigravity", harnessRequest(t, "oversized"))
+	if err == nil || !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("oversized output error=%v", err)
+	}
+}
+
+// BenchmarkLiveModelDiscovery exercises exactly the project-aware no-sync Go
+// discovery used by Wizard, Doctor, and Dispatch. Explicit opt-in keeps normal
+// tests hermetic. Each iteration starts a fresh harness; upstream caches remain.
+func BenchmarkLiveModelDiscovery(b *testing.B) {
+	root := os.Getenv("AL_MODEL_DISCOVERY_BENCHMARK_ROOT")
+	if root == "" {
+		b.Skip("set AL_MODEL_DISCOVERY_BENCHMARK_ROOT to an initialized project")
+	}
+	project, err := config.LoadProjectConfig(root)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, agent := range []string{"claude", "codex", "grok", "antigravity"} {
+		b.Run(agent, func(b *testing.B) {
+			req := DefaultDiscoveryRequest()
+			req.Project = project
+			b.ResetTimer()
+			for range b.N {
+				started := time.Now()
+				models, err := DiscoverModels(agent, req)
+				if err != nil {
+					b.Fatalf("discovery failed after %s: %v", time.Since(started), err)
+				}
+				b.ReportMetric(float64(len(models)), "models")
+			}
+		})
+	}
+}

--- a/internal/agentoptions/options.go
+++ b/internal/agentoptions/options.go
@@ -1,12 +1,12 @@
 package agentoptions
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
 
-	antigravityclient "github.com/conn-castle/agent-layer/internal/clients/antigravity"
 	"github.com/conn-castle/agent-layer/internal/config"
 )
 
@@ -22,6 +22,8 @@ const (
 
 // DiscoveryRequest controls live option discovery.
 type DiscoveryRequest struct {
+	Context  context.Context
+	Project  *config.ProjectConfig
 	Env      []string
 	LookPath func(string) (string, error)
 	Live     bool
@@ -35,22 +37,24 @@ type OptionSet struct {
 	Configured        string
 	Suggestions       []string
 	AllowCustom       bool
+	// Source is harness for discovered models, not_requested when skipped,
+	// unavailable on discovery failure, and catalog for non-model options only.
+	Source         string
+	DiscoveryError string
 }
 
 type fieldProvider struct {
 	key        string
 	configured func(config.Config) string
-	live       func(DiscoveryRequest) []string
 }
 
 var providers = map[string]map[Kind]fieldProvider{
-	"antigravity": {
+	agentAntigravity: {
 		KindModel: {
 			key: config.AntigravityModelFieldKey,
 			configured: func(cfg config.Config) string {
 				return cfg.Agents.Antigravity.Model
 			},
-			live: antigravityModelOptions,
 		},
 	},
 	agentClaude: {
@@ -116,7 +120,7 @@ func DefaultDiscoveryRequest() DiscoveryRequest {
 }
 
 // Resolve returns the option metadata for an agent field, including live
-// suggestions when available and catalog fallback otherwise.
+// suggestions only from the harness. Model discovery never uses a fallback.
 func Resolve(cfg config.Config, agent string, kind Kind, req DiscoveryRequest) OptionSet {
 	provider, ok := lookup(agent, kind)
 	option := OptionSet{
@@ -129,18 +133,28 @@ func Resolve(cfg config.Config, agent string, kind Kind, req DiscoveryRequest) O
 	option.Configured = strings.TrimSpace(provider.configured(cfg))
 	field, _ := config.LookupField(provider.key)
 	option.AllowCustom = field.AllowCustom
-	option.Suggestions = values(provider, field, req)
+	if kind != KindModel {
+		option.Suggestions = values(field)
+		option.Source = "catalog"
+		return option
+	}
+	option.Source = "not_requested"
+	if req.Live {
+		models, err := DiscoverModels(agent, req)
+		if err != nil {
+			option.Source = "unavailable"
+			option.DiscoveryError = err.Error()
+		} else {
+			option.Suggestions = models
+			option.Source = "harness"
+		}
+	}
 	return option
 }
 
 // Values returns suggested values for an agent field.
 func Values(agent string, kind Kind, req DiscoveryRequest) []string {
-	provider, ok := lookup(agent, kind)
-	if !ok {
-		return nil
-	}
-	field, _ := config.LookupField(provider.key)
-	return values(provider, field, req)
+	return Resolve(config.Config{}, agent, kind, req).Suggestions
 }
 
 // Supports reports whether an agent exposes the requested option surface.
@@ -167,23 +181,10 @@ func lookup(agent string, kind Kind) (fieldProvider, bool) {
 	return provider, ok
 }
 
-func values(provider fieldProvider, field config.FieldDef, req DiscoveryRequest) []string {
-	if req.Live && provider.live != nil {
-		if live := provider.live(req); len(live) > 0 {
-			return live
-		}
-	}
+func values(field config.FieldDef) []string {
 	values := make([]string, 0, len(field.Options))
 	for _, option := range field.Options {
 		values = append(values, option.Value)
 	}
 	return values
-}
-
-func antigravityModelOptions(req DiscoveryRequest) []string {
-	return antigravityclient.ModelOptions(antigravityclient.ModelOptionsRequest{
-		Env:      req.Env,
-		LookPath: req.LookPath,
-		Timeout:  req.Timeout,
-	})
 }

--- a/internal/agentoptions/options_test.go
+++ b/internal/agentoptions/options_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -13,7 +14,7 @@ import (
 func TestResolveUsesLiveAntigravityModels(t *testing.T) {
 	binDir := t.TempDir()
 	agyPath := filepath.Join(binDir, "agy")
-	script := "#!/bin/sh\nif [ \"$1\" = \"models\" ]; then\n  printf 'Live Model\\nBackup Model\\n'\nfi\n"
+	script := "#!/bin/sh\nif [ \"$1\" = \"models\" ]; then\n  printf 'live\\tLive Model\\nbackup\\tBackup Model\\n'\nfi\n"
 	if err := os.WriteFile(agyPath, []byte(script), 0o700); err != nil { // #nosec G306 -- test writes an executable mock agy stub; the executable bit is required.
 		t.Fatalf("write agy stub: %v", err)
 	}
@@ -40,7 +41,7 @@ func TestResolveUsesLiveAntigravityModels(t *testing.T) {
 	if options.Configured != "Configured Model" {
 		t.Fatalf("configured = %q, want trimmed configured model", options.Configured)
 	}
-	want := []string{"Live Model", "Backup Model"}
+	want := []string{"live", "Live Model", "backup", "Backup Model"}
 	if !reflect.DeepEqual(options.Suggestions, want) {
 		t.Fatalf("suggestions = %v, want %v", options.Suggestions, want)
 	}
@@ -49,9 +50,9 @@ func TestResolveUsesLiveAntigravityModels(t *testing.T) {
 	}
 }
 
-func TestValuesFallsBackToCatalogWhenLiveDisabled(t *testing.T) {
+func TestValuesDoesNotInventModelsWhenLiveDisabled(t *testing.T) {
 	got := Values("antigravity", KindModel, DiscoveryRequest{})
-	want := config.FieldOptionValues(config.AntigravityModelFieldKey)
+	want := []string{}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("values = %v, want catalog %v", got, want)
 	}
@@ -64,19 +65,15 @@ func TestValuesUsesSharedStaticFieldCatalog(t *testing.T) {
 		kind  Kind
 		key   string
 	}{
-		{name: "claude model", agent: "claude", kind: KindModel, key: config.ClaudeModelFieldKey},
 		{name: "claude reasoning", agent: "claude", kind: KindReasoningEffort, key: config.ClaudeReasoningEffortFieldKey},
-		{name: "codex model", agent: "codex", kind: KindModel, key: config.CodexModelFieldKey},
 		{name: "codex reasoning", agent: "codex", kind: KindReasoningEffort, key: config.CodexReasoningEffortFieldKey},
-		{name: "copilot cli model", agent: "copilot_cli", kind: KindModel, key: config.CopilotCLIModelFieldKey},
-		{name: "grok model", agent: "grok", kind: KindModel, key: config.GrokModelFieldKey},
 		{name: "grok reasoning", agent: "grok", kind: KindReasoningEffort, key: config.GrokReasoningEffortFieldKey},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := Values(tt.agent, tt.kind, DiscoveryRequest{Live: true})
+			got := Values(tt.agent, tt.kind, DiscoveryRequest{})
 			want := config.FieldOptionValues(tt.key)
-			if !reflect.DeepEqual(got, want) {
+			if !slices.Equal(got, want) {
 				t.Fatalf("values = %v, want shared catalog %v", got, want)
 			}
 		})

--- a/internal/benchmark/assets/pier_agent_layer.py
+++ b/internal/benchmark/assets/pier_agent_layer.py
@@ -1056,14 +1056,14 @@ with open(path, "w", encoding="utf-8") as stream:
             await environment.upload_file(self._antigravity_credentials_path, remote_credential)
             await self.exec_as_agent(environment, command=f"chmod 0600 {remote_credential}")
             if self._preflight_only:
-                models_path = "/tmp/agent-layer-antigravity-models.txt"
+                # Transport native output only. The host validates it with
+                # Agent Layer's shared Go model parser before paid execution.
+                models_path = str(EnvironmentPaths.agent_dir / "model-discovery.txt")
                 await self.exec_as_agent(
                     environment,
                     command=(
                         f"AGY_CLI_DISABLE_AUTO_UPDATE=1 agy --gemini_dir={REMOTE_WORKSPACE}/.agy models "
-                        f"> {models_path} && awk -v expected={shlex.quote(self.model_name or '')} "
-                        f"{shlex.quote('$1 == expected { found=1 } END { exit !found }')} {models_path} || "
-                        f"{{ echo 'Antigravity benchmark model is unavailable' >&2; cat {models_path} >&2; exit 1; }}"
+                        f"> {shlex.quote(models_path)}"
                     ),
                 )
                 await self._preflight_retained_stream_validator(environment, "antigravity")
@@ -1131,15 +1131,11 @@ class AgentLayerGrok(_AgentLayerStreamAgent):
                 Path(local_prompt).unlink(missing_ok=True)
             env = self.build_process_env({"GROK_HOME": grok_home, "GROK_MEMORY": "0", "GROK_CLAUDE_AGENTS_ENABLED": "false"})
             if self._preflight_only:
-                models_path = "/tmp/agent-layer-grok-models.txt"
+                models_path = str(EnvironmentPaths.agent_dir / "model-discovery.txt")
                 await self.exec_as_agent(
                     environment,
                     command=(
-                        f"grok --no-auto-update --sandbox {self.SANDBOX_PROFILE} models > {models_path} && "
-                        f"awk -v expected={shlex.quote(self.model_name or '')} "
-                        f"{shlex.quote('$1 ~ /^[-*]$/ && $2 == expected { found=1 } END { exit !found }')} "
-                        f"{models_path} || "
-                        f"{{ echo 'Grok benchmark model is unavailable' >&2; cat {models_path} >&2; exit 1; }}"
+                        f"grok --no-auto-update --sandbox {self.SANDBOX_PROFILE} models > {shlex.quote(models_path)}"
                     ),
                     env=env,
                 )

--- a/internal/benchmark/catalog.go
+++ b/internal/benchmark/catalog.go
@@ -130,7 +130,10 @@ type Model struct {
 	ProviderClientVersion string `json:"provider_client_version"`
 }
 
-var supportedModels = []Model{
+// historicalModels preserves serialized study identities from earlier releases.
+// This is not an availability catalog: new selections use provider/model:effort
+// and the executing harness remains the authority on model support.
+var historicalModels = []Model{
 	{Name: "luna", PublishedIdentifier: publishedLuna, RuntimeIdentifier: "openai/gpt-5.6-luna", Adapter: adapterCodex, ProviderClientVersion: CodexClientVersion},
 	{Name: "terra", PublishedIdentifier: "gpt-5-6-terra", RuntimeIdentifier: "openai/gpt-5.6-terra", Adapter: adapterCodex, ProviderClientVersion: CodexClientVersion},
 	{Name: "sol", PublishedIdentifier: "gpt-5-6-sol", RuntimeIdentifier: "openai/gpt-5.6-sol", Adapter: adapterCodex, ProviderClientVersion: CodexClientVersion},
@@ -152,13 +155,34 @@ var supportedModels = []Model{
 var supportedEfforts = []string{"none", "minimal", effortLow, effortMedium, effortHigh, effortXHigh, effortMax}
 var legacyEfforts = []string{effortLow, effortMedium, effortHigh, effortXHigh, effortMax}
 
-// ParseModelSelection validates the stable family:effort identity.
+// ParseModelSelection parses an explicit provider/model:effort identity or an
+// immutable historical family:effort identity. Parsing is offline; it does not
+// claim that the executing harness supports the selected model.
 func ParseModelSelection(value string) (Model, string, error) {
 	parts := strings.Split(strings.TrimSpace(value), ":")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return Model{}, "", fmt.Errorf("model %q must be in the form <model>:<effort>", value)
 	}
-	for _, model := range supportedModels {
+	if provider, identifier, qualified := strings.Cut(parts[0], "/"); qualified {
+		adapter := provider
+		if adapter == providerClaude {
+			adapter = adapterClaudeCode
+		}
+		descriptor, err := benchmarkProvider(adapter)
+		if err != nil {
+			return Model{}, "", err
+		}
+		if strings.TrimSpace(identifier) != identifier || identifier == "" || strings.ContainsAny(identifier, "\r\n\t") || strings.TrimSpace(parts[1]) != parts[1] {
+			return Model{}, "", fmt.Errorf("invalid explicit model selection %q", value)
+		}
+		runtimeIdentifier := identifier
+		if adapter == adapterCodex {
+			runtimeIdentifier = "openai/" + identifier
+		}
+		return Model{Name: parts[0], PublishedIdentifier: parts[0], RuntimeIdentifier: runtimeIdentifier,
+			Adapter: adapter, ProviderClientVersion: descriptor.ClientVersion}, parts[1], nil
+	}
+	for _, model := range historicalModels {
 		if model.Name != strings.ToLower(parts[0]) {
 			continue
 		}
@@ -184,7 +208,7 @@ func ParseModelSelection(value string) (Model, string, error) {
 		}
 		return Model{}, "", fmt.Errorf("unsupported reasoning effort %q (supported: %s)", parts[1], strings.Join(legacyEfforts, ", "))
 	}
-	return Model{}, "", fmt.Errorf("unsupported model %q (supported: %s)", parts[0], strings.Join(supportedModelNames(), ", "))
+	return Model{}, "", fmt.Errorf("unsupported model shorthand %q; use <provider>/<model>:<effort> for a model selected from the harness", parts[0])
 }
 
 var grokEfforts = []string{"none", "minimal", effortLow, effortMedium, effortHigh, effortXHigh, effortMax}
@@ -199,7 +223,7 @@ func antigravitySlugEffort(slug string) (string, bool) {
 }
 
 func modelNameForPublished(identifier string) string {
-	for _, model := range supportedModels {
+	for _, model := range historicalModels {
 		if model.PublishedIdentifier == identifier {
 			return model.Name
 		}
@@ -207,9 +231,9 @@ func modelNameForPublished(identifier string) string {
 	return identifier
 }
 
-func supportedPublishedModelIdentifiers() []string {
-	identifiers := make([]string, 0, len(supportedModels))
-	for _, model := range supportedModels {
+func historicalPublishedModelIdentifiers() []string {
+	identifiers := make([]string, 0, len(historicalModels))
+	for _, model := range historicalModels {
 		identifiers = append(identifiers, model.PublishedIdentifier)
 	}
 	return identifiers
@@ -237,14 +261,6 @@ func containsString(values []string, wanted string) bool {
 		}
 	}
 	return false
-}
-
-func supportedModelNames() []string {
-	values := make([]string, 0, len(supportedModels))
-	for _, model := range supportedModels {
-		values = append(values, model.Name)
-	}
-	return values
 }
 
 func validRequiredDispatchRole(role string) bool {

--- a/internal/benchmark/normalize.go
+++ b/internal/benchmark/normalize.go
@@ -6,15 +6,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
 
 	"go.yaml.in/yaml/v3"
+
+	"github.com/conn-castle/agent-layer/internal/agentoptions"
 )
 
 var errPierTaskResultAbsent = errors.New("pier task result is absent")
@@ -242,6 +246,11 @@ func validatePierTreatmentPreflight(stage string, request ExecutionRequest) erro
 	if string(raw.ExceptionInfo) != "" && string(raw.ExceptionInfo) != "null" {
 		return fmt.Errorf("treatment runtime preflight failed: %s", raw.ExceptionInfo)
 	}
+	if request.Model.Adapter == adapterAntigravity || request.Model.Adapter == adapterGrok {
+		if err := validateRemoteModelDiscovery(stage, request.Model); err != nil {
+			return err
+		}
+	}
 	if request.Bundle != nil && request.Bundle.Manifest.Mode == TreatmentInstructionsAndSkills {
 		provider, err := benchmarkProvider(request.Model.Adapter)
 		if err != nil {
@@ -291,6 +300,48 @@ func validatePierTreatmentPreflight(stage string, request ExecutionRequest) erro
 }
 
 const buildErrorExcerptLines = 20
+
+func validateRemoteModelDiscovery(stage string, model Model) error {
+	root, err := os.OpenRoot(filepath.Join(stage, "jobs"))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	var matches int
+	err = fs.WalkDir(root.FS(), ".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || entry.Name() != "model-discovery.txt" {
+			return nil
+		}
+		matches++
+		file, err := root.Open(path)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = file.Close() }()
+		output, err := io.ReadAll(io.LimitReader(file, 2*1024*1024+1))
+		if err != nil {
+			return err
+		}
+		models, err := agentoptions.ParseModelCommandOutput(dispatchAgent(model), output)
+		if err != nil {
+			return err
+		}
+		if !slices.Contains(models, dispatchModel(model)) {
+			return fmt.Errorf("benchmark model %q is not listed by the executing %s harness", dispatchModel(model), dispatchAgent(model))
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("benchmark model preflight: %w", err)
+	}
+	if matches != 1 {
+		return fmt.Errorf("benchmark model preflight requires exactly one native model list, found %d", matches)
+	}
+	return nil
+}
 
 func verifierBuildFailed(stage string) (bool, string, error) {
 	jobsRoot, err := os.OpenRoot(filepath.Join(stage, "jobs"))

--- a/internal/benchmark/provider_catalog_test.go
+++ b/internal/benchmark/provider_catalog_test.go
@@ -44,6 +44,18 @@ func TestProviderCatalogParsesProviderSpecificSelections(t *testing.T) {
 	}
 }
 
+func TestExplicitModelSelectionDoesNotRequireCatalogUpdates(t *testing.T) {
+	for _, provider := range []string{providerClaude, adapterCodex, adapterGrok, adapterAntigravity} {
+		model, effort, err := ParseModelSelection(provider + "/future-model:future-effort")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dispatchAgent(model) != provider || dispatchModel(model) != "future-model" || effort != "future-effort" {
+			t.Fatalf("incorrect explicit selection: %+v %q", model, effort)
+		}
+	}
+}
+
 func TestProviderCatalogPreservesSlugAndPublishedIdentityCompatibility(t *testing.T) {
 	for _, test := range []struct {
 		slug string
@@ -70,9 +82,9 @@ func TestProviderCatalogPreservesSlugAndPublishedIdentityCompatibility(t *testin
 	// The published catalog is static, but malformed future catalog entries
 	// must still fail as configuration errors instead of silently accepting a
 	// model with an unprovable thinking tier.
-	original := supportedModels
-	supportedModels = append(append([]Model(nil), original...), Model{Name: "invalid-gemini", RuntimeIdentifier: "gemini-3.5-flash", Adapter: adapterAntigravity})
-	t.Cleanup(func() { supportedModels = original })
+	original := historicalModels
+	historicalModels = append(append([]Model(nil), original...), Model{Name: "invalid-gemini", RuntimeIdentifier: "gemini-3.5-flash", Adapter: adapterAntigravity})
+	t.Cleanup(func() { historicalModels = original })
 	if _, _, err := ParseModelSelection("invalid-gemini:low"); err == nil || !strings.Contains(err.Error(), "must be an exact Gemini slug") {
 		t.Fatalf("malformed Antigravity catalog entry was accepted: %v", err)
 	}
@@ -382,7 +394,7 @@ func TestProviderPreflightMapComparisonRejectsMissingOrChangedCapacity(t *testin
 }
 
 func TestBenchmarkProviderRegistryCoversEverySelectableModel(t *testing.T) {
-	for _, model := range supportedModels {
+	for _, model := range historicalModels {
 		provider, err := benchmarkProvider(model.Adapter)
 		if err != nil || provider.Binary == "" || provider.PierAgent == "" || provider.ClientVersion != model.ProviderClientVersion {
 			t.Fatalf("model %#v provider = %#v, %v", model, provider, err)

--- a/internal/benchmark/recovery_test.go
+++ b/internal/benchmark/recovery_test.go
@@ -754,7 +754,7 @@ func TestTreatmentPierArgumentsRequireAnImmutableBundleAndCredentials(t *testing
 
 func TestBenchmarkAuthenticationRejectsUnusableCredentials(t *testing.T) {
 	repository := t.TempDir()
-	codex := []parsedSelection{{model: supportedModels[0], effort: effortLow}}
+	codex := []parsedSelection{{model: historicalModels[0], effort: effortLow}}
 	path := filepath.Join(repository, ".codex", "auth.json")
 
 	if _, err := validateAuthentication(context.Background(), repository, codex); err == nil ||

--- a/internal/benchmark/runtime_test.go
+++ b/internal/benchmark/runtime_test.go
@@ -1140,6 +1140,38 @@ func TestInstructionsOnlyRuntimePreflightDoesNotRequireDispatchEvidence(t *testi
 	}
 }
 
+func TestRuntimePreflightValidatesNativeModelEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name, provider, output string
+		valid                  bool
+	}{
+		{"agy slug", adapterAntigravity, "future-model\tFuture Display\n", true},
+		{"grok authenticated", adapterGrok, "Available models:\n  - future-model\n", true},
+		{"grok auth fallback", adapterGrok, "You are not authenticated.\nAvailable models:\n  - future-model\n", false},
+		{"unlisted", adapterGrok, "Available models:\n  - another-model\n", false},
+		{"missing", adapterAntigravity, "", false},
+		{"malformed", adapterAntigravity, "unexpected output\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stage := writePierStage(t, "task-checksum", .5, 0)
+			if tc.output != "" {
+				path := filepath.Join(stage, "jobs", "one", "agent", "model-discovery.txt")
+				if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(tc.output), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			request := ExecutionRequest{Task: "example-task", TaskChecksum: "task-checksum", Model: Model{Adapter: tc.provider, RuntimeIdentifier: "future-model"}}
+			err := validatePierTreatmentPreflight(stage, request)
+			if (err == nil) != tc.valid {
+				t.Fatalf("preflight error=%v, want valid=%t", err, tc.valid)
+			}
+		})
+	}
+}
+
 func TestPinnedCheckoutValidationRejectsMissingAndWrongRepositoryState(t *testing.T) {
 	root := t.TempDir()
 	checkout := filepath.Join(root, "checkout")

--- a/internal/benchmark/study_execution.go
+++ b/internal/benchmark/study_execution.go
@@ -240,19 +240,19 @@ func validateMatrixSelection(selection matrixSelection) error {
 	model, effort, err := ParseModelSelection(modelNameForPublished(selection.Selector.Model) + ":" + selection.Selector.Reasoning)
 	if err != nil {
 		return fmt.Errorf(
-			"benchmark selection selector model %q with reasoning %q is invalid (supported models: %s): %w",
+			"benchmark selection selector model %q with reasoning %q is invalid (historical identifiers: %s; new identities use provider/model): %w",
 			selection.Selector.Model,
 			selection.Selector.Reasoning,
-			strings.Join(supportedPublishedModelIdentifiers(), ", "),
+			strings.Join(historicalPublishedModelIdentifiers(), ", "),
 			err,
 		)
 	}
 	if model.PublishedIdentifier != selection.Selector.Model || effort != selection.Selector.Reasoning {
 		return fmt.Errorf(
-			"benchmark selection selector model %q with reasoning %q must use exact canonical spelling (supported models: %s)",
+			"benchmark selection selector model %q with reasoning %q must use exact canonical spelling (historical identifiers: %s)",
 			selection.Selector.Model,
 			selection.Selector.Reasoning,
-			strings.Join(supportedPublishedModelIdentifiers(), ", "),
+			strings.Join(historicalPublishedModelIdentifiers(), ", "),
 		)
 	}
 	seen, excluded := map[string]bool{}, map[string]bool{}

--- a/internal/benchmark/study_execution_test.go
+++ b/internal/benchmark/study_execution_test.go
@@ -205,7 +205,7 @@ func TestStudySelectionNamesInvalidSelectorAndSupportedModels(t *testing.T) {
 	if err == nil ||
 		!strings.Contains(err.Error(), `model "grok-4-5" with reasoning "low"`) ||
 		!strings.Contains(err.Error(), "grok-4.5") ||
-		!strings.Contains(err.Error(), "supported models:") {
+		!strings.Contains(err.Error(), "historical identifiers:") {
 		t.Fatalf("invalid selector error = %v", err)
 	}
 }

--- a/internal/clients/antigravity/models.go
+++ b/internal/clients/antigravity/models.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,29 +15,23 @@ import (
 	"github.com/conn-castle/agent-layer/internal/config"
 )
 
-const modelListTimeout = 3 * time.Second
+// Model listing authenticates and fetches the remote catalog. Allow headroom
+// above observed 1–4 second startup times, while bounding an unavailable service.
+const modelListTimeout = 10 * time.Second
 
 // ModelOptionsRequest configures Antigravity model option discovery.
 type ModelOptionsRequest struct {
+	Context  context.Context
+	Project  *config.ProjectConfig
 	Env      []string
 	LookPath func(string) (string, error)
 	// Timeout bounds the live `agy models` command. Zero or negative uses modelListTimeout.
 	Timeout time.Duration
 }
 
-// ModelOptions returns Antigravity model display strings.
-//
-// It prefers the live `agy models` command and falls back to Agent Layer's
-// field catalog only when live discovery is unavailable.
-func ModelOptions(req ModelOptionsRequest) []string {
-	models, err := liveModelOptions(req)
-	if err == nil {
-		return models
-	}
-	return config.FieldOptionValues(config.AntigravityModelFieldKey)
-}
-
-func liveModelOptions(req ModelOptionsRequest) ([]string, error) {
+// DiscoverModels lists models without syncing or starting a conversation.
+// Discovery failures are returned to the caller, never replaced by a catalog.
+func DiscoverModels(req ModelOptionsRequest) ([]string, error) {
 	lookPath := req.LookPath
 	if lookPath == nil {
 		lookPath = exec.LookPath
@@ -49,13 +44,20 @@ func liveModelOptions(req ModelOptionsRequest) ([]string, error) {
 	if timeout <= 0 {
 		timeout = modelListTimeout
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	parent := req.Context
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
-	output, err := runModelCommand(ctx, binary, req.Env)
+	output, err := runModelCommand(ctx, binary, req)
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	if err != nil {
 		return nil, err
 	}
-	models, err := parseModelOutput(output)
+	models, err := ParseModelOutput(output)
 	if err != nil {
 		return nil, err
 	}
@@ -65,18 +67,56 @@ func liveModelOptions(req ModelOptionsRequest) ([]string, error) {
 	return models, nil
 }
 
-func runModelCommand(ctx context.Context, binary string, env []string) ([]byte, error) {
+func runModelCommand(ctx context.Context, binary string, req ModelOptionsRequest) ([]byte, error) {
+	env := req.Env
 	if env == nil {
 		env = os.Environ()
 	}
-	env = clients.SetEnv(env, disableAutoUpdateEnv, "1")
+	args := make([]string, 0, 1)
+	if req.Project != nil {
+		var err error
+		args, err = BaseArgs(req.Project.Root, req.Project.Config)
+		if err != nil {
+			return nil, err
+		}
+		env = clients.BuildEnv(env, req.Project.Env, nil)
+	}
+	env = ConfigureEnvironment(env)
+	args = append(args, "models")
 	// #nosec G204 -- binary is resolved by LookPath; the command arguments are fixed by Agent Layer.
-	cmd := exec.CommandContext(ctx, binary, "models")
+	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Env = env
-	return cmd.Output()
+	cmd.WaitDelay = time.Second
+	if req.Project != nil {
+		cmd.Dir = req.Project.Root
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	stopClose := context.AfterFunc(ctx, func() { _ = stdout.Close() })
+	defer stopClose()
+	const maxOutput = 2 * 1024 * 1024
+	output, readErr := io.ReadAll(io.LimitReader(stdout, maxOutput+1))
+	if readErr != nil || len(output) > maxOutput {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		if readErr != nil {
+			return nil, readErr
+		}
+		return nil, errors.New("agy models output exceeded size limit")
+	}
+	if err := cmd.Wait(); err != nil {
+		return nil, err
+	}
+	return output, nil
 }
 
-func parseModelOutput(output []byte) ([]string, error) {
+// ParseModelOutput decodes native agy output, including remote benchmark output.
+func ParseModelOutput(output []byte) ([]string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(output))
 	models := make([]string, 0)
 	for scanner.Scan() {
@@ -84,6 +124,14 @@ func parseModelOutput(output []byte) ([]string, error) {
 		if model == "" {
 			continue
 		}
+		// Require the native slug<TAB>display format. Arbitrary stdout (such
+		// as an authentication message) must not become a model suggestion.
+		slug, label, ok := strings.Cut(scanner.Text(), "\t")
+		if !ok || strings.TrimSpace(slug) == "" || strings.TrimSpace(label) == "" || strings.Contains(label, "\t") {
+			return nil, errors.New("agy models returned an invalid model row; expected slug<TAB>display name")
+		}
+		model = strings.TrimSpace(label)
+		models = append(models, strings.TrimSpace(slug))
 		models = append(models, model)
 	}
 	if err := scanner.Err(); err != nil {

--- a/internal/clients/antigravity/models_test.go
+++ b/internal/clients/antigravity/models_test.go
@@ -1,14 +1,40 @@
 package antigravity
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/conn-castle/agent-layer/internal/config"
 )
+
+func TestDiscoverModelsPreservesContextErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "agy")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexec sleep 30\n"), 0o700); err != nil { // #nosec G306 -- executable harness fixture.
+		t.Fatal(err)
+	}
+	for _, cancelled := range []bool{false, true} {
+		t.Run(fmt.Sprint(cancelled), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			want := context.DeadlineExceeded
+			if cancelled {
+				cancel()
+				want = context.Canceled
+			}
+			models, err := DiscoverModels(ModelOptionsRequest{
+				Context: ctx, Timeout: 100 * time.Millisecond,
+				LookPath: func(string) (string, error) { return path, nil },
+			})
+			if !errors.Is(err, want) || len(models) != 0 {
+				t.Fatalf("models=%v err=%v, want %v", models, err, want)
+			}
+		})
+	}
+}
 
 func TestLiveModelOptionsParsesAgyModels(t *testing.T) {
 	binDir := t.TempDir()
@@ -20,12 +46,12 @@ fi
 if [ "$AGY_CLI_DISABLE_AUTO_UPDATE" != "1" ]; then
   exit 3
 fi
-printf '\nGemini 3.5 Flash (Medium)\nGemini 3.5 Flash (High)\n'
+printf '\nmedium-id\tGemini 3.5 Flash (Medium)\nhigh-id\tGemini 3.5 Flash (High)\n'
 `
 	if err := os.WriteFile(agyPath, []byte(script), 0o700); err != nil { // #nosec G306 -- test writes an executable mock agy stub; the executable bit is required.
 		t.Fatalf("write agy stub: %v", err)
 	}
-	models, err := liveModelOptions(ModelOptionsRequest{
+	models, err := DiscoverModels(ModelOptionsRequest{
 		Env: []string{"PATH=/bin"},
 		LookPath: func(name string) (string, error) {
 			if name != "agy" {
@@ -38,37 +64,62 @@ printf '\nGemini 3.5 Flash (Medium)\nGemini 3.5 Flash (High)\n'
 	if err != nil {
 		t.Fatalf("liveModelOptions error: %v", err)
 	}
-	want := []string{"Gemini 3.5 Flash (Medium)", "Gemini 3.5 Flash (High)"}
+	want := []string{"medium-id", "Gemini 3.5 Flash (Medium)", "high-id", "Gemini 3.5 Flash (High)"}
 	if !reflect.DeepEqual(models, want) {
 		t.Fatalf("models = %v, want %v", models, want)
 	}
 }
 
-func TestModelOptionsFallsBackToFieldCatalogWhenAgyUnavailable(t *testing.T) {
-	models := ModelOptions(ModelOptionsRequest{
+func TestDiscoverModelsReportsMissingBinary(t *testing.T) {
+	_, err := DiscoverModels(ModelOptionsRequest{
 		LookPath: func(string) (string, error) {
 			return "", os.ErrNotExist
 		},
 	})
-	want := config.FieldOptionValues(config.AntigravityModelFieldKey)
-	if !reflect.DeepEqual(models, want) {
-		t.Fatalf("models = %v, want catalog %v", models, want)
+	if err == nil {
+		t.Fatal("missing binary was not reported")
 	}
 }
 
-func TestModelOptionsFallsBackToFieldCatalogWhenLiveCommandFails(t *testing.T) {
+func TestDiscoverModelsReportsCommandFailure(t *testing.T) {
 	binDir := t.TempDir()
 	agyPath := filepath.Join(binDir, "agy")
 	if err := os.WriteFile(agyPath, []byte("#!/bin/sh\nexit 42\n"), 0o700); err != nil { // #nosec G306 -- test writes an executable mock agy stub; the executable bit is required.
 		t.Fatalf("write agy stub: %v", err)
 	}
-	models := ModelOptions(ModelOptionsRequest{
+	_, err := DiscoverModels(ModelOptionsRequest{
 		LookPath: func(string) (string, error) {
 			return agyPath, nil
 		},
 	})
-	want := config.FieldOptionValues(config.AntigravityModelFieldKey)
-	if !reflect.DeepEqual(models, want) {
-		t.Fatalf("models = %v, want catalog %v", models, want)
+	if err == nil {
+		t.Fatal("command failure was not reported")
+	}
+}
+
+func TestParseModelRows(t *testing.T) {
+	for _, tc := range []struct {
+		name, output string
+		want         []string
+		invalid      bool
+	}{
+		{"current", "slug\tDisplay Name\nsecond\tOther Model\n", []string{"slug", "Display Name", "second", "Other Model"}, false},
+		{"unstructured output", "\nAuthentication failed\n", nil, true},
+		{"missing label", "slug\t\n", nil, true},
+		{"missing slug", "\tDisplay Name\n", nil, true},
+		{"extra column", "slug\tDisplay\textra\n", nil, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			models, err := ParseModelOutput([]byte(tc.output))
+			if tc.invalid {
+				if err == nil {
+					t.Fatal("invalid row accepted")
+				}
+				return
+			}
+			if err != nil || !reflect.DeepEqual(models, tc.want) {
+				t.Fatalf("models=%v err=%v", models, err)
+			}
+		})
 	}
 }

--- a/internal/config/fields.go
+++ b/internal/config/fields.go
@@ -32,8 +32,8 @@ type FieldDef struct {
 }
 
 const (
-	// AntigravityModelFieldKey is the canonical config path for agy's model display
-	// string. Sync projects this typed Agent Layer setting into Antigravity's
+	// AntigravityModelFieldKey is the canonical config path for agy's model
+	// selector (native slug or display name). Sync projects it into Antigravity's
 	// generated settings.json.
 	AntigravityModelFieldKey = "agents.antigravity.model"
 	// ClaudeModelFieldKey is the canonical config path for Claude Code model aliases.
@@ -53,41 +53,9 @@ const (
 )
 
 var (
-	antigravityModelOptions = fieldOptions(
-		"Gemini 3.5 Flash (Medium)",
-		"Gemini 3.5 Flash (High)",
-		"Gemini 3.5 Flash (Low)",
-		"Gemini 3.1 Pro (Low)",
-		"Gemini 3.1 Pro (High)",
-		"Claude Sonnet 4.6 (Thinking)",
-		"Claude Opus 4.6 (Thinking)",
-		"GPT-OSS 120B (Medium)",
-	)
-	claudeModelOptions = fieldOptions(
-		"default",
-		"best",
-		"fable",
-		"sonnet",
-		"opus",
-		"haiku",
-		"sonnet[1m]",
-		"opus[1m]",
-		"opusplan",
-	)
 	claudeReasoningEffortOptions = fieldOptions("low", "medium", "high", "xhigh", "max")
-	codexModelOptions            = fieldOptions(
-		"gpt-5.6-sol",
-		"gpt-5.6-terra",
-		"gpt-5.6-luna",
-		"gpt-5.5",
-		"gpt-5.4",
-		"gpt-5.4-mini",
-		"gpt-5.3-codex-spark",
-	)
-	codexReasoningEffortOptions = fieldOptions("low", "medium", "high", "xhigh", "max", "ultra")
-	copilotCLIModelOptions      = fieldOptions("auto", "claude-sonnet-4.6", "gpt-5.4", "claude-haiku-4.5", "gpt-5.3-codex", "gemini-3.1-pro-preview", "gemini-3.5-flash", "mai-code-1-flash")
-	grokModelOptions            = fieldOptions("grok-4.6", "grok-4.5")
-	grokReasoningEffortOptions  = fieldOptions("none", "minimal", "low", "medium", "high", "xhigh", "max")
+	codexReasoningEffortOptions  = fieldOptions("low", "medium", "high", "xhigh", "max", "ultra")
+	grokReasoningEffortOptions   = fieldOptions("none", "minimal", "low", "medium", "high", "xhigh", "max")
 )
 
 // fields is the canonical ordered registry of all config fields with constrained values.
@@ -112,14 +80,12 @@ var fields = []FieldDef{
 		Key:         AntigravityModelFieldKey,
 		Type:        FieldEnum,
 		AllowCustom: true,
-		Options:     antigravityModelOptions,
 	},
 	{Key: "agents.claude.enabled", Type: FieldBool, Required: true},
 	{
 		Key:         ClaudeModelFieldKey,
 		Type:        FieldEnum,
 		AllowCustom: true,
-		Options:     claudeModelOptions,
 	},
 	{
 		Key:         ClaudeReasoningEffortFieldKey,
@@ -136,7 +102,6 @@ var fields = []FieldDef{
 		Key:         CodexModelFieldKey,
 		Type:        FieldEnum,
 		AllowCustom: true,
-		Options:     codexModelOptions,
 	},
 	{
 		Key:         CodexReasoningEffortFieldKey,
@@ -154,14 +119,12 @@ var fields = []FieldDef{
 		Key:         CopilotCLIModelFieldKey,
 		Type:        FieldEnum,
 		AllowCustom: true,
-		Options:     copilotCLIModelOptions,
 	},
 	{Key: "agents.grok.enabled", Type: FieldBool, Required: true},
 	{
 		Key:         GrokModelFieldKey,
 		Type:        FieldEnum,
 		AllowCustom: true,
-		Options:     grokModelOptions,
 	},
 	{
 		Key:         GrokReasoningEffortFieldKey,

--- a/internal/config/fields_test.go
+++ b/internal/config/fields_test.go
@@ -81,8 +81,8 @@ func TestLookupField_EnumWithCustom(t *testing.T) {
 	if !f.AllowCustom {
 		t.Error("expected agents.claude.model to allow custom values")
 	}
-	if len(f.Options) == 0 {
-		t.Error("expected agents.claude.model to have options")
+	if len(f.Options) != 0 {
+		t.Error("model suggestions must come from the harness, not the config catalog")
 	}
 }
 
@@ -153,65 +153,9 @@ func TestLookupField_DispatchMaxDepth(t *testing.T) {
 	}
 }
 
-func TestFieldOptionValues_ClaudeModelCatalog(t *testing.T) {
-	values := FieldOptionValues(ClaudeModelFieldKey)
-	want := []string{"default", "best", "fable", "sonnet", "opus", "haiku", "sonnet[1m]", "opus[1m]", "opusplan"}
-	if len(values) != len(want) {
-		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
-	}
-	for i, expected := range want {
-		if values[i] != expected {
-			t.Fatalf("value at index %d = %q, want %q", i, values[i], expected)
-		}
-	}
-}
-
-func TestFieldOptionValues_AntigravityModelCatalog(t *testing.T) {
-	values := FieldOptionValues("agents.antigravity.model")
-	want := []string{
-		"Gemini 3.5 Flash (Medium)",
-		"Gemini 3.5 Flash (High)",
-		"Gemini 3.5 Flash (Low)",
-		"Gemini 3.1 Pro (Low)",
-		"Gemini 3.1 Pro (High)",
-		"Claude Sonnet 4.6 (Thinking)",
-		"Claude Opus 4.6 (Thinking)",
-		"GPT-OSS 120B (Medium)",
-	}
-	if len(values) != len(want) {
-		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
-	}
-	for i, expected := range want {
-		if values[i] != expected {
-			t.Fatalf("value at index %d = %q, want %q", i, values[i], expected)
-		}
-	}
-}
-
 func TestFieldOptionValues_ClaudeReasoningCatalog(t *testing.T) {
 	values := FieldOptionValues(ClaudeReasoningEffortFieldKey)
 	want := []string{"low", "medium", "high", "xhigh", "max"}
-	if len(values) != len(want) {
-		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
-	}
-	for i, expected := range want {
-		if values[i] != expected {
-			t.Fatalf("value at index %d = %q, want %q", i, values[i], expected)
-		}
-	}
-}
-
-func TestFieldOptionValues_CodexModelCatalog(t *testing.T) {
-	values := FieldOptionValues(CodexModelFieldKey)
-	want := []string{
-		"gpt-5.6-sol",
-		"gpt-5.6-terra",
-		"gpt-5.6-luna",
-		"gpt-5.5",
-		"gpt-5.4",
-		"gpt-5.4-mini",
-		"gpt-5.3-codex-spark",
-	}
 	if len(values) != len(want) {
 		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
 	}
@@ -235,19 +179,6 @@ func TestFieldOptionValues_CodexReasoningCatalog(t *testing.T) {
 	}
 }
 
-func TestFieldOptionValues_CopilotCliModelCatalog(t *testing.T) {
-	values := FieldOptionValues(CopilotCLIModelFieldKey)
-	want := []string{"auto", "claude-sonnet-4.6", "gpt-5.4", "claude-haiku-4.5", "gpt-5.3-codex", "gemini-3.1-pro-preview", "gemini-3.5-flash", "mai-code-1-flash"}
-	if len(values) != len(want) {
-		t.Fatalf("expected %d values, got %d (%v)", len(want), len(values), values)
-	}
-	for i, expected := range want {
-		if values[i] != expected {
-			t.Fatalf("value at index %d = %q, want %q", i, values[i], expected)
-		}
-	}
-}
-
 func TestFieldsCopySemantics(t *testing.T) {
 	all := Fields()
 	if len(all) == 0 {
@@ -261,6 +192,14 @@ func TestFieldsCopySemantics(t *testing.T) {
 	}
 	if original.Key == "mutated" {
 		t.Error("mutation of Fields() result affected the registry")
+	}
+}
+
+func TestModelFieldsNeverContainStaticSuggestions(t *testing.T) {
+	for _, field := range Fields() {
+		if strings.HasSuffix(field.Key, ".model") && len(field.Options) != 0 {
+			t.Errorf("%s contains a static model catalog", field.Key)
+		}
 	}
 }
 

--- a/internal/doctor/models.go
+++ b/internal/doctor/models.go
@@ -1,0 +1,54 @@
+package doctor
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/conn-castle/agent-layer/internal/agentoptions"
+	"github.com/conn-castle/agent-layer/internal/config"
+)
+
+// CheckModels queries enabled harnesses with explicit model overrides
+// concurrently, without sync. Client defaults need no model lookup. A model
+// absent from a picker is not necessarily invalid (aliases and custom endpoints
+// remain supported); report it as a warning rather than rejecting config.
+// The caller must supply a non-nil, loaded project configuration.
+func CheckModels(project *config.ProjectConfig, req agentoptions.DiscoveryRequest) []Result {
+	agents := []struct {
+		name    string
+		enabled *bool
+	}{
+		{"claude", project.Config.Agents.Claude.Enabled},
+		{"codex", project.Config.Agents.Codex.Enabled},
+		{"grok", project.Config.Agents.Grok.Enabled},
+		{"antigravity", project.Config.Agents.Antigravity.Enabled},
+	}
+	req.Project = project
+	req.Live = true
+	results := make([]Result, len(agents))
+	var workers sync.WaitGroup
+	for i, agent := range agents {
+		if agent.enabled == nil || !*agent.enabled || agentoptions.ConfiguredValue(project.Config, agent.name, agentoptions.KindModel) == "" {
+			continue
+		}
+		workers.Go(func() {
+			option := agentoptions.Resolve(project.Config, agent.name, agentoptions.KindModel, req)
+			result := Result{CheckName: agent.name + " models", Status: StatusOK,
+				Message: fmt.Sprintf("Harness lists %d selectable models", len(option.Suggestions))}
+			switch {
+			case option.DiscoveryError != "":
+				result.Status = StatusWarn
+				result.Message = option.DiscoveryError
+				result.Recommendation = "Check the harness installation, authentication, and connectivity; no model list is available."
+			case option.Configured != "" && !slices.Contains(option.Suggestions, option.Configured):
+				result.Status = StatusWarn
+				result.Message = fmt.Sprintf("Configured model %q is not in the harness model list", option.Configured)
+				result.Recommendation = "Check the model with the harness. Custom model IDs and aliases may still be valid."
+			}
+			results[i] = result
+		})
+	}
+	workers.Wait()
+	return slices.DeleteFunc(results, func(result Result) bool { return result.CheckName == "" })
+}

--- a/internal/doctor/models_test.go
+++ b/internal/doctor/models_test.go
@@ -1,0 +1,56 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/conn-castle/agent-layer/internal/agentoptions"
+	"github.com/conn-castle/agent-layer/internal/config"
+)
+
+func TestCheckModelsDistinguishesDiscoveryFailureAndUnlistedModel(t *testing.T) {
+	enabled := true
+	for _, tc := range []struct {
+		name, script, model string
+		status              Status
+		message             string
+	}{
+		{"listed", "printf 'Available models:\\n  - future-model\\n'", "future-model", StatusOK, "1 selectable"},
+		{"custom", "printf 'Available models:\\n  - future-model\\n'", "private-model", StatusWarn, "not in the harness"},
+		{"unauthenticated", "printf 'You are not authenticated.\\n'", "future-model", StatusWarn, "not authenticated"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, "grok")
+			if err := os.WriteFile(path, []byte("#!/bin/sh\n"+tc.script+"\n"), 0o700); err != nil {
+				t.Fatal(err)
+			} // #nosec G306 -- executable harness fixture.
+			project := &config.ProjectConfig{Root: root, Config: config.Config{Agents: config.AgentsConfig{Grok: config.GrokConfig{Enabled: &enabled, Model: tc.model}}}}
+			results := CheckModels(project, agentoptions.DiscoveryRequest{Env: []string{}, LookPath: func(string) (string, error) { return path, nil }})
+			if len(results) != 1 || results[0].Status != tc.status || !strings.Contains(results[0].Message, tc.message) {
+				t.Fatalf("results=%+v", results)
+			}
+		})
+	}
+}
+
+func TestCheckModelsSkipsDisabledHarnesses(t *testing.T) {
+	results := CheckModels(&config.ProjectConfig{}, agentoptions.DiscoveryRequest{LookPath: func(string) (string, error) { t.Fatal("disabled harness queried"); return "", nil }})
+	if len(results) != 0 {
+		t.Fatalf("results=%+v", results)
+	}
+}
+
+func TestCheckModelsSkipsClientDefaults(t *testing.T) {
+	enabled := true
+	project := &config.ProjectConfig{Config: config.Config{Agents: config.AgentsConfig{Antigravity: config.AntigravityConfig{Enabled: &enabled}}}}
+	results := CheckModels(project, agentoptions.DiscoveryRequest{LookPath: func(string) (string, error) {
+		t.Fatal("client default caused model discovery")
+		return "", nil
+	}})
+	if len(results) != 0 {
+		t.Fatalf("unexpected model checks: %+v", results)
+	}
+}

--- a/internal/templates/config.toml
+++ b/internal/templates/config.toml
@@ -34,7 +34,7 @@ enabled = false
 # Antigravity model selection is projected into .agy/antigravity-cli/settings.json.
 # Run `agy models` for the current CLI surface; some agy model names include
 # effort in the display string.
-# model = "Gemini 3.5 Flash (High)"
+# model = "..."
 # Use agent_specific to inject unmanaged JSON keys into settings.json
 # (deep-merged with Agent Layer-managed permissions). Do not put model here;
 # use agents.antigravity.model above.
@@ -83,7 +83,7 @@ enabled = true
 [agents.codex]
 enabled = true
 # model is optional; when omitted, Agent Layer does not pass a model setting and the client uses its default.
-# model = "gpt-5.6-sol"
+# model = "..."
 # reasoning_effort is optional; when omitted, the client uses its default.
 # reasoning_effort = "xhigh" # codex only
 # local_config_dir sets CODEX_HOME=<repo>/.codex for per-repo auth, sessions,
@@ -122,7 +122,7 @@ enabled = true
 [agents.grok]
 enabled = false
 # model is optional; when omitted, Agent Layer does not pass a model flag and the client uses its default.
-# model = "grok-4.6" # grok-4.6 | grok-4.5
+# model = "..."
 # reasoning_effort is optional; Grok applies it where the active model supports it.
 # reasoning_effort = "high" # none | minimal | low | medium | high | xhigh | max
 # GROK_HOME is always set to <repo>/.grok-config for al grok, dispatch, and al vscode.

--- a/internal/wizard/catalog.go
+++ b/internal/wizard/catalog.go
@@ -1,7 +1,9 @@
 package wizard
 
 import (
-	"sync"
+	"context"
+	"fmt"
+	"io"
 
 	"github.com/conn-castle/agent-layer/internal/agentoptions"
 	"github.com/conn-castle/agent-layer/internal/config"
@@ -67,62 +69,76 @@ func ApprovalModeFieldOptions() []config.FieldOption {
 var wizardOptionDiscoveryRequestFunc = agentoptions.DefaultDiscoveryRequest
 
 type wizardOptionDiscoveryCache struct {
-	mu                       sync.Mutex
-	antigravityModelValues   []string
-	antigravityModelsReady   bool
-	antigravityModelsStarted bool
-	antigravityModelsDone    chan struct{}
+	project *config.ProjectConfig
+	out     io.Writer
+	ctx     context.Context
+	entries map[string]*wizardModelDiscovery
 }
 
-func (c *wizardOptionDiscoveryCache) prefetchAntigravityModels() {
-	c.mu.Lock()
-	if c.antigravityModelsStarted {
-		c.mu.Unlock()
-		return
-	}
-	c.antigravityModelsStarted = true
-	done := make(chan struct{})
-	c.antigravityModelsDone = done
-	c.mu.Unlock()
+type wizardModelDiscovery struct {
+	done   chan struct{}
+	option agentoptions.OptionSet
+}
 
+// The UI goroutine owns the map. Workers publish results by closing done.
+func (c *wizardOptionDiscoveryCache) prefetch(agent string) *wizardModelDiscovery {
+	if c.entries == nil {
+		c.entries = make(map[string]*wizardModelDiscovery)
+	}
+	if entry := c.entries[agent]; entry != nil {
+		return entry
+	}
+	entry := &wizardModelDiscovery{done: make(chan struct{})}
+	c.entries[agent] = entry
 	req := wizardOptionDiscoveryRequestFunc()
+	req.Project = c.project
+	req.Context = c.ctx
+	if !req.Live || !agentoptions.HasModelDiscovery(agent) {
+		entry.option = agentoptions.Resolve(config.Config{}, agent, agentoptions.KindModel, req)
+		close(entry.done)
+		return entry
+	}
 	go func() {
-		values := agentoptions.Values(AgentAntigravity, agentoptions.KindModel, req)
-		c.mu.Lock()
-		c.antigravityModelValues = values
-		c.antigravityModelsReady = true
-		close(done)
-		c.mu.Unlock()
+		entry.option = agentoptions.Resolve(config.Config{}, agent, agentoptions.KindModel, req)
+		close(entry.done)
 	}()
+	return entry
 }
 
-func (c *wizardOptionDiscoveryCache) antigravityModelOptions(waitForPrefetch bool) []string {
-	c.mu.Lock()
-	if c.antigravityModelsReady {
-		values := append([]string(nil), c.antigravityModelValues...)
-		c.mu.Unlock()
-		return values
-	}
-	done := c.antigravityModelsDone
-	started := c.antigravityModelsStarted
-	c.mu.Unlock()
-
-	if waitForPrefetch {
-		if started {
-			<-done
-			c.mu.Lock()
-			values := append([]string(nil), c.antigravityModelValues...)
-			c.mu.Unlock()
-			return values
+func (c *wizardOptionDiscoveryCache) prefetchEnabled(choices *Choices) {
+	for _, agent := range SupportedAgents() {
+		if choices.EnabledAgents[agent] && agentoptions.HasModelDiscovery(agent) {
+			c.prefetch(agent)
 		}
-		return agentoptions.Values(AgentAntigravity, agentoptions.KindModel, wizardOptionDiscoveryRequestFunc())
 	}
-
-	return agentoptions.Values(AgentAntigravity, agentoptions.KindModel, agentoptions.DiscoveryRequest{})
 }
 
-func modelOptions(agent string) []string {
-	return agentoptions.Values(agent, agentoptions.KindModel, wizardOptionDiscoveryRequestFunc())
+func (c *wizardOptionDiscoveryCache) selectModel(ui UI, agent, title string, value *string) error {
+	// Scripted answers are explicit configuration, not a request for suggestions.
+	if scripted, ok := ui.(*ScriptedUI); ok {
+		answer, _, found := lookupStringScriptedAnswer(scripted.answers.Select, title)
+		if !found {
+			return missingScriptedAnswer("select", title)
+		}
+		return selectOptionalValue(ui, title, []string{answer}, value)
+	}
+	if !agentoptions.HasModelDiscovery(agent) {
+		// Copilot CLI has no discovery adapter. Offer explicit input only.
+		return selectOptionalValue(ui, title, nil, value)
+	}
+	entry := c.prefetch(agent)
+	select {
+	case <-entry.done:
+	default:
+		if c.out != nil {
+			_, _ = fmt.Fprintf(c.out, "Discovering %s models…\n", agent)
+		}
+		<-entry.done
+	}
+	if entry.option.DiscoveryError != "" {
+		return fmt.Errorf("cannot select %s model: %s; check harness installation, authentication, and connectivity", agent, entry.option.DiscoveryError)
+	}
+	return selectOptionalValue(ui, title, entry.option.Suggestions, value)
 }
 
 func reasoningEffortOptions(agent string) []string {

--- a/internal/wizard/option_discovery_test.go
+++ b/internal/wizard/option_discovery_test.go
@@ -1,452 +1,139 @@
 package wizard
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
 	"slices"
-	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/conn-castle/agent-layer/internal/agentoptions"
-	"github.com/conn-castle/agent-layer/internal/config"
 	"github.com/conn-castle/agent-layer/internal/messages"
 )
 
 func TestMain(m *testing.M) {
-	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
-		return agentoptions.DiscoveryRequest{}
-	}
+	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest { return agentoptions.DiscoveryRequest{} }
 	os.Exit(m.Run())
 }
 
-func TestPromptModelsAntigravityUsesReadyAsyncPrefetch(t *testing.T) {
-	orig := wizardOptionDiscoveryRequestFunc
-	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
-
-	binDir := t.TempDir()
-	agyPath := filepath.Join(binDir, "agy")
-	script := "#!/bin/sh\nif [ \"$1\" = \"models\" ]; then\n  printf 'Ready Async Model\\nFallback Wizard Model\\n'\nfi\n"
-	if err := os.WriteFile(agyPath, []byte(script), 0o700); err != nil { // #nosec G306 -- test writes an executable mock agy stub; the executable bit is required.
-		t.Fatalf("write agy stub: %v", err)
+func TestModelDiscoveryPrefetchWaitsAndReusesResult(t *testing.T) {
+	original := wizardOptionDiscoveryRequestFunc
+	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = original })
+	path := filepath.Join(t.TempDir(), "agy")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nprintf 'new-model\\tNew Model\\n'\n"), 0o700); err != nil { // #nosec G306 -- executable harness fixture.
+		t.Fatal(err)
 	}
+	started, release := make(chan struct{}), make(chan struct{})
+	var lookups atomic.Int32
 	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
-		return agentoptions.DiscoveryRequest{
-			LookPath: func(name string) (string, error) {
-				if name != "agy" {
-					return "", errors.New("unexpected binary lookup")
-				}
-				return agyPath, nil
-			},
-			Live:    true,
-			Timeout: 30 * time.Second,
+		return agentoptions.DiscoveryRequest{Live: true, LookPath: func(string) (string, error) {
+			if lookups.Add(1) == 1 {
+				close(started)
+			}
+			<-release
+			return path, nil
+		}}
+	}
+	var out bytes.Buffer
+	cache := &wizardOptionDiscoveryCache{out: &out}
+	cache.prefetch(AgentAntigravity)
+	<-started
+	// A pending discovery must be awaited rather than replaced by stale options.
+	timer := time.AfterFunc(30*time.Millisecond, func() { close(release) })
+	defer timer.Stop()
+	ui := &MockUI{SelectFunc: func(_ string, options []string, current *string) error {
+		if !slices.Contains(options, "New Model") {
+			t.Errorf("missing discovered model: %v", options)
+		}
+		*current = "New Model"
+		return nil
+	}}
+	var selected string
+	for range 2 {
+		if err := cache.selectModel(ui, AgentAntigravity, messages.WizardAntigravityModelTitle, &selected); err != nil {
+			t.Fatal(err)
 		}
 	}
+	if lookups.Load() != 1 {
+		t.Fatalf("discovery ran %d times", lookups.Load())
+	}
+	if !bytes.Contains(out.Bytes(), []byte("Discovering antigravity models")) {
+		t.Fatal("missing progress message")
+	}
+}
 
-	cache := &wizardOptionDiscoveryCache{}
-	cache.prefetchAntigravityModels()
-	waitForAntigravityModelDiscoveryReady(t, cache)
-
-	choices := NewChoices()
-	choices.EnabledAgents[AgentAntigravity] = true
+func TestModelDiscoveryFailureStopsPickerWithoutChangingConfiguredValue(t *testing.T) {
+	original := wizardOptionDiscoveryRequestFunc
+	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = original })
+	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
+		return agentoptions.DiscoveryRequest{Live: true, LookPath: func(string) (string, error) { return "", errors.New("harness missing") }}
+	}
 	ui := &MockUI{
-		SelectFunc: func(title string, options []string, current *string) error {
-			if title != messages.WizardAntigravityModelTitle {
-				t.Fatalf("unexpected select title %q", title)
-			}
-			want := []string{messages.WizardLeaveBlankOption, "Ready Async Model", "Fallback Wizard Model", messages.WizardCustomOption}
-			if !slices.Equal(options, want) {
-				t.Fatalf("options = %v, want %v", options, want)
-			}
-			*current = "Ready Async Model"
+		SelectFunc: func(_ string, options []string, current *string) error {
+			t.Error("failed discovery opened a picker")
 			return nil
 		},
 	}
-
-	if err := promptModels(ui, choices, cache); err != nil {
-		t.Fatalf("promptModels error: %v", err)
-	}
-	if choices.AntigravityModel != "Ready Async Model" {
-		t.Fatalf("AntigravityModel = %q, want ready async selection", choices.AntigravityModel)
-	}
-}
-
-func TestPromptModelsAntigravityFallsBackWithoutWaitingForPendingAsyncPrefetch(t *testing.T) {
-	orig := wizardOptionDiscoveryRequestFunc
-	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
-
-	started := make(chan struct{})
-	release := make(chan struct{})
-	var startedOnce sync.Once
-	var releaseOnce sync.Once
-	releaseDiscovery := func() { releaseOnce.Do(func() { close(release) }) }
-	defer releaseDiscovery()
-
-	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
-		return agentoptions.DiscoveryRequest{
-			LookPath: func(name string) (string, error) {
-				if name != "agy" {
-					return "", errors.New("unexpected binary lookup")
-				}
-				startedOnce.Do(func() { close(started) })
-				<-release
-				return "", errors.New("released pending discovery")
-			},
-			Live:    true,
-			Timeout: 30 * time.Second,
-		}
-	}
-
 	cache := &wizardOptionDiscoveryCache{}
-	cache.prefetchAntigravityModels()
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for async Antigravity model prefetch to start")
-	}
-
-	catalogOptions := config.FieldOptionValues(config.AntigravityModelFieldKey)
-	wantOptions := make([]string, 0, len(catalogOptions)+2)
-	wantOptions = append(wantOptions, messages.WizardLeaveBlankOption)
-	wantOptions = append(wantOptions, catalogOptions...)
-	wantOptions = append(wantOptions, messages.WizardCustomOption)
-
-	choices := NewChoices()
-	choices.EnabledAgents[AgentAntigravity] = true
-	ui := &MockUI{
-		SelectFunc: func(title string, options []string, current *string) error {
-			if title != messages.WizardAntigravityModelTitle {
-				t.Fatalf("unexpected select title %q", title)
-			}
-			if !slices.Equal(options, wantOptions) {
-				t.Fatalf("options = %v, want catalog fallback %v", options, wantOptions)
-			}
-			*current = messages.WizardLeaveBlankOption
-			return nil
-		},
-	}
-
-	result := make(chan error, 1)
-	go func() {
-		result <- promptModels(ui, choices, cache)
-	}()
-	select {
-	case err := <-result:
-		if err != nil {
-			t.Fatalf("promptModels error: %v", err)
+	selected := "my-custom-model"
+	for range 2 {
+		if err := cache.selectModel(ui, AgentClaude, messages.WizardClaudeModelTitle, &selected); err == nil || !bytes.Contains([]byte(err.Error()), []byte("harness missing")) {
+			t.Fatalf("expected actionable discovery failure, got %v", err)
 		}
-	case <-time.After(time.Second):
-		t.Fatal("promptModels blocked waiting for pending Antigravity model prefetch")
 	}
-
-	releaseDiscovery()
-	waitForAntigravityModelDiscoveryReady(t, cache)
+	if selected != "my-custom-model" {
+		t.Fatalf("selected=%q", selected)
+	}
 }
 
-func TestPromptModelsScriptedAntigravityWaitsForPendingAsyncPrefetch(t *testing.T) {
-	orig := wizardOptionDiscoveryRequestFunc
-	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
-
-	binDir := t.TempDir()
-	agyPath := filepath.Join(binDir, "agy")
-	script := "#!/bin/sh\nif [ \"$1\" = \"models\" ]; then\n  printf 'Live Scripted Model\\n'\nfi\n"
-	if err := os.WriteFile(agyPath, []byte(script), 0o700); err != nil { // #nosec G306 -- test writes an executable mock agy stub; the executable bit is required.
-		t.Fatalf("write agy stub: %v", err)
-	}
-
-	started := make(chan struct{})
+func TestPrefetchEnabledModelsRunsConcurrently(t *testing.T) {
+	original := wizardOptionDiscoveryRequestFunc
+	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = original })
+	started := make(chan string, 4)
 	release := make(chan struct{})
-	var startedOnce sync.Once
-	var releaseOnce sync.Once
-	releaseDiscovery := func() { releaseOnce.Do(func() { close(release) }) }
-	defer releaseDiscovery()
-
 	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
-		return agentoptions.DiscoveryRequest{
-			LookPath: func(name string) (string, error) {
-				if name != "agy" {
-					return "", errors.New("unexpected binary lookup")
-				}
-				startedOnce.Do(func() { close(started) })
-				<-release
-				return agyPath, nil
-			},
-			Live:    true,
-			Timeout: 30 * time.Second,
-		}
+		return agentoptions.DiscoveryRequest{Live: true, LookPath: func(name string) (string, error) { started <- name; <-release; return "", os.ErrNotExist }}
 	}
-
-	cache := &wizardOptionDiscoveryCache{}
-	cache.prefetchAntigravityModels()
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for async Antigravity model prefetch to start")
-	}
-
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		releaseDiscovery()
-	}()
-
 	choices := NewChoices()
-	choices.EnabledAgents[AgentAntigravity] = true
-	ui := &ScriptedUI{
-		answers: scriptedAnswers{
-			Select: map[string]string{messages.WizardAntigravityModelTitle: "Live Scripted Model"},
-		},
-		used: make(map[string]struct{}),
+	for _, agent := range []string{AgentAntigravity, AgentClaude, AgentCodex, AgentGrok} {
+		choices.EnabledAgents[agent] = true
 	}
-
-	if err := promptModels(ui, choices, cache); err != nil {
-		t.Fatalf("promptModels error: %v", err)
-	}
-	if choices.AntigravityModel != "Live Scripted Model" {
-		t.Fatalf("AntigravityModel = %q, want live scripted selection", choices.AntigravityModel)
-	}
-}
-
-func TestAntigravityModelOptionsReturnsCachedCopy(t *testing.T) {
-	cache := &wizardOptionDiscoveryCache{
-		antigravityModelValues: []string{"Cached Model"},
-		antigravityModelsReady: true,
-	}
-
-	values := cache.antigravityModelOptions(false)
-	values[0] = "Mutated Model"
-
-	again := cache.antigravityModelOptions(false)
-	if !slices.Equal(again, []string{"Cached Model"}) {
-		t.Fatalf("cached values = %v, want immutable cached model", again)
-	}
-}
-
-func TestClaudeModelOptionsUsesSharedFieldCatalog(t *testing.T) {
-	orig := wizardOptionDiscoveryRequestFunc
-	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
-	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
-		return agentoptions.DiscoveryRequest{
-			Live: true,
-			LookPath: func(string) (string, error) {
-				t.Fatal("Claude model options must not run live discovery without an authoritative CLI source")
-				return "", errors.New("unexpected lookup")
-			},
-		}
-	}
-
-	got := modelOptions(AgentClaude)
-	want := config.FieldOptionValues(config.ClaudeModelFieldKey)
-	if !slices.Equal(got, want) {
-		t.Fatalf("Claude model options = %v, want shared catalog %v", got, want)
-	}
-}
-
-func TestPromptModelsCodexUsesSharedFieldCatalogs(t *testing.T) {
-	choices := NewChoices()
-	choices.EnabledAgents[AgentCodex] = true
-
-	prompted := make(map[string]bool)
-	ui := &MockUI{
-		SelectFunc: func(title string, options []string, _ *string) error {
-			var catalog []string
-			switch title {
-			case messages.WizardCodexModelTitle:
-				catalog = config.FieldOptionValues(config.CodexModelFieldKey)
-			case messages.WizardCodexReasoningEffortTitle:
-				catalog = config.FieldOptionValues(config.CodexReasoningEffortFieldKey)
-			default:
-				t.Fatalf("unexpected select title %q", title)
-			}
-			want := make([]string, 0, len(catalog)+2)
-			want = append(want, messages.WizardLeaveBlankOption)
-			want = append(want, catalog...)
-			want = append(want, messages.WizardCustomOption)
-			if !slices.Equal(options, want) {
-				t.Fatalf("%s options = %v, want shared catalog choices %v", title, options, want)
-			}
-			prompted[title] = true
-			return nil
-		},
-		ConfirmFunc:     func(string, *bool) error { return nil },
-		MultiSelectFunc: func(string, []string, *[]string) error { return nil },
-	}
-
-	if err := promptModels(ui, choices, &wizardOptionDiscoveryCache{}); err != nil {
-		t.Fatalf("promptModels error: %v", err)
-	}
-	for _, title := range []string{messages.WizardCodexModelTitle, messages.WizardCodexReasoningEffortTitle} {
-		if !prompted[title] {
-			t.Fatalf("expected Codex prompt %q", title)
-		}
-	}
-}
-
-func TestPrefetchAntigravityModelsStartsOnlyOnce(t *testing.T) {
-	orig := wizardOptionDiscoveryRequestFunc
-	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
-
-	started := make(chan struct{})
-	release := make(chan struct{})
-	var requestCalls int
-	var startedOnce sync.Once
-	var releaseOnce sync.Once
-	releaseDiscovery := func() { releaseOnce.Do(func() { close(release) }) }
-	defer releaseDiscovery()
-
-	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
-		requestCalls++
-		return agentoptions.DiscoveryRequest{
-			LookPath: func(name string) (string, error) {
-				if name != "agy" {
-					return "", errors.New("unexpected binary lookup")
-				}
-				startedOnce.Do(func() { close(started) })
-				<-release
-				return "", errors.New("released pending discovery")
-			},
-			Live:    true,
-			Timeout: 30 * time.Second,
-		}
-	}
-
 	cache := &wizardOptionDiscoveryCache{}
-	cache.prefetchAntigravityModels()
-	cache.prefetchAntigravityModels()
-	if requestCalls != 1 {
-		t.Fatalf("discovery requests = %d, want one idempotent prefetch", requestCalls)
+	cache.prefetchEnabled(choices)
+	for range 4 {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			close(release)
+			t.Fatal("discovery did not start concurrently")
+		}
 	}
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for async Antigravity model prefetch to start")
-	}
-
-	releaseDiscovery()
-	waitForAntigravityModelDiscoveryReady(t, cache)
-	cache.prefetchAntigravityModels()
-	if requestCalls != 1 {
-		t.Fatalf("discovery requests after completion = %d, want one idempotent prefetch", requestCalls)
+	close(release)
+	for _, entry := range cache.entries {
+		<-entry.done
 	}
 }
 
-func TestPromptWizardFlowPrefetchesAntigravityModelsOnceAcrossModelRevisit(t *testing.T) {
-	orig := wizardOptionDiscoveryRequestFunc
-	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
-
-	var discoveryRequests int
+func TestScriptedModelSelectionDoesNotDiscover(t *testing.T) {
+	original := wizardOptionDiscoveryRequestFunc
+	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = original })
 	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
-		discoveryRequests++
+		t.Fatal("explicit scripted model caused discovery")
 		return agentoptions.DiscoveryRequest{}
 	}
-
-	choices := NewChoices()
-	choices.ApprovalMode = config.ApprovalModeAll
-
-	var modelPrompts int
-	var enableLayerPrompts int
-	ui := &MockUI{
-		SelectFunc: func(title string, options []string, _ *string) error {
-			if title == messages.WizardInstructionSetTitle {
-				enableLayerPrompts++
-				if enableLayerPrompts == 1 {
-					return errWizardBack
-				}
-				return nil
-			}
-			if title != messages.WizardAntigravityModelTitle {
-				return nil
-			}
-			modelPrompts++
-			wantOptions := append([]string{messages.WizardLeaveBlankOption}, config.FieldOptionValues(config.AntigravityModelFieldKey)...)
-			wantOptions = append(wantOptions, messages.WizardCustomOption)
-			if !slices.Equal(options, wantOptions) {
-				t.Fatalf("options = %v, want catalog fallback %v", options, wantOptions)
-			}
-			return nil
-		},
-		MultiSelectFunc: func(title string, _ []string, selected *[]string) error {
-			switch title {
-			case messages.WizardEnableAgentsTitle:
-				*selected = []string{AgentAntigravity}
-			case messages.WizardEnableDefaultMCPServersTitle:
-				*selected = []string{}
-			}
-			return nil
-		},
-		ConfirmFunc: func(title string, value *bool) error {
-			if title == messages.WizardEnableWarningsPrompt {
-				*value = false
-			}
-			return nil
-		},
+	ui := &ScriptedUI{answers: scriptedAnswers{Select: map[string]string{messages.WizardAntigravityModelTitle: "future-native-model"}}, used: map[string]struct{}{}}
+	var value string
+	cache := &wizardOptionDiscoveryCache{}
+	if err := cache.selectModel(ui, AgentAntigravity, messages.WizardAntigravityModelTitle, &value); err != nil {
+		t.Fatal(err)
 	}
-
-	if err := promptWizardFlow(t.TempDir(), ui, choices); err != nil {
-		t.Fatalf("promptWizardFlow error: %v", err)
+	if value != "future-native-model" {
+		t.Fatalf("configured value = %q", value)
 	}
-	if modelPrompts != 2 {
-		t.Fatalf("model prompts = %d, want 2 after back-navigation revisit", modelPrompts)
-	}
-	if enableLayerPrompts != 2 {
-		t.Fatalf("enable-layer prompts = %d, want 2", enableLayerPrompts)
-	}
-	if discoveryRequests != 1 {
-		t.Fatalf("discovery requests = %d, want exactly one flow-owned prefetch", discoveryRequests)
-	}
-}
-
-func TestPromptWizardFlowSkipsAntigravityPrefetchWhenAgentDisabled(t *testing.T) {
-	orig := wizardOptionDiscoveryRequestFunc
-	t.Cleanup(func() { wizardOptionDiscoveryRequestFunc = orig })
-
-	var discoveryRequests int
-	wizardOptionDiscoveryRequestFunc = func() agentoptions.DiscoveryRequest {
-		discoveryRequests++
-		return agentoptions.DiscoveryRequest{}
-	}
-
-	choices := NewChoices()
-	choices.ApprovalMode = config.ApprovalModeAll
-	ui := &MockUI{
-		MultiSelectFunc: func(title string, _ []string, selected *[]string) error {
-			switch title {
-			case messages.WizardEnableAgentsTitle, messages.WizardEnableDefaultMCPServersTitle:
-				*selected = []string{}
-			}
-			return nil
-		},
-		ConfirmFunc: func(title string, value *bool) error {
-			if title == messages.WizardEnableWarningsPrompt {
-				*value = false
-			}
-			return nil
-		},
-	}
-
-	if err := promptWizardFlow(t.TempDir(), ui, choices); err != nil {
-		t.Fatalf("promptWizardFlow error: %v", err)
-	}
-	if discoveryRequests != 0 {
-		t.Fatalf("discovery requests = %d, want none when Antigravity stays disabled", discoveryRequests)
-	}
-}
-
-func waitForAntigravityModelDiscoveryReady(t *testing.T, cache *wizardOptionDiscoveryCache) {
-	t.Helper()
-	cache.mu.Lock()
-	ready := cache.antigravityModelsReady
-	done := cache.antigravityModelsDone
-	cache.mu.Unlock()
-	if ready {
-		return
-	}
-	if done == nil {
-		t.Fatal("async Antigravity model discovery was not started")
-	}
-	select {
-	case <-done:
-	case <-time.After(30 * time.Second):
-		t.Fatal("timed out waiting for async Antigravity model discovery")
+	if err := ui.AssertComplete(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -1,6 +1,7 @@
 package wizard
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -31,8 +32,6 @@ var (
 	errWizardBack             = ErrBack
 	errWizardCancelled        = errors.New("wizard cancelled")
 )
-
-const defaultAntigravityModel = "Gemini 3.5 Flash (High)"
 
 // Run starts the interactive wizard.
 // pinVersion is written to .agent-layer/al.version when install is needed.
@@ -108,7 +107,7 @@ func runWithWriter(root string, ui UI, runSync syncer, pinVersion string, out io
 		applyFreshSetupDefaults(choices)
 	}
 
-	if err := promptWizardFlow(root, ui, choices); err != nil {
+	if err := promptWizardFlow(root, ui, choices, &wizardOptionDiscoveryCache{project: cfg, out: out}); err != nil {
 		if errors.Is(err, errWizardCancelled) || errors.Is(err, errWizardBack) {
 			if !freshInstall {
 				_, _ = fmt.Fprintln(out, messages.WizardExitWithoutChanges)
@@ -134,7 +133,6 @@ func runWithWriter(root string, ui UI, runSync syncer, pinVersion string, out io
 func applyFreshSetupDefaults(choices *Choices) {
 	choices.InstructionSet = InstructionSetRulesAndMemory
 	choices.EnabledAgents[AgentAntigravity] = true
-	choices.AntigravityModel = defaultAntigravityModel
 	// Statusline defaults come from initializeChoices: absent config keys default
 	// on in the interactive wizard, while explicit false remains off.
 }
@@ -422,11 +420,14 @@ const (
 )
 
 // promptWizardFlow drives the step-by-step prompt loop.
-func promptWizardFlow(root string, ui UI, choices *Choices) error {
+func promptWizardFlow(root string, ui UI, choices *Choices, caches ...*wizardOptionDiscoveryCache) error {
 	optionCache := &wizardOptionDiscoveryCache{}
-	if choices.EnabledAgents[AgentAntigravity] {
-		optionCache.prefetchAntigravityModels()
+	if len(caches) > 0 {
+		optionCache = caches[0]
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	optionCache.ctx = ctx
 	// The instruction prompt is install-only. Once instruction or memory files
 	// exist on disk, the wizard does not offer a refresh action; users who want
 	// a full managed update can use `al upgrade`.
@@ -446,10 +447,10 @@ func promptWizardFlow(root string, ui UI, choices *Choices) error {
 			err = promptApprovalMode(ui, choices)
 		case wizardFlowStepAgents:
 			err = promptEnabledAgents(ui, choices)
-			if err == nil && choices.EnabledAgents[AgentAntigravity] {
-				optionCache.prefetchAntigravityModels()
-			}
 		case wizardFlowStepModels:
+			if _, scripted := ui.(*ScriptedUI); !scripted {
+				optionCache.prefetchEnabled(choices)
+			}
 			err = promptModels(ui, choices, optionCache)
 		case wizardFlowStepInstructions:
 			err = promptInstructionSet(ui, choices)
@@ -700,14 +701,13 @@ func confirmWizardExitOnFirstStepEscape(ui UI) (bool, error) {
 
 func promptModels(ui UI, choices *Choices, optionCache *wizardOptionDiscoveryCache) error {
 	if choices.EnabledAgents[AgentAntigravity] {
-		_, scripted := ui.(*ScriptedUI)
-		if err := selectOptionalValue(ui, messages.WizardAntigravityModelTitle, optionCache.antigravityModelOptions(scripted), &choices.AntigravityModel); err != nil {
+		if err := optionCache.selectModel(ui, AgentAntigravity, messages.WizardAntigravityModelTitle, &choices.AntigravityModel); err != nil {
 			return err
 		}
 		choices.AntigravityModelTouched = true
 	}
 	if choices.EnabledAgents[AgentClaude] {
-		if err := selectOptionalValue(ui, messages.WizardClaudeModelTitle, modelOptions(AgentClaude), &choices.ClaudeModel); err != nil {
+		if err := optionCache.selectModel(ui, AgentClaude, messages.WizardClaudeModelTitle, &choices.ClaudeModel); err != nil {
 			return err
 		}
 		choices.ClaudeModelTouched = true
@@ -742,7 +742,7 @@ func promptModels(ui UI, choices *Choices, optionCache *wizardOptionDiscoveryCac
 		}
 	}
 	if choices.EnabledAgents[AgentCodex] {
-		if err := selectOptionalValue(ui, messages.WizardCodexModelTitle, modelOptions(AgentCodex), &choices.CodexModel); err != nil {
+		if err := optionCache.selectModel(ui, AgentCodex, messages.WizardCodexModelTitle, &choices.CodexModel); err != nil {
 			return err
 		}
 		choices.CodexModelTouched = true
@@ -790,13 +790,13 @@ func promptModels(ui UI, choices *Choices, optionCache *wizardOptionDiscoveryCac
 		}
 	}
 	if choices.EnabledAgents[AgentCopilotCLI] {
-		if err := selectOptionalValue(ui, messages.WizardCopilotCLIModelTitle, modelOptions(AgentCopilotCLI), &choices.CopilotCLIModel); err != nil {
+		if err := optionCache.selectModel(ui, AgentCopilotCLI, messages.WizardCopilotCLIModelTitle, &choices.CopilotCLIModel); err != nil {
 			return err
 		}
 		choices.CopilotCLIModelTouched = true
 	}
 	if choices.EnabledAgents[AgentGrok] {
-		if err := selectOptionalValue(ui, messages.WizardGrokModelTitle, modelOptions(AgentGrok), &choices.GrokModel); err != nil {
+		if err := optionCache.selectModel(ui, AgentGrok, messages.WizardGrokModelTitle, &choices.GrokModel); err != nil {
 			return err
 		}
 		choices.GrokModelTouched = true

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -437,7 +437,7 @@ func TestPromptModels_AntigravityModelOptions(t *testing.T) {
 			wantOptions := append([]string{messages.WizardLeaveBlankOption}, config.FieldOptionValues(config.AntigravityModelFieldKey)...)
 			wantOptions = append(wantOptions, messages.WizardCustomOption)
 			assert.Equal(t, wantOptions, options)
-			assert.Equal(t, "Gemini 3.5 Flash (High)", *current)
+			assert.Equal(t, messages.WizardCustomOption, *current)
 			*current = "Gemini 3.1 Pro (High)"
 			return nil
 		},
@@ -741,13 +741,13 @@ func TestInitializeChoices_AntigravityModelReadBack(t *testing.T) {
 	assert.Equal(t, "Gemini 3.5 Flash (High)", choices.AntigravityModel)
 }
 
-func TestApplyFreshSetupDefaults_DefaultsAntigravityModelToHigh(t *testing.T) {
+func TestApplyFreshSetupDefaults_UsesAntigravityClientDefault(t *testing.T) {
 	choices := NewChoices()
 
 	applyFreshSetupDefaults(choices)
 
 	assert.True(t, choices.EnabledAgents[AgentAntigravity])
-	assert.Equal(t, defaultAntigravityModel, choices.AntigravityModel)
+	assert.Empty(t, choices.AntigravityModel)
 }
 
 // TestReadCodexBrowserDisabled covers detecting the Codex browser-disable state.

--- a/scripts/test-e2e/scenarios/init-doctor-wizard-doctor.sh
+++ b/scripts/test-e2e/scenarios/init-doctor-wizard-doctor.sh
@@ -88,6 +88,11 @@ _init_doctor_wizard_assert_expected_doctor_output() {
     "$phase doctor config check passed"
   assert_output_contains "$output" "Update check skipped because AL_NO_NETWORK is set" \
     "$phase doctor reports expected offline update warning"
+  local provider
+  for provider in claude codex grok antigravity; do
+    assert_output_not_contains "$output" "$provider models" \
+      "$phase doctor does not query $provider models when clients use their defaults"
+  done
   assert_output_contains "$output" "No required secrets found in configuration." \
     "$phase doctor secrets check passed"
   assert_output_contains "$output" "Agent enabled: Claude" \

--- a/site/docs/agent-dispatch.mdx
+++ b/site/docs/agent-dispatch.mdx
@@ -211,4 +211,9 @@ Codex and Grok also receive the hard tool timeout as per-server `tool_timeout_se
 
 Dispatch honors the repository's configured agents, models, reasoning effort, approvals, environment isolation, and pinned Agent Layer version. Use [`al dispatch options`](./reference#dispatch) to inspect the resolved provider choices before starting work.
 
+Model suggestions come only from the installed harnesses. Options queries run
+concurrently and do not sync; discovery failures return an empty list and an
+explicit `discovery_error`, never bundled or fallback models. Start and continue
+do not repeat model discovery.
+
 For exact configuration fields and CLI summaries, see [Reference](./reference). For internal implementation details, see [`docs/AGENT-DISPATCH.md`](https://github.com/conn-castle/agent-layer/blob/main/docs/AGENT-DISPATCH.md).

--- a/site/docs/reference.mdx
+++ b/site/docs/reference.mdx
@@ -177,12 +177,31 @@ Shared project instructions for Grok live in root `AGENTS.md`. The Claude instru
 
 Each agent has an `enabled` flag and an optional `model` value. Omit `model` and `reasoning_effort` to use the client defaults.
 
+Wizard, Doctor, and Dispatch options share live model discovery for Claude,
+Codex, Grok, and Antigravity. Discovery uses the project's normal provider
+configuration without sync or inference, runs concurrently across harnesses,
+and allows ten seconds per lookup. Wizard starts queries at model selection
+and reuses results during navigation. Failed discovery stops the interactive
+picker: there are no bundled model lists or fallbacks. Scripted answers do not
+trigger discovery; explicit custom values remain accepted. Copilot CLI has
+manual model entry only. Doctor queries only enabled agents with configured
+model overrides and warns when discovery
+fails or a configured model is absent from the harness list; absence alone does
+not prove that a custom model or alias is invalid.
+
+Dispatch options obtains fresh lists on each explicit request, with provider
+version checks also concurrent. Launch, sync, and dispatch start/continue do not
+query models. Model defaults are delegated to the harness, never hard-coded by
+Agent Layer. Antigravity suggestions retain both native slugs and display names.
+Discovery may create the normal repo-local `.agy` and `.grok-config` directories
+when absent; it does not sync configuration or create dispatch runs.
+
 **Reasoning effort**
 
 - Claude supports `reasoning_effort` (`low`, `medium`, `high`, `xhigh`, `max`). Agent Layer passes the value through to Claude Code regardless of the selected model, including when `model` is unset. Claude Code applies it where the active model supports it. `max` is session-only and is passed via the `--effort` CLI flag; it is not written to `settings.json`. Custom values outside the catalog pass through with a sync-time warning so new effort levels work before Agent Layer is updated.
 - Codex supports `reasoning_effort` with its own set of options.
 - Copilot CLI supports `model` but not `reasoning_effort`.
-- Grok supports `model` (`grok-4.6`, `grok-4.5`) and `reasoning_effort` (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`).
+- Grok supports `model` (discovered using `grok models`) and `reasoning_effort` (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`).
 
 **Repo-local isolation**
 

--- a/site/docs/reference.mdx
+++ b/site/docs/reference.mdx
@@ -189,7 +189,7 @@ model overrides and warns when discovery
 fails or a configured model is absent from the harness list; absence alone does
 not prove that a custom model or alias is invalid.
 
-Dispatch options obtains fresh lists on each explicit request, with provider
+Dispatch options obtain fresh lists on each explicit request, with provider
 version checks also concurrent. Launch, sync, and dispatch start/continue do not
 query models. Model defaults are delegated to the harness, never hard-coded by
 Agent Layer. Antigravity suggestions retain both native slugs and display names.


### PR DESCRIPTION
## Summary

- Discovers models directly from installed Claude, Codex, Grok, and Antigravity harnesses without sync or inference.
- Eliminates hardcoded static model catalogs and fallback lists, ensuring suggestions reflect live provider capabilities.
- Integrates model discovery into `al wizard`, `al doctor`, agent dispatch, and benchmark configuration with concurrent resolution.

## Changes

- `internal/agentoptions`: Added `DiscoverModels` supporting Claude (via initialize/list), Codex (`debug models`), Grok (`models`), and Antigravity (`agy models`). Removed static model catalogs and fallbacks.
- `cmd/al/doctor.go`, `internal/doctor/models.go`: Added concurrent model verification check in `al doctor` validating configured model overrides against live harness offerings without failing config on custom models.
- `internal/agentdispatch`, `internal/wizard`: Updated model suggestion and validation paths to query live harness discovery concurrently.
- `internal/benchmark`: Normalized model names and updated catalog discovery tests.
- `docs/`, `site/docs/`, `README.md`: Updated documentation to describe live harness model discovery.

## Verification

- `go test ./...` — all tests pass.
- `make fmt-check` — formatting is clean.
- `make dead-code` — no dead code detected.
- `make tidy-check` — go.mod and go.sum are tidy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added live model discovery for Claude, Codex, Grok, and Antigravity.
  - Wizard and Dispatch query enabled harnesses concurrently; Wizard reuses results, while Dispatch refreshes on requests.
  - Doctor checks configured models and reports unavailable or unlisted selections.
  - Antigravity suggestions include native slugs and display names.
  - Custom model values remain supported, including undiscovered models.

- **Bug Fixes**
  - Added cancellation, timeout, offline-mode, and authentication error handling with explicit discovery status.

- **Documentation**
  - Updated guidance for model discovery, benchmark selection, and command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->